### PR TITLE
adding dependency of readoutlibs in trigger

### DIFF
--- a/spack-repos/release-repo-template/packages/trigger/package.py
+++ b/spack-repos/release-repo-template/packages/trigger/package.py
@@ -30,6 +30,7 @@ class Trigger(CMakePackage):
     depends_on("daqdataformats")
     depends_on("detdataformats")
     depends_on("detchannelmaps")
+    depends_on("readoutlibs")
     depends_on("hdf5libs")
     depends_on("cli11")
 


### PR DESCRIPTION
This is related to PR DUNE-DAQ/trigger#110.

`find_package(readoutlibs REQUIRED)` was added in this PR, which got merged to develop yesterday.

This broke the [nightly workflow](https://github.com/DUNE-DAQ/daq-release/actions/runs/2349901314) for spack release. 