### PR TITLE
Dingpf/39 create pybind11 ups pkg

### DIFF
--- a/scripts/bootstrap-ups-build.sh
+++ b/scripts/bootstrap-ups-build.sh
@@ -36,7 +36,7 @@ source $PROD_DIR/setup
 export CETPKG_INSTALL=$PROD_DIR
 export CETPKG_J=$NCORE
 cd $CET_BUILD_DIR
-for i in double_conversion fmt glog googletest libevent folly zmq cppzmq msgpack_c; do
+for i in double_conversion fmt glog googletest libevent folly zmq cppzmq msgpack_c pybind11; do
   ibuild_dir=build_${i}
   isrc_dir=$WORK_DIR/daq-release/scripts/cetbuildtools_scripts/${i}/ups
   mkdir -p ${ibuild_dir}

--- a/scripts/build-all-cet-ups.sh
+++ b/scripts/build-all-cet-ups.sh
@@ -36,7 +36,7 @@ source $PROD_DIR/setup
 export CETPKG_INSTALL=$PROD_DIR
 export CETPKG_J=$NCORE
 cd $CET_BUILD_DIR
-for i in double_conversion fmt glog googletest libevent folly zmq cppzmq msgpack_c; do
+for i in double_conversion fmt glog googletest libevent folly zmq cppzmq msgpack_c pybind11; do
   ibuild_dir=build_${i}
   isrc_dir=$WORK_DIR/daq-release/scripts/cetbuildtools_scripts/${i}/ups
   mkdir -p ${ibuild_dir}

--- a/scripts/cetbuildtools_scripts/pybind11/CMakeLists.txt
+++ b/scripts/cetbuildtools_scripts/pybind11/CMakeLists.txt
@@ -1,0 +1,44 @@
+# ======================================================================
+#  pybind11 main build file
+#
+#  cd .../path/to/build/directory
+#  source .../path/to/pybind11/ups/setup_for_development <-d|-o|-p>
+#  cmake [-DCMAKE_INSTALL_PREFIX=/install/path]
+#        -DCMAKE_BUILD_TYPE=$CETPKG_TYPE
+#        $CETPKG_SOURCE
+#  make
+#  make test
+#  make install
+#  make package
+# ======================================================================
+
+
+# use cmake 2.8 or later
+cmake_minimum_required (VERSION 3.4)
+
+project(pybind11)
+
+# cetbuildtools contains our cmake modules
+set( CETBUILDTOOLS_VERSION $ENV{CETBUILDTOOLS_VERSION} )
+if( NOT CETBUILDTOOLS_VERSION )
+  message( FATAL_ERROR "ERROR: setup cetbuildtools to get the cmake modules" )
+endif()
+set(CMAKE_MODULE_PATH $ENV{CETBUILDTOOLS_DIR}/Modules 
+		      ${CMAKE_MODULE_PATH})
+
+include(CetCMakeEnv)
+cet_cmake_env()
+
+cet_set_compiler_flags(DIAGS VIGILANT WERROR EXTRA_FLAGS -pedantic)
+cet_report_compiler_flags()
+
+find_ups_product( cetbuildtools v2_03_00 )
+
+# source
+add_subdirectory(pybind11)
+
+# ups - table and config files
+add_subdirectory(ups)
+
+# packaging utility - enable building a package tarball
+include(UseCPack)

--- a/scripts/cetbuildtools_scripts/pybind11/pybind11/CMakeLists.txt
+++ b/scripts/cetbuildtools_scripts/pybind11/pybind11/CMakeLists.txt
@@ -1,0 +1,22 @@
+include(ExternalProject)
+
+ExternalProject_Add (
+  pybind11
+
+  PREFIX         pybind11
+  GIT_REPOSITORY https://github.com/pybind/pybind11.git
+  GIT_TAG        v2.6.2
+  GIT_SHALLOW    ON
+
+  BUILD_ALWAYS   OFF
+  INSTALL_DIR    ${PROJECT_BINARY_DIR}/external_staging
+  CMAKE_ARGS     -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+)
+
+# We have to use relative paths for the DESTINATION (which are
+# interpreted as being relative to ${CMAKE_INSTALL_PREFIX}), so that
+# CPack will work
+install(DIRECTORY ${PROJECT_BINARY_DIR}/external_staging/share
+       DESTINATION ${flavorqual_dir})
+install(DIRECTORY ${PROJECT_BINARY_DIR}/external_staging/include
+       DESTINATION ${flavorqual_dir})

--- a/scripts/cetbuildtools_scripts/pybind11/ups/CMakeLists.txt
+++ b/scripts/cetbuildtools_scripts/pybind11/ups/CMakeLists.txt
@@ -1,0 +1,4 @@
+
+process_ups_files()
+
+# cet_cmake_config()

--- a/scripts/cetbuildtools_scripts/pybind11/ups/product-config.cmake.in
+++ b/scripts/cetbuildtools_scripts/pybind11/ups/product-config.cmake.in
@@ -1,0 +1,17 @@
+
+set( @product@_VERSION @VERSION_MAJOR@.@VERSION_MINOR@.@VERSION_PATCH@ )
+set( @product@_UPS_VERSION v@VERSION_MAJOR@_@VERSION_MINOR@_@VERSION_PATCH@ )
+
+@PACKAGE_INIT@
+
+if (IS_DIRECTORY "${PACKAGE_PREFIX_DIR}/@product@/@version@/Modules")
+  list(APPEND CMAKE_MODULE_PATH "${PACKAGE_PREFIX_DIR}/@product@/@version@/Modules")
+endif()
+
+@CONFIG_FIND_UPS_COMMANDS@
+
+@CONFIG_FIND_LIBRARY_COMMANDS@
+
+check_required_components(@product@)
+
+include(${CMAKE_CURRENT_LIST_DIR}/pybind11Targets.cmake)

--- a/scripts/cetbuildtools_scripts/pybind11/ups/product_deps
+++ b/scripts/cetbuildtools_scripts/pybind11/ups/product_deps
@@ -1,0 +1,38 @@
+# See $CETBUILDTOOLS_DIR/templates/product_deps.template for a more
+# fully annotated product_deps file.
+
+# Product specification
+parent pybind11 v2_6_2
+defaultqual e19
+
+# Table-file variable setup specification.
+incdir      fq_dir include
+libdir      fq_dir      lib64
+bindir      fq_dir      bin
+
+# define product/version pairs
+product		version
+gcc		v8_2_0
+python		v3_8_3b
+cetbuildtools	v7_15_01	-	only_for_build
+end_product_list
+
+# Matrix of qualifiers versus dependent products
+qualifier	gcc	python 	notes
+e19:debug	-nq-	-nq-	
+e19:opt		-nq-	-nq-
+e19:prof	-nq-	-nq-
+end_qualifier_list
+
+table_fragment_begin
+# this is a table file fragment
+# it will be copied verbatim
+table_fragment_end
+
+# Preserve tabs and formatting in emacs and vi / vim:
+
+### Local Variables:
+### tab-width: 8
+### End:
+
+# vi:set ts=8 noexpandtab:

--- a/scripts/cetbuildtools_scripts/pybind11/ups/setup_for_development
+++ b/scripts/cetbuildtools_scripts/pybind11/ups/setup_for_development
@@ -1,0 +1,94 @@
+# NO USER-SERVICEABLE PARTS BELOW.
+#
+# There should be as little as possible here,
+# with most of the heavy lifting done by other small scripts
+#
+# When sourcing this file from a script, you may have to tell this
+# source file where it is via the fw_db shell (or env) variable.
+# I.e.:
+#    set fw_db=/some/path; source /some/path/this_file
+# or  fw_db=/some/path; . /some/path/this_file
+
+test $?shell = 1 && set ss=csh || ss=sh
+#echo Shell type is $ss.
+
+# make some things similar. need to use set_ because sh builtin set would hide function set
+# Note: perhaps the trickiest thing in this file is the sh set_ function tries to return the same status
+#       as at the start of the function (which most likely is the result of a back-tick expression
+test "$ss" = csh && alias set_ set && alias vecho_ 'if ($?vv == 1) echo \!*' || eval 'vecho_() { test -n "${vv-}" && echo "$@"; return 0; }'
+test "$ss" =  sh && eval 'set_() { sts=$?;for xx in "$@";do var=`expr "$xx" : "\([^=]*\)"`;val=`expr "$xx" : "[^=]*=\(.*\)"`;eval "$var=\"$val\"";done;return $sts; }'
+test "$ss" =  sh && eval 'setenv() { export $1;eval "$1=\"\${2-}\""; }; source() { file=$1; shift; . $file "$@"; }; unsetenv_() { unset "$@"; }'
+test "$ss" =  sh && eval 'tnotnull() { eval "test -n \"\${$1-}\""; }'                             && eval 'nullout() { "$@" >/dev/null 2>&1; }'
+test "$ss" = csh && alias tnotnull "eval '"'test $?'"\!* -eq 1' && eval '"'test -n "$'"\!*"'"'"'" && alias nullout "\!* >& /dev/null" && alias unsetenv_ unsetenv
+test "$ss" = csh && alias return exit
+
+set_ msg1='ERROR: You MUST setup ups'
+test -z $UPS_DIR && ( echo ""; echo "$msg1"; echo "" ) && return
+
+set_ msg3='ERROR: You MUST specify either -o, -p, or -d'
+set_ msg4='Usage: setup_for_development <-d|-o|-p> <qualifier list>'
+test -z "$1" && ( echo ""; echo "$msg4"; echo "$msg3"; echo "" ) && return
+
+# make sure we know where this script lives
+# now if we were passed a path or if not, we can figure it out (maybe if we are interactive)
+#   bash, zsh, ksh and tcsh pass params to a source file, csh does not. but someone will be writing csh scripts
+set_ msg2='Please set shell or env. variable fw_db (to be the path to the framework source code). Fix this and other errors may go away.'
+tnotnull fw_db && set_ db=`sh -c "cd $fw_db >/dev/null 2>&1 && pwd"` && vecho_ 'setting db from fw_db variable' || set_ db=
+
+test -z "$db" && tnotnull BASH_SOURCE && set_ me=`dirname $BASH_SOURCE` && set_ db=`sh -c "cd $me >/dev/null 2>&1 && pwd"` && vecho_ 'setting db via BASH_SOURCE'
+
+# history is applicable only for interactive t/csh
+test -z "$db" -a "$ss" = csh && test $?history = 0 && set history=5  # make sure history 1 works
+test -z "$db" -a "$ss" = csh && set me=`history 1|sed 's/^[ 	0-9:]*//'` && test -n "$me" && set me=`dirname $me[2]` \
+    && set db=`sh -c "cd $me >/dev/null 2>&1 && pwd"` && vecho_ 'setting db via interactive history'
+#echo This script lives in $db
+
+test -z "$db" && echo "$msg2" || vecho_ "db=$db"
+test -n "$db" && setenv CETPKG_SOURCE `dirname $db`
+
+# make sure we know the current directory
+setenv CETPKG_BUILD `pwd`
+#echo Build directory is $CETPKG_BUILD
+
+echo The working build directory is $CETPKG_BUILD
+echo The source code directory is $CETPKG_SOURCE
+
+set_ msg5='ERROR: setup of required products has failed'
+
+echo ----------- check this block for errors -----------------------
+set_ setup_fail="false"
+set_ exit_now="false"
+set_ cetb=` grep -e '^[ \t]*cetbuildtools' $CETPKG_SOURCE/ups/product_deps | grep  only_for_build| awk '{ print $1 }' `
+set_ cetv=` grep -e '^[ \t]*cetbuildtools' $CETPKG_SOURCE/ups/product_deps | grep  only_for_build| awk '{ print $2 }' `
+#echo Found $cetb $cetv
+setup -B $cetb $cetv
+test "$?" = 0 || set_ setup_fail="true"
+# now get the rest of the products
+set_ cmd="$CETBUILDTOOLS_DIR/bin/set_dev_products $CETPKG_SOURCE $CETPKG_BUILD $*"
+#echo Ready to run $cmd
+source `$cmd`
+test "$?" = 0 || set_ setup_fail="true"
+#echo "$cmd returned $setup_fail"
+test "$setup_fail" = "true" && echo "$msg5"
+test "$setup_fail" = "true" && set_ exit_now="true"
+test -e "$CETPKG_BUILD/diag_report" && cat $CETPKG_BUILD/diag_report
+echo ----------------------------------------------------------------
+
+test "${exit_now}" = "true" && test "$ss" = csh && unalias tnotnull nullout set_ vecho_ return
+test "${exit_now}" = "true" && unset ss db me thisdir msg1 msg2 msg3 msg4 msg5 setup_fail set_ setenv unsetenv_ tnotnull nullout vecho_
+test "${exit_now}" = "true" && return 1
+
+# add lib to LD_LIBRARY_PATH
+source $CETBUILDTOOLS_DIR/bin/set_dev_lib
+# add bin to path
+source $CETBUILDTOOLS_DIR/bin/set_dev_bin
+# set FHICL_FILE_PATH
+source $CETBUILDTOOLS_DIR/bin/set_dev_fhicl
+
+# final sanity check and report
+source $CETBUILDTOOLS_DIR/bin/set_dev_check_report
+
+# cleanup before exiting
+test "$ss" = csh && unalias tnotnull nullout set_ vecho_ return
+unset ss db me thisdir msg1 msg2 msg3 msg4 msg5 setup_fail
+unset set_ setenv unsetenv_ tnotnull nullout vecho_

--- a/scripts/ups_build_scripts/uhal/v2_8_0/build_uhal.sh
+++ b/scripts/ups_build_scripts/uhal/v2_8_0/build_uhal.sh
@@ -1,0 +1,203 @@
+#!/bin/bash
+#
+# buildJsoncpp.sh 
+# (in source build required)
+#
+
+usage()
+{
+   echo "USAGE: `basename ${0}` <product_dir> <e15|e17> <prof> [tar]"
+}
+
+# -------------------------------------------------------------------
+# shared boilerplate
+# -------------------------------------------------------------------
+
+get_this_dir() 
+{
+    ( cd / ; /bin/pwd -P ) >/dev/null 2>&1
+    if (( $? == 0 )); then
+      pwd_P_arg="-P"
+    fi
+    reldir=`dirname ${0}`
+    thisdir=`cd ${reldir} && /bin/pwd ${pwd_P_arg}`
+}
+
+get_ssibuildshims()
+{
+    # make sure we can use the setup alias
+    if [ -z ${UPS_DIR} ]
+    then
+       echo "ERROR: please setup ups"
+       exit 1
+    fi
+    source `${UPS_DIR}/bin/ups setup ${SETUP_UPS}`
+    
+    setup ssibuildshims ${ssibuildshims_version} -z ${product_dir}:${PRODUCTS}
+}
+
+function setup_and_verify()
+{
+    # this should not complain
+    echo "Finished building ${package} ${pkgver}"
+    setup ${package} ${pkgver} -q ${fullqual} -z ${product_dir}:${PRODUCTS}
+    echo "${package} is installed at ${UHAL_FQ_DIR}"
+}
+
+
+# -------------------------------------------------------------------
+# start processing
+# -------------------------------------------------------------------
+
+product_dir=${1}
+basequal=${2}
+extraqual=${3}
+maketar=${4}
+
+if [[ "${basequal}" == e1[0245] ]]
+then
+  cc=gcc
+  cxx=g++
+  cxxflg="-std=c++14"
+elif [[ "${basequal}" == e1[79] ]]
+then
+  cc=gcc
+  cxx=g++
+  cxxflg="-std=c++17"
+elif [[ "${basequal}" == c[27] ]]
+then
+  cc=clang
+  cxx=clang++
+  cxxflg="-std=c++17"
+else
+  ssi_die "Qualifier $basequal not recognized."
+fi
+extra_command="${extra_command} -DCMAKE_CXX_FLAGS=${cxxflg}"
+
+if [ -z ${product_dir} ]
+then
+   echo "ERROR: please specify the local product directory"
+   usage
+   exit 1
+fi
+
+# -------------------------------------------------------------------
+# package name and version
+# -------------------------------------------------------------------
+
+srcpkgname=ipbus-software
+package=uhal
+pkgver=v2_8_0
+ssibuildshims_version=v1_04_14
+pkgdotver="2.8.0"
+pkgtar=v${pkgdotver}.tar.gz
+
+
+make_tarball_opts=("\${product_dir}" "\${package}" "\${pkgver}" "\${fullqual}")
+
+get_this_dir
+get_ssibuildshims
+source define_basics --
+
+
+if [ "${maketar}" = "tar" ] && [ -d ${pkgdir}/lib ]
+then
+   eval ${SSIBUILDSHIMS_DIR}/bin/make_distribution_tarball "${make_tarball_opts[@]}"
+   exit 0
+fi
+
+echo "building ${package} for ${OS}-${plat}-${qualdir} (flavor ${flvr})"
+
+mkdir -p ${pkgdir}
+if [ ! -d ${pkgdir} ]
+then
+   echo "ERROR: failed to create ${pkgdir}"
+   exit 1
+fi
+
+# declare now so we can setup
+# fake ups declare
+fakedb=${product_dir}/${package}/${pkgver}/fakedb
+${SSIBUILDSHIMS_DIR}/bin/fake_declare_product ${product_dir} ${package} ${pkgver} ${fullqual}
+
+setup -B ${package} ${pkgver} -q ${fullqual} -z ${fakedb}:${product_dir}:${PRODUCTS} || ssi_die "ERROR: fake setup failed"
+
+
+setup python v3_8_3b
+
+# doing build now
+cd ${pkgdir} || ssi_die "Unable to cd to ${pkgdir}"
+mkdir -p ${tardir}
+wget -O ${tardir}/${pkgtar} https://github.com/ipbus/ipbus-software/archive/v${pkgdotver}.tar.gz
+tar xf ${tardir}/${pkgtar} || ssi_die "Unable to unwind ${tardir}/${pkgtar} into ${PWD}"
+
+# apply patch
+echo ${patchdir}
+cd ${pkgdir}
+patch -b -p1 <${patchdir}/ipbus.patch || ssi_die "Unable to apply patch"
+
+cd ${pkgdir}/${srcpkgname}-${pkgdotver} || ssi_die "Unable to cd to ${pkgdir}/${srcpkgname}-${pkgdotver}"
+
+set -x
+
+ncore=`${SSIBUILDSHIMS_DIR}/bin/ncores`
+
+# NOW COMPILE
+export Set=uhal
+export EXTERN_PYBIND11_INCLUDE_PREFIX=$PYBIND11_INC
+export EXTERN_BOOST_INCLUDE_PREFIX=$BOOST_INC
+export EXTERN_BOOST_LIB_PREFIX=$BOOST_LIB
+export EXTERN_PUGIXML_INCLUDE_PREFIX=$PUGIXML_INC
+export EXTERN_PUGIXML_LIB_PREFIX=$PUGIXML_LIB
+Set=uhal \
+CC=${cc} \
+CXX=${cxx}  \
+make -j 8 || ssi_die "Failed in 'make'"
+#make -j $ncore || ssi_die "Failed in 'make'"
+
+# NOW INSTALL
+incdir=${product_dir}/${package}/${pkgver}/include
+srcdir=${product_dir}/${package}/${pkgver}/src
+Set=uhal \
+make install prefix=${pkgdir} includedir=${incdir} || ssi_die "Failed to install"
+
+# NOW clean up
+#if [ -d ${incdir}/${package} ]; then
+#    mv ${incdir}/${package} ${incdir}
+#    rm -rf ${incdir}/${package}
+#fi
+
+if [ -d ${pkgdir}/bin/${package} ]; then
+    find ${pkgdir}/bin -type f -exec mv {} ${pkgdir}/bin \;
+    rm -rf ${pkgdir}/bin/${package}
+fi
+
+pushd ${pkgdir}/lib
+for i in `find . -type l`; do j=`echo $i|grep -o ".*.so" `; rm -f $i; ln -s $j.2.6.4 $i; done
+popd
+
+
+if [ ! -d ${srcdir} ]; then
+    mv ${pkgdir}/${srcpkgname}-${pkgdotver} ${srcdir}
+fi
+
+set +x
+
+# real ups declare
+## 
+${SSIBUILDSHIMS_DIR}/bin/declare_product ${product_dir} ${package} ${pkgver} ${fullqual} || \
+  ssi_die "failed to declare ${package} ${pkgver} -q ${fullqual}"
+
+# -------------------------------------------------------------------
+# common bottom stuff
+# -------------------------------------------------------------------
+
+setup_and_verify
+
+# this must be last
+if [ "${maketar}" = "tar" ] && [ -d ${pkgdir}/lib ]
+then
+   eval ${SSIBUILDSHIMS_DIR}/bin/make_distribution_tarball "${make_tarball_opts[@]}"
+fi
+
+exit 0

--- a/scripts/ups_build_scripts/uhal/v2_8_0/build_uhal.sh
+++ b/scripts/ups_build_scripts/uhal/v2_8_0/build_uhal.sh
@@ -173,7 +173,7 @@ if [ -d ${pkgdir}/bin/${package} ]; then
 fi
 
 pushd ${pkgdir}/lib
-for i in `find . -type l`; do j=`echo $i|grep -o ".*.so" `; rm -f $i; ln -s $j.2.6.4 $i; done
+for i in `find . -type l`; do j=`echo $i|grep -o ".*.so" `; rm -f $i; ln -s $j.2.8.0 $i; done
 popd
 
 

--- a/scripts/ups_build_scripts/uhal/v2_8_0/patch/ipbus.patch
+++ b/scripts/ups_build_scripts/uhal/v2_8_0/patch/ipbus.patch
@@ -1,0 +1,59 @@
+diff -Naur old/ipbus-software-2.8.0/controlhub/Makefile new/ipbus-software-2.8.0/controlhub/Makefile
+--- old/ipbus-software-2.8.0/controlhub/Makefile	2021-01-29 01:18:00.000000000 +0000
++++ new/ipbus-software-2.8.0/controlhub/Makefile	2021-01-31 05:54:26.109817120 +0000
+@@ -159,27 +159,27 @@
+ install:
+ 	cd scripts; find . -name "controlhub_*" -exec install -D -m 755 {} $(bindir)/{} \;
+ 	mkdir -p $(libdir) && cp -r rel/controlhub $(libdir)/
+-	install -D -m 644 pkg/rsyslog.d.conf /etc/rsyslog.d/controlhub.conf
+-	install -D -m 644 pkg/logrotate.d.conf /etc/logrotate.d/controlhub.conf
++	#install -D -m 644 pkg/rsyslog.d.conf /etc/rsyslog.d/controlhub.conf
++	#install -D -m 644 pkg/logrotate.d.conf /etc/logrotate.d/controlhub.conf
+ 
+-	mkdir -p /etc/controlhub/default
+-	mv $(libdir)/controlhub/sys.config /etc/controlhub/default/sys.config
+-	sed -i "s|\".*core.config\"|\"$(libdir)/controlhub/core.config\"|" /etc/controlhub/default/sys.config
+-	sed -i "s|CONTROLHUB_CONFIG_FILE_DEFAULT=.*|CONTROLHUB_CONFIG_FILE_DEFAULT=/etc/controlhub/default/sys.config|" $(libdir)/controlhub/bin/controlhub
+-	sed -i "s|CONTROLHUB_CONFIG_FILE_OPTIONAL=.*|CONTROLHUB_CONFIG_FILE_OPTIONAL=/etc/controlhub/sys.config|" $(libdir)/controlhub/bin/controlhub
++	#mkdir -p /etc/controlhub/default
++	#mv $(libdir)/controlhub/sys.config /etc/controlhub/default/sys.config
++	#sed -i "s|\".*core.config\"|\"$(libdir)/controlhub/core.config\"|" /etc/controlhub/default/sys.config
++	#sed -i "s|CONTROLHUB_CONFIG_FILE_DEFAULT=.*|CONTROLHUB_CONFIG_FILE_DEFAULT=/etc/controlhub/default/sys.config|" $(libdir)/controlhub/bin/controlhub
++	#sed -i "s|CONTROLHUB_CONFIG_FILE_OPTIONAL=.*|CONTROLHUB_CONFIG_FILE_OPTIONAL=/etc/controlhub/sys.config|" $(libdir)/controlhub/bin/controlhub
+ 
+ 	sed -i "s|CONTROLHUB_BIN_DIR=.*|CONTROLHUB_BIN_DIR=$(libdir)/controlhub/bin|" $(bindir)/controlhub_*
+ 
+-	mkdir -p /var/log/controlhub
+-	touch /var/log/controlhub/controlhub.log
+-	chmod 644 /var/log/controlhub/controlhub.log
+-ifeq (,$(shell /bin/bash -c "command -v service"))
+-	@echo " WARNING : 'service' command not detected! After the installation has finished, you should restart rsyslog to ensure that the ControlHub syslog config is loaded"
+-else
+-	-service rsyslog restart
+-endif
++	#mkdir -p /var/log/controlhub
++	#touch /var/log/controlhub/controlhub.log
++	#chmod 644 /var/log/controlhub/controlhub.log
++#ifeq (,$(shell /bin/bash -c "command -v service"))
++	#@echo " WARNING : 'service' command not detected! After the installation has finished, you should restart rsyslog to ensure that the ControlHub syslog config is loaded"
++#else
++#	-service rsyslog restart
++#endif
+ 
+ uninstall:
+ 	rm -rf $(bindir)/controlhub*
+ 	rm -rf $(libdir)/controlhub
+-	rm -rf /etc/rsyslog.d/controlhub.conf /etc/logrotate.d/controlhub.conf /etc/controlhub/default
++	#rm -rf /etc/rsyslog.d/controlhub.conf /etc/logrotate.d/controlhub.conf /etc/controlhub/default
+diff -Naur old/ipbus-software-2.8.0/uhal/python/Makefile new/ipbus-software-2.8.0/uhal/python/Makefile
+--- old/ipbus-software-2.8.0/uhal/python/Makefile	2021-01-29 01:18:00.000000000 +0000
++++ new/ipbus-software-2.8.0/uhal/python/Makefile	2021-01-31 05:55:33.256950919 +0000
+@@ -27,7 +27,7 @@
+ 
+ 
+ IncludePaths = include  \
+-		pybind11/include \
++		${EXTERN_PYBIND11_INCLUDE_PREFIX} \
+ 		${EXTERN_BOOST_INCLUDE_PREFIX} \
+ 		${EXTERN_PUGIXML_INCLUDE_PREFIX} \
+ 		${PYTHON_INCLUDE_PREFIX} \

--- a/scripts/ups_build_scripts/uhal/v2_8_0/ups/uhal.table
+++ b/scripts/ups_build_scripts/uhal/v2_8_0/ups/uhal.table
@@ -1,0 +1,38 @@
+File=Table
+Product=uhal
+
+#*************************************************
+# Starting Group definition
+Group:
+
+Flavor=ANY
+Qualifiers=e19:prof
+
+  Action=DefineFQ
+    envSet (UHAL_FQ_DIR, ${UPS_PROD_DIR}/${UPS_PROD_FLAVOR}-e19-prof)
+
+  Action = ExtraSetup
+    setupRequired( gcc v8_2_0 )
+    setupRequired( python v3_8_3b )
+    setupRequired( boost v1_73_0 -q +e19:+prof )
+    setupRequired( pugixml v1_11 -q +e19)
+    setupRequired( pybind11 v2_6_2 -q +e19:+prof)
+
+Common:
+   Action=setup
+      setupenv()
+      proddir()
+      ExeActionRequired(DefineFQ)
+      envSet(UHAL, ${UPS_PROD_DIR})
+      envSet(UHAL_VERSION, ${UPS_PROD_VERSION})
+      # add the lib directory to LD_LIBRARY_PATH
+      envSet(UHAL_LIB, ${UHAL_FQ_DIR}/lib)
+      envSet(UHAL_INC, ${UPS_PROD_DIR}/include)
+      envPrepend(LD_LIBRARY_PATH, ${UHAL_FQ_DIR}/lib)
+      pathPrepend(PATH, ${UHAL_FQ_DIR}/bin)
+      pathPrepend(PYTHONPATH, ${UHAL_FQ_DIR}/lib/python3.8/site-packages)
+      # requirements
+      exeActionRequired(ExtraSetup)
+End:
+# End Group definition
+#*************************************************


### PR DESCRIPTION
`pybind11 v2_6_2 -q e19:prof` was built successfully and deployed to cvmfs under `prodcuts_dev`.

`uhal v2_8_0 -q e19:prof` was also built successfully and deployed to `products_dev` in cvmfs. It utilizes this new `pybind11` version.

My test of the following succeeded:

```
[root@86058f28572b scratch]# setup uhal v2_8_0 -q e19:prof
[root@86058f28572b scratch]# ups active
Active ups products:
boost             v1_73_0         -f Linux64bit+3.10-2.17 -q e19:prof        -z /cvmfs/dune.opensciencegrid.org/dunedaq/DUNE/products
cetpkgsupport     v1_14_01        -f NULL                                    -z /cvmfs/dune.opensciencegrid.org/dunedaq/DUNE/products
gcc               v8_2_0          -f Linux64bit+3.10-2.17                    -z /cvmfs/dune.opensciencegrid.org/dunedaq/DUNE/products
pugixml           v1_11           -f Linux64bit+3.10-2.17 -q e19             -z /cvmfs/dune.opensciencegrid.org/dunedaq/DUNE/products_dev
pybind11          v2_6_2          -f Linux64bit+3.10-2.17 -q e19:prof        -z /cvmfs/dune.opensciencegrid.org/dunedaq/DUNE/products_dev
python            v3_8_3b         -f Linux64bit+3.10-2.17                    -z /cvmfs/dune.opensciencegrid.org/dunedaq/DUNE/products
sqlite            v3_32_03_00     -f Linux64bit+3.10-2.17                    -z /cvmfs/dune.opensciencegrid.org/dunedaq/DUNE/products
uhal              v2_8_0          -f Linux64bit+3.10-2.17 -q e19:prof        -z /cvmfs/dune.opensciencegrid.org/dunedaq/DUNE/products_dev
ups               v6_0_8          -f Linux64bit+3.10-2.17                    -z /cvmfs/dune.opensciencegrid.org/dunedaq/DUNE/products
[root@86058f28572b scratch]# python
Python 3.8.3 (default, Jun 28 2020, 20:05:39)
[GCC 4.8.5 20150623 (Red Hat 4.8.5-39)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import uhal
>>>

```

