### PR TITLE
Use MPI variant of HDF5 and HighFive

### DIFF
--- a/configs/dunedaq/dunedaq-develop/release.yaml
+++ b/configs/dunedaq/dunedaq-develop/release.yaml
@@ -21,10 +21,10 @@
           variant: ~
         - name: highfive
           version: 2.7.1
-          variant: "~mpi  ^hdf5@1.12.0~mpi+threadsafe"
+          variant: "+mpi  ^hdf5@1.12.0+mpi+threadsafe"
         - name: hdf5
           version: 1.12.0
-          variant: "~mpi +threadsafe"
+          variant: "+mpi +threadsafe"
         - name: libarchive
           version: 3.6.2
           variant: ~

--- a/configs/dunedaq/dunedaq-develop/release.yaml
+++ b/configs/dunedaq/dunedaq-develop/release.yaml
@@ -21,10 +21,10 @@
           variant: ~
         - name: highfive
           version: 2.7.1
-          variant: "+mpi  ^hdf5@1.12.0+mpi+threadsafe"
+          variant: "+mpi"
         - name: hdf5
           version: 1.12.0
-          variant: "+mpi +threadsafe"
+          variant: "+mpi+threadsafe"
         - name: libarchive
           version: 3.6.2
           variant: ~

--- a/spack-repos/dunedaq-repo-template/packages/hdf5libs/package.py
+++ b/spack-repos/dunedaq-repo-template/packages/hdf5libs/package.py
@@ -18,7 +18,7 @@ class Hdf5libs(CMakePackage):
     version("XVERSIONX", commit="XHASHX")
 
     depends_on("logging")
-    depends_on("highfive ~mpi")
+    depends_on("highfive +mpi")
     depends_on("daqdataformats")
     depends_on("detdataformats")
     depends_on("detchannelmaps")


### PR DESCRIPTION
This PR uses the `mpi` variant of `hdf5` and `highfive`. A special nightly release has been built with it `NAFDT23-10-05` and `NFDT23-10-05`.

In the special nightly release, `leo-update-tests-apps` branch of `hdf5libs` is used.