### PR TITLE
Support for new scripts/, python/ and schema/ in DAQ ups packages

### DIFF
--- a/scripts/upsify-daq-pkgs.py
+++ b/scripts/upsify-daq-pkgs.py
@@ -172,6 +172,7 @@ def create_ups_pkg(install_dir, source_dir, equal, dqual, dest_dir, pkg_name="")
         git_version = vdot_ver # branch name, or commit hash
     commit_hash = get_commit_hash(source_dir)
     version = git_version if git_version else commit_hash
+    dot_ver = dot_ver if git_version else commit_hash
     tmp_dir = tempfile.mkdtemp()
     renamed = False
     orig_pkg_name = pkg_name

--- a/scripts/upsify-daq-pkgs.py
+++ b/scripts/upsify-daq-pkgs.py
@@ -7,7 +7,6 @@ import subprocess
 import getpass
 import datetime
 import argparse
-import os.path as path
 
 
 def check_output(cmd):
@@ -279,10 +278,10 @@ if __name__ == "__main__":
                         help="flag for the 'debug' qualifer ('prof' if unset).")
 
     args = parser.parse_args()
-    workdir = path.abspath(args.work_dir)
+    workdir = os.path.abspath(args.work_dir)
     install_dir = os.path.join(workdir, "install")
     source_dir = os.path.join(workdir, "sourcecode")
-    dest_dir = path.abspath(args.tarball_dir)
+    dest_dir = os.path.abspath(args.tarball_dir)
     equal = args.equalifier
     if args.debug:
         dqual = "debug"

--- a/scripts/upsify-daq-pkgs.py
+++ b/scripts/upsify-daq-pkgs.py
@@ -7,6 +7,7 @@ import subprocess
 import getpass
 import datetime
 import argparse
+import os.path as path
 
 
 def check_output(cmd):
@@ -15,9 +16,11 @@ def check_output(cmd):
     out = irun.communicate()
     rc = irun.returncode
     if rc != 0:
-        print('Error: command "{}" has exit non-zero exit status,\
-please check!'.format(cmd))
-        print('Output from the commnd: {}'.format(out))
+        print('\nERROR: command "{}" has exit non-zero exit status,\
+please check!\n'.format(cmd))
+        print('Command output:\n {}\n'.format(out[0].decode('utf-8')))
+        print('Command error:\n{}\n'.format(out[1].decode('utf-8')))
+
         exit(10)
     return out
 
@@ -240,10 +243,10 @@ if __name__ == "__main__":
                         help="flag for the 'debug' qualifer ('prof' if unset).")
 
     args = parser.parse_args()
-    workdir = args.work_dir
+    workdir = path.abspath(args.work_dir)
     install_dir = os.path.join(workdir, "install")
     source_dir = os.path.join(workdir, "sourcecode")
-    dest_dir = args.tarball_dir
+    dest_dir = path.abspath(args.tarball_dir)
     equal = args.equalifier
     if args.debug:
         dqual = "debug"


### PR DESCRIPTION
This PR complements DUNE-DAQ/daq-cmake#10 and DUNE-DAQ/daq-cmake#11 by including the new dir in the relevant runtime search paths.
