### PR TITLE
Switching to tarballs urls for moo

### DIFF
--- a/configs/dunedaq-v2.0.0/pyvenv_requirements.txt
+++ b/configs/dunedaq-v2.0.0/pyvenv_requirements.txt
@@ -16,4 +16,4 @@ six==1.15.0
 requests==2.25.0
 # PyPI already has another package named "moo";
 # Picking up moo from github repo:
--e git://github.com/brettviren/moo.git@0.5.1#egg=moo
+https://github.com/brettviren/moo/archive/0.5.1.tar.gz#egg=moo

--- a/configs/dunedaq-v2.1.0/pyvenv_requirements.txt
+++ b/configs/dunedaq-v2.1.0/pyvenv_requirements.txt
@@ -16,4 +16,4 @@ six==1.15.0
 requests==2.25.0
 # PyPI already has another package named "moo";
 # Picking up moo from github repo:
--e git://github.com/brettviren/moo.git@0.5.1#egg=moo
+https://github.com/brettviren/moo/archive/0.5.1.tar.gz#egg=moo

--- a/configs/dunedaq-v2.2.0/pyvenv_requirements.txt
+++ b/configs/dunedaq-v2.2.0/pyvenv_requirements.txt
@@ -17,4 +17,4 @@ requests==2.25.0
 h5py==3.1.0
 # PyPI already has another package named "moo";
 # Picking up moo from github repo:
--e git://github.com/brettviren/moo.git@0.5.2#egg=moo
+https://github.com/brettviren/moo/archive/0.5.2.tar.gz#egg=moo


### PR DESCRIPTION
This PR updates the `dunedaq-v2.0.0` to `dunedaq-v2.0.0` python requirement files to pull `moo` as tarball rather than via `git clone`.