### PR TITLE
creating uhal v2_6_4b which is based on our own build of boost v1_70_…

### DIFF
--- a/scripts/ups_build_scripts/uhal/v2_6_4b/build_uhal.sh
+++ b/scripts/ups_build_scripts/uhal/v2_6_4b/build_uhal.sh
@@ -1,0 +1,202 @@
+#!/bin/bash
+#
+# buildJsoncpp.sh 
+# (in source build required)
+#
+
+usage()
+{
+   echo "USAGE: `basename ${0}` <product_dir> <e15|e17> <prof> [tar]"
+}
+
+# -------------------------------------------------------------------
+# shared boilerplate
+# -------------------------------------------------------------------
+
+get_this_dir() 
+{
+    ( cd / ; /bin/pwd -P ) >/dev/null 2>&1
+    if (( $? == 0 )); then
+      pwd_P_arg="-P"
+    fi
+    reldir=`dirname ${0}`
+    thisdir=`cd ${reldir} && /bin/pwd ${pwd_P_arg}`
+}
+
+get_ssibuildshims()
+{
+    # make sure we can use the setup alias
+    if [ -z ${UPS_DIR} ]
+    then
+       echo "ERROR: please setup ups"
+       exit 1
+    fi
+    source `${UPS_DIR}/bin/ups setup ${SETUP_UPS}`
+    
+    setup ssibuildshims ${ssibuildshims_version} -z ${product_dir}:${PRODUCTS}
+}
+
+function setup_and_verify()
+{
+    # this should not complain
+    echo "Finished building ${package} ${pkgver}"
+    setup ${package} ${pkgver} -q ${fullqual} -z ${product_dir}:${PRODUCTS}
+    echo "${package} is installed at ${UHAL_FQ_DIR}"
+}
+
+
+# -------------------------------------------------------------------
+# start processing
+# -------------------------------------------------------------------
+
+product_dir=${1}
+basequal=${2}
+extraqual=${3}
+maketar=${4}
+
+if [[ "${basequal}" == e1[0245] ]]
+then
+  cc=gcc
+  cxx=g++
+  cxxflg="-std=c++14"
+elif [[ "${basequal}" == e1[79] ]]
+then
+  cc=gcc
+  cxx=g++
+  cxxflg="-std=c++17"
+elif [[ "${basequal}" == c[27] ]]
+then
+  cc=clang
+  cxx=clang++
+  cxxflg="-std=c++17"
+else
+  ssi_die "Qualifier $basequal not recognized."
+fi
+extra_command="${extra_command} -DCMAKE_CXX_FLAGS=${cxxflg}"
+
+if [ -z ${product_dir} ]
+then
+   echo "ERROR: please specify the local product directory"
+   usage
+   exit 1
+fi
+
+# -------------------------------------------------------------------
+# package name and version
+# -------------------------------------------------------------------
+
+srcpkgname=ipbus-software
+package=uhal
+pkgver=v2_6_4b
+ssibuildshims_version=v1_04_14
+pkgdotver="2.6.4"
+pkgtar=v${pkgdotver}.tar.gz
+
+
+make_tarball_opts=("\${product_dir}" "\${package}" "\${pkgver}" "\${fullqual}")
+
+get_this_dir
+get_ssibuildshims
+source define_basics --
+
+
+if [ "${maketar}" = "tar" ] && [ -d ${pkgdir}/lib ]
+then
+   eval ${SSIBUILDSHIMS_DIR}/bin/make_distribution_tarball "${make_tarball_opts[@]}"
+   exit 0
+fi
+
+echo "building ${package} for ${OS}-${plat}-${qualdir} (flavor ${flvr})"
+
+mkdir -p ${pkgdir}
+if [ ! -d ${pkgdir} ]
+then
+   echo "ERROR: failed to create ${pkgdir}"
+   exit 1
+fi
+
+# declare now so we can setup
+# fake ups declare
+fakedb=${product_dir}/${package}/${pkgver}/fakedb
+${SSIBUILDSHIMS_DIR}/bin/fake_declare_product ${product_dir} ${package} ${pkgver} ${fullqual}
+
+setup -B ${package} ${pkgver} -q ${fullqual} -z ${fakedb}:${product_dir}:${PRODUCTS} || ssi_die "ERROR: fake setup failed"
+
+
+setup python v3_8_3b
+
+# doing build now
+cd ${pkgdir} || ssi_die "Unable to cd to ${pkgdir}"
+mkdir -p ${tardir}
+wget -O ${tardir}/${pkgtar} https://github.com/ipbus/ipbus-software/archive/v${pkgdotver}.tar.gz
+tar xf ${tardir}/${pkgtar} || ssi_die "Unable to unwind ${tardir}/${pkgtar} into ${PWD}"
+
+# apply patch
+echo ${patchdir}
+cd ${pkgdir}
+patch -b -p1 <${patchdir}/ipbus.patch || ssi_die "Unable to apply patch"
+
+cd ${pkgdir}/${srcpkgname}-${pkgdotver} || ssi_die "Unable to cd to ${pkgdir}/${srcpkgname}-${pkgdotver}"
+
+set -x
+
+ncore=`${SSIBUILDSHIMS_DIR}/bin/ncores`
+
+# NOW COMPILE
+export Set=uhal
+export EXTERN_BOOST_INCLUDE_PREFIX=$BOOST_INC
+export EXTERN_BOOST_LIB_PREFIX=$BOOST_LIB
+export EXTERN_PUGIXML_INCLUDE_PREFIX=$PUGIXML_INC
+export EXTERN_PUGIXML_LIB_PREFIX=$PUGIXML_LIB
+Set=uhal \
+CC=${cc} \
+CXX=${cxx}  \
+make -j 8 || ssi_die "Failed in 'make'"
+#make -j $ncore || ssi_die "Failed in 'make'"
+
+# NOW INSTALL
+incdir=${product_dir}/${package}/${pkgver}/include
+srcdir=${product_dir}/${package}/${pkgver}/src
+Set=uhal \
+make install prefix=${pkgdir} includedir=${incdir} || ssi_die "Failed to install"
+
+# NOW clean up
+#if [ -d ${incdir}/${package} ]; then
+#    mv ${incdir}/${package} ${incdir}
+#    rm -rf ${incdir}/${package}
+#fi
+
+if [ -d ${pkgdir}/bin/${package} ]; then
+    find ${pkgdir}/bin -type f -exec mv {} ${pkgdir}/bin \;
+    rm -rf ${pkgdir}/bin/${package}
+fi
+
+pushd ${pkgdir}/lib
+for i in `find . -type l`; do j=`echo $i|grep -o ".*.so" `; rm -f $i; ln -s $j.2.6.4 $i; done
+popd
+
+
+if [ ! -d ${srcdir} ]; then
+    mv ${pkgdir}/${srcpkgname}-${pkgdotver} ${srcdir}
+fi
+
+set +x
+
+# real ups declare
+## 
+${SSIBUILDSHIMS_DIR}/bin/declare_product ${product_dir} ${package} ${pkgver} ${fullqual} || \
+  ssi_die "failed to declare ${package} ${pkgver} -q ${fullqual}"
+
+# -------------------------------------------------------------------
+# common bottom stuff
+# -------------------------------------------------------------------
+
+setup_and_verify
+
+# this must be last
+if [ "${maketar}" = "tar" ] && [ -d ${pkgdir}/lib ]
+then
+   eval ${SSIBUILDSHIMS_DIR}/bin/make_distribution_tarball "${make_tarball_opts[@]}"
+fi
+
+exit 0

--- a/scripts/ups_build_scripts/uhal/v2_6_4b/patch/ipbus.patch
+++ b/scripts/ups_build_scripts/uhal/v2_6_4b/patch/ipbus.patch
@@ -1,0 +1,79 @@
+diff -Naur old/ipbus-software-2.6.4/controlhub/Makefile new/ipbus-software-2.6.4/controlhub/Makefile
+--- old/ipbus-software-2.6.4/controlhub/Makefile	2019-07-29 17:38:26.000000000 +0200
++++ new/ipbus-software-2.6.4/controlhub/Makefile	2019-09-19 04:40:21.228790668 +0200
+@@ -147,24 +147,24 @@
+ install:
+ 	cd scripts; find . -name "controlhub_*" -exec install -D -m 755 {} $(bindir)/{} \;
+ 	mkdir -p $(libdir) && cp -r rel/controlhub $(libdir)/
+-	install -D -m 644 pkg/rsyslog.d.conf /etc/rsyslog.d/controlhub.conf
+-	install -D -m 644 pkg/logrotate.d.conf /etc/logrotate.d/controlhub.conf
++	#install -D -m 644 pkg/rsyslog.d.conf /etc/rsyslog.d/controlhub.conf
++	#install -D -m 644 pkg/logrotate.d.conf /etc/logrotate.d/controlhub.conf
+ 
+-	mkdir -p /etc/controlhub/default
+-	mv $(libdir)/controlhub/sys.config /etc/controlhub/default/sys.config
+-	sed -i "s|\".*core.config\"|\"$(libdir)/controlhub/core.config\"|" /etc/controlhub/default/sys.config
+-	sed -i "s|CONTROLHUB_CONFIG_FILE_DEFAULT=.*|CONTROLHUB_CONFIG_FILE_DEFAULT=/etc/controlhub/default/sys.config|" $(libdir)/controlhub/bin/controlhub
+-	sed -i "s|CONTROLHUB_CONFIG_FILE_OPTIONAL=.*|CONTROLHUB_CONFIG_FILE_OPTIONAL=/etc/controlhub/sys.config|" $(libdir)/controlhub/bin/controlhub
++	#mkdir -p /etc/controlhub/default
++	#mv $(libdir)/controlhub/sys.config /etc/controlhub/default/sys.config
++	#sed -i "s|\".*core.config\"|\"$(libdir)/controlhub/core.config\"|" /etc/controlhub/default/sys.config
++	#sed -i "s|CONTROLHUB_CONFIG_FILE_DEFAULT=.*|CONTROLHUB_CONFIG_FILE_DEFAULT=/etc/controlhub/default/sys.config|" $(libdir)/controlhub/bin/controlhub
++	#sed -i "s|CONTROLHUB_CONFIG_FILE_OPTIONAL=.*|CONTROLHUB_CONFIG_FILE_OPTIONAL=/etc/controlhub/sys.config|" $(libdir)/controlhub/bin/controlhub
+ 
+-	sed -i "s|CONTROLHUB_BIN_DIR=.*|CONTROLHUB_BIN_DIR=$(libdir)/controlhub/bin|" $(bindir)/controlhub_*
++	#sed -i "s|CONTROLHUB_BIN_DIR=.*|CONTROLHUB_BIN_DIR=$(libdir)/controlhub/bin|" $(bindir)/controlhub_*
+ 
+-	mkdir -p /var/log/controlhub
+-	touch /var/log/controlhub/controlhub.log
+-	chmod 644 /var/log/controlhub/controlhub.log
++	#mkdir -p /var/log/controlhub
++	#touch /var/log/controlhub/controlhub.log
++	#chmod 644 /var/log/controlhub/controlhub.log
+ ifeq (,$(shell /bin/bash -c "command -v service"))
+-	@echo " WARNING : 'service' command not detected! After the installation has finished, you should restart rsyslog to ensure that the ControlHub syslog config is loaded"
++	#@echo " WARNING : 'service' command not detected! After the installation has finished, you should restart rsyslog to ensure that the ControlHub syslog config is loaded"
+ else
+-	service rsyslog restart
++	#service rsyslog restart
+ endif
+ 
+ uninstall:
+diff -Naur old/ipbus-software-2.6.4/uhal/uhal/include/uhal/ClientFactory.hpp new/ipbus-software-2.6.4/uhal/uhal/include/uhal/ClientFactory.hpp
+--- old/ipbus-software-2.6.4/uhal/uhal/include/uhal/ClientFactory.hpp	2019-07-29 17:38:26.000000000 +0200
++++ new/ipbus-software-2.6.4/uhal/uhal/include/uhal/ClientFactory.hpp	2019-09-19 04:38:26.690904695 +0200
+@@ -46,6 +46,7 @@
+ 
+ #include <boost/shared_ptr.hpp>
+ #include <boost/unordered_map.hpp>
++#include <boost/core/noncopyable.hpp>
+ 
+ #include <map>
+ 
+diff -Naur old/ipbus-software-2.6.4/uhal/uhal/include/uhal/ConnectionManager.hpp new/ipbus-software-2.6.4/uhal/uhal/include/uhal/ConnectionManager.hpp
+--- old/ipbus-software-2.6.4/uhal/uhal/include/uhal/ConnectionManager.hpp	2019-07-29 17:38:26.000000000 +0200
++++ new/ipbus-software-2.6.4/uhal/uhal/include/uhal/ConnectionManager.hpp	2019-09-19 04:38:46.100054831 +0200
+@@ -45,6 +45,7 @@
+ #include "uhal/HwInterface.hpp"
+ 
+ #include <boost/filesystem/path.hpp>
++#include <boost/core/noncopyable.hpp>
+ 
+ #include <vector>
+ #include <set>
+diff -Naur old/ipbus-software-2.6.4/uhal/pycohal/Makefile new/ipbus-software-2.6.4/uhal/pycohal/Makefile
+--- old/ipbus-software-2.6.4/uhal/pycohal/Makefile	2019-07-29 15:38:26.000000000 +0000
++++ new/ipbus-software-2.6.4/uhal/pycohal/Makefile	2021-01-28 05:56:19.431166267 +0000
+@@ -22,11 +22,7 @@
+ PythonModules = ["uhal"]
+ LibraryFile = pkg/uhal/_core.so
+ 
+-ifeq ($(shell python -c "import sys; print(sys.version_info[0])"),3)
+-  EXTERN_BOOST_PYTHON_LIB = boost_python3
+-else
+-  EXTERN_BOOST_PYTHON_LIB = boost_python
+-endif
++EXTERN_BOOST_PYTHON_LIB = boost_python38
+ 
+ IncludePaths = include  \
+ 		${EXTERN_BOOST_INCLUDE_PREFIX} \

--- a/scripts/ups_build_scripts/uhal/v2_6_4b/ups/uhal.table
+++ b/scripts/ups_build_scripts/uhal/v2_6_4b/ups/uhal.table
@@ -1,0 +1,37 @@
+File=Table
+Product=uhal
+
+#*************************************************
+# Starting Group definition
+Group:
+
+Flavor=ANY
+Qualifiers=e19:prof
+
+  Action=DefineFQ
+    envSet (UHAL_FQ_DIR, ${UPS_PROD_DIR}/${UPS_PROD_FLAVOR}-e19-prof)
+
+  Action = ExtraSetup
+    setupRequired( gcc v8_2_0 )
+    setupRequired( python v3_8_3b )
+    setupRequired( boost v1_70_0a -q +e19:+prof )
+    setupRequired( pugixml v1_11 -q +e19)
+
+Common:
+   Action=setup
+      setupenv()
+      proddir()
+      ExeActionRequired(DefineFQ)
+      envSet(UHAL, ${UPS_PROD_DIR})
+      envSet(UHAL_VERSION, ${UPS_PROD_VERSION})
+      # add the lib directory to LD_LIBRARY_PATH
+      envSet(UHAL_LIB, ${UHAL_FQ_DIR}/lib)
+      envSet(UHAL_INC, ${UPS_PROD_DIR}/include)
+      envPrepend(LD_LIBRARY_PATH, ${UHAL_FQ_DIR}/lib)
+      pathPrepend(PATH, ${UHAL_FQ_DIR}/bin)
+      pathPrepend(PYTHONPATH, ${UHAL_FQ_DIR}/lib/python3.8/site-packages)
+      # requirements
+      exeActionRequired(ExtraSetup)
+End:
+# End Group definition
+#*************************************************


### PR DESCRIPTION
…0a with python3.8

`uhal v2_6_4b -q e19:prof` has been built and published to cvmfs. It is available under the products_dev area.

One can set this up via:

`setup uhal v2_6_4b -q e19:prof`

With this new version, I can successfully do `import uhal` interactively.


 