### PR TITLE
Johnfreeman/daq deliverables issue122 install integration tests

### DIFF
--- a/.github/workflows/nightly-integtest.yml
+++ b/.github/workflows/nightly-integtest.yml
@@ -33,11 +33,11 @@ jobs:
 
     steps:
 
-    - name: Checkout daq-systemtest
+    - name: Checkout daqsystemtest
       uses: actions/checkout@v4
       with:
-        repository: DUNE-DAQ/daq-systemtest
-        path: daq-systemtest
+        repository: DUNE-DAQ/daqsystemtest
+        path: daqsystemtest
     
     - name: setup release and run test
       env:
@@ -53,10 +53,10 @@ jobs:
           export PATH=$HOME/bin:$PATH
           type get-ticket.sh && get-ticket.sh
           rm -f $GITHUB_WORKSPACE/test-results.xml
-          pytest --junit-xml=$GITHUB_WORKSPACE/test-results.xml $GITHUB_WORKSPACE/daq-systemtest/integtest/minimal_system_quick_test.py
+          pytest --junit-xml=$GITHUB_WORKSPACE/test-results.xml $GITHUB_WORKSPACE/daqsystemtest/integtest/minimal_system_quick_test.py
           cd $GITHUB_WORKSPACE
           rm -rf minimal_test_$NIGHTLY_TAG
-          rm -rf daq-systemtest
+          rm -rf daqsystemtest
 
     - name: Surface failing tests
       if: always()

--- a/.github/workflows/test-single-pkg.yml
+++ b/.github/workflows/test-single-pkg.yml
@@ -154,12 +154,12 @@ jobs:
         repository: DUNE-DAQ/${{ github.event.inputs.pkg-name }}
         path: scratch/sourcecode/${{ github.event.inputs.pkg-name }}
 
-    - name: Checkout daq-systemtest
+    - name: Checkout daqsystemtest
       uses: actions/checkout@v4
       with:
-        repository: DUNE-DAQ/daq-systemtest
+        repository: DUNE-DAQ/daqsystemtest
         ref: kbiery/small_footprint_quick_test 
-        path: daq-systemtest
+        path: daqsystemtest
     
 
     - name: build pkg
@@ -177,8 +177,8 @@ jobs:
         dbt-build
         dbt-workarea-env
         rm -f $GITHUB_WORKSPACE/test-results.xml
-        pytest --junit-xml=$GITHUB_WORKSPACE/test-results.xml $GITHUB_WORKSPACE/daq-systemtest/integtest/small_footprint_quick_test.py
-        #pytest --junit-xml=$GITHUB_WORKSPACE/test-results.xml $GITHUB_WORKSPACE/daq-systemtest/integtest/minimal_system_quick_test.py
+        pytest --junit-xml=$GITHUB_WORKSPACE/test-results.xml $GITHUB_WORKSPACE/daqsystemtest/integtest/small_footprint_quick_test.py
+        #pytest --junit-xml=$GITHUB_WORKSPACE/test-results.xml $GITHUB_WORKSPACE/daqsystemtest/integtest/minimal_system_quick_test.py
 
     - name: Surface failing tests
       if: always()

--- a/configs/dunedaq/dunedaq-develop/release.yaml
+++ b/configs/dunedaq/dunedaq-develop/release.yaml
@@ -122,7 +122,7 @@
 
     dunedaq:
         - name: daq-cmake
-          version: "v2.3.4"
+          version: "johnfreeman/daq_deliverables_issue122_install_integration_tests"
           commit: null
         - name: ers
           version: "develop"

--- a/configs/dunedaq/dunedaq-develop/release.yaml
+++ b/configs/dunedaq/dunedaq-develop/release.yaml
@@ -246,7 +246,7 @@
         - name: daq-buildtools
           version: "develop"
           commit: null
-        - name: daq-systemtest
+        - name: daqsystemtest
           version: "develop"
           commit: null
         - name: pocket

--- a/configs/dunedaq/dunedaq-develop/release.yaml
+++ b/configs/dunedaq/dunedaq-develop/release.yaml
@@ -122,7 +122,7 @@
 
     dunedaq:
         - name: daq-cmake
-          version: "johnfreeman/daq_deliverables_issue122_install_integration_tests"
+          version: v2.4.0
           commit: null
         - name: ers
           version: "develop"

--- a/configs/dunedaq/dunedaq-v4.1.0/release.yaml
+++ b/configs/dunedaq/dunedaq-v4.1.0/release.yaml
@@ -231,7 +231,7 @@
         - name: daq-buildtools
           version: v7.2.1
           commit: null
-        - name: daq-systemtest
+        - name: daqsystemtest
           version: v2.0.4
           commit: null
         - name: pocket

--- a/configs/dunedaq/dunedaq-v4.1.1/release.yaml
+++ b/configs/dunedaq/dunedaq-v4.1.1/release.yaml
@@ -231,7 +231,7 @@
         - name: daq-buildtools
           version: v7.2.1
           commit: null
-        - name: daq-systemtest
+        - name: daqsystemtest
           version: v2.0.5
           commit: null
         - name: pocket

--- a/configs/fddaq/fddaq-develop/dbt-build-order.cmake
+++ b/configs/fddaq/fddaq-develop/dbt-build-order.cmake
@@ -65,6 +65,7 @@ set(build_order "daq-cmake"
                 "ctbmodules"
                 "dpdklibs"
 		"snbmodules"
+		"daq-systemtest"
 		# ND packages
                 "nddetdataformats"
                 "ndreadoutlibs"

--- a/configs/fddaq/fddaq-develop/dbt-build-order.cmake
+++ b/configs/fddaq/fddaq-develop/dbt-build-order.cmake
@@ -65,7 +65,7 @@ set(build_order "daq-cmake"
                 "ctbmodules"
                 "dpdklibs"
 		"snbmodules"
-		"daq-systemtest"
+		"daqsystemtest"
 		# ND packages
                 "nddetdataformats"
                 "ndreadoutlibs"

--- a/configs/fddaq/fddaq-develop/release.yaml
+++ b/configs/fddaq/fddaq-develop/release.yaml
@@ -54,6 +54,9 @@
         - name: fddaqconf
           version: "develop"
           commit: null
+        - name: daq-systemtest
+          version: "develop"
+          commit: null
 
     pymodules:
         - name: pip

--- a/configs/fddaq/fddaq-develop/release.yaml
+++ b/configs/fddaq/fddaq-develop/release.yaml
@@ -54,7 +54,7 @@
         - name: fddaqconf
           version: "develop"
           commit: null
-        - name: daq-systemtest
+        - name: daqsystemtest
           version: "develop"
           commit: null
 

--- a/configs/nddaq/nddaq-develop/dbt-build-order.cmake
+++ b/configs/nddaq/nddaq-develop/dbt-build-order.cmake
@@ -65,6 +65,7 @@ set(build_order "daq-cmake"
                 "ctbmodules"
                 "dpdklibs"
 		"snbmodules"
+		"daq-systemtest"
 		# ND packages
                 "nddetdataformats"
                 "ndreadoutlibs"

--- a/configs/nddaq/nddaq-develop/dbt-build-order.cmake
+++ b/configs/nddaq/nddaq-develop/dbt-build-order.cmake
@@ -65,7 +65,7 @@ set(build_order "daq-cmake"
                 "ctbmodules"
                 "dpdklibs"
 		"snbmodules"
-		"daq-systemtest"
+		"daqsystemtest"
 		# ND packages
                 "nddetdataformats"
                 "ndreadoutlibs"

--- a/docs/team_repos.md
+++ b/docs/team_repos.md
@@ -9,7 +9,7 @@
     * connectivityserver
     * coredal
     * dal
-    * daq-systemtest
+    * daqsystemtest
     * daqconf
     * dbe
     * dqm
@@ -39,7 +39,7 @@
 * **Repositories with write access**:
     * appfwk
     * ctbmodules
-    * daq-systemtest
+    * daqsystemtest
     * daqconf
     * daqdataformats
     * dfmessages
@@ -79,7 +79,7 @@
 ## dqm
 * **People to contact**: Wes Ketchum, Pip Hamilton
 * **Repositories with write access**:
-    * daq-systemtest
+    * daqsystemtest
     * dqm
     * dqm-backend
     * rawdatautils
@@ -106,7 +106,7 @@
 ## trigger
 * **People to contact**: Josh Klein, Michal Rigan
 * **Repositories with write access**:
-    * daq-systemtest
+    * daqsystemtest
     * datafilter
     * trigger
     * triggeralgs
@@ -115,7 +115,7 @@
 ## udaq
 * **People to contact**: Jim Brooke
 * **Repositories with write access**:
-    * daq-systemtest
+    * daqsystemtest
     * dtpcontrols
     * dtpctrllibs
     * dtpemulator

--- a/scripts/github-ci/repo.sh
+++ b/scripts/github-ci/repo.sh
@@ -118,5 +118,5 @@ dune_packages=(
  "dtpemulator"
  "datafilter"
  "hsilibs"
- "daq-systemtest"
+ "daqsystemtest"
 )

--- a/scripts/spack/make-release-repo.py
+++ b/scripts/spack/make-release-repo.py
@@ -63,7 +63,7 @@ def get_commit_hash(repo, tag_or_branch, fall_back_tag="develop"):
     commit_hash = output[0].decode('utf-8').strip()
     cmd = "cd /tmp; rm -rf daq_repo_*"
     output = check_output(cmd)
-    return commit_hash
+    return (tag_or_branch, commit_hash)
 
 
 class DAQRelease:
@@ -95,10 +95,11 @@ class DAQRelease:
                 else:
                     iver = ipkg["version"]
                 ihash = ipkg["commit"]
+                itag = iver
                 if not iname.startswith('py-'):
-                    ihash = get_commit_hash(iname, iver, ipkg["version"])
+                    (itag, ihash) = get_commit_hash(iname, iver, ipkg["version"])
                 self.rdict[self.rtype][i]["commit"] = ihash
-                print(f"Info: {iname:<20} | {iver:<20} | {ihash}")
+                print(f"Info: {iname:<20} | {itag:<20} | {ihash}")
             # rewrite YAML
             with open(self.yaml, 'w') as outfile:
                 outfile.write('---\n')

--- a/spack-repos/fddaq-repo-template/packages/daq-systemtest/package.py
+++ b/spack-repos/fddaq-repo-template/packages/daq-systemtest/package.py
@@ -1,0 +1,34 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack import *
+
+
+class DaqSystemtest(CMakePackage):
+    """This package contains configurations for system-level DAQ tests."""
+
+    homepage = "https://github.com/DUNE-DAQ/daq-systemtest"
+    git =      "https://github.com/DUNE-DAQ/daq-systemtest.git"
+
+    maintainers = ["jcfreeman2"]
+
+    version("XVERSIONX", commit="XHASHX")
+
+    depends_on("daq-cmake")
+    depends_on("py-moo", type='build')
+
+    # DBT_DEBUG is used by daq-cmake to set compiler options
+    def cmake_args(self):
+        if str(self.spec.variants['build_type']) == "build_type=Debug":
+            return ["-DDBT_DEBUG=true"]
+        else:
+            return ["-DDBT_DEBUG=false"]
+
+    def setup_run_environment(self, env):
+        env.set(self.__module__.split(".")[-1].upper().replace("-", "_") + "_SHARE", self.prefix + "/share" )
+        env.prepend_path('DUNEDAQ_SHARE_PATH', self.prefix + "/share")
+        env.prepend_path('PYTHONPATH', self.prefix.lib + "64/python")
+

--- a/spack-repos/fddaq-repo-template/packages/daqsystemtest/package.py
+++ b/spack-repos/fddaq-repo-template/packages/daqsystemtest/package.py
@@ -7,11 +7,11 @@
 from spack import *
 
 
-class DaqSystemtest(CMakePackage):
+class Daqsystemtest(CMakePackage):
     """This package contains configurations for system-level DAQ tests."""
 
-    homepage = "https://github.com/DUNE-DAQ/daq-systemtest"
-    git =      "https://github.com/DUNE-DAQ/daq-systemtest.git"
+    homepage = "https://github.com/DUNE-DAQ/daqsystemtest"
+    git =      "https://github.com/DUNE-DAQ/daqsystemtest.git"
 
     maintainers = ["jcfreeman2"]
 


### PR DESCRIPTION
Adding `daq-systemtest` to the release. 

The following things should be done prior to merge this PR:
1. merge DUNE-DAQ/daq-systemtest#67
2. merge DUNE-DAQ/daq-cmake#98
3. create new tag for `daq-cmake`
4. update `daq-release/configs/dunedaq/dunedaq-develop/release.yaml` to use the new tag for `daq-cmake`.