### PR TITLE
JCF: in felix-software's package.py, remove awkward/unreliable requir…

### DIFF
--- a/spack-repos/externals/packages/felix-software/package.py
+++ b/spack-repos/externals/packages/felix-software/package.py
@@ -7,7 +7,7 @@ import spack.util.environment as envutil
 
 class FelixSoftware(Package):
 
-    git = "https://github.com/jcfreeman2/intentionallyempty.git"
+    has_code=False
 
     version("dunedaq-v2.10.0")
     version("dunedaq-v2.8.0")
@@ -15,8 +15,6 @@ class FelixSoftware(Package):
     depends_on('boost', type='build')
     depends_on('python', type='build')
     depends_on('cmake', type='build')
-#    depends_on('qt@5.15.2', type='build')
-#    depends_on('intel-tbb', type='build')
     depends_on('yaml-cpp@0.6.3', type='build')
     depends_on('czmq@4.1.1', type='build')
     depends_on('cppzmq', type='build')


### PR DESCRIPTION
…ement that there be an empty repo under my personal git account

Because felix-software is actually composed of code downloaded from a set of repos where the downloading has all been placed in the install step, there's not a natural git repository or URL for Spack's fetch function to go to. As a hack last year, I made an empty repository under my own DUNE-DAQ account and set that as the original repo for the fetch command as essentially a "null" operation to allow the installation of felix-software to proceed. 

A better solution is to set the `has_code` variable to `False`, which is what I've done in this PR. For more on this, look at the `do_fetch` function of the `PackageBase` superclass in `$SPACK_ROOT/lib/spack/spack/package.py` file. 