### PR TITLE
Johnfreeman/old checkout action for sl7

### DIFF
--- a/.github/workflows/build-frozen-release.yml
+++ b/.github/workflows/build-frozen-release.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     - name: Checkout daq-release
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
       with:
         repository: DUNE-DAQ/daq-release
         path: daq-release

--- a/.github/workflows/dunedaq-feature-branch-cpp-ci.yml
+++ b/.github/workflows/dunedaq-feature-branch-cpp-ci.yml
@@ -35,7 +35,7 @@ jobs:
     # Runs a single command using the runners shell
     
     - name: Checkout daq-release
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
       with:
         repository: DUNE-DAQ/daq-release
         path: daq-release

--- a/.github/workflows/nightly-spack.yml
+++ b/.github/workflows/nightly-spack.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
 
     - name: Checkout daq-release
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
       with:
         repository: DUNE-DAQ/daq-release
         path: daq-release

--- a/.github/workflows/nightly-update-pypi-repo.yml
+++ b/.github/workflows/nightly-update-pypi-repo.yml
@@ -18,7 +18,7 @@ jobs:
     name: update_pypi_repo
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/dune-daq/sl7-slim-externals:latest
+      image: ghcr.io/dune-daq/sl7-slim-externals:v1.1
     defaults:
       run:
         shell: bash

--- a/.github/workflows/nightly-update-pypi-repo.yml
+++ b/.github/workflows/nightly-update-pypi-repo.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Checkout daq-release
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
       with:
         repository: DUNE-DAQ/daq-release
         path: daq-release

--- a/.github/workflows/nightly-update-pypi-repo.yml
+++ b/.github/workflows/nightly-update-pypi-repo.yml
@@ -35,7 +35,7 @@ jobs:
           mkdir -p $GITHUB_WORKSPACE/workdir
           cd $GITHUB_WORKSPACE/workdir
           source /cvmfs/dunedaq.opensciencegrid.org/spack/externals/ext-v1.1/spack-0.20.0-gcc-12.1.0/spack-installation/share/spack/setup-env.sh
-          spack load python
+          spack load python@3.10.10
           python -m venv pypi-repo-venv
           source pypi-repo-venv/bin/activate
           echo "activated pyvenv"
@@ -46,7 +46,8 @@ jobs:
       run: |
           cd $GITHUB_WORKSPACE/workdir
           source /cvmfs/dunedaq.opensciencegrid.org/spack/externals/ext-v1.1/spack-0.20.0-gcc-12.1.0/spack-installation/share/spack/setup-env.sh
-          spack load python
+          spack load python@3.10.10
+          spack load go	  
           source pypi-repo-venv/bin/activate
           manifest_file="$GITHUB_WORKSPACE/daq-release/configs/fddaq/fddaq-develop/release.yaml"
           repo_path="/cvmfs/dunedaq.opensciencegrid.org/pypi-repo"
@@ -68,7 +69,8 @@ jobs:
           cd $GITHUB_WORKSPACE/workdir
           python3 $GITHUB_WORKSPACE/daq-release/scripts/spack/make-release-repo.py -o  $GITHUB_WORKSPACE --pyvenv-requirements -i $GITHUB_WORKSPACE/daq-release/configs/fddaq/fddaq-develop/release.yaml
           source /cvmfs/dunedaq.opensciencegrid.org/spack/externals/ext-v1.1/spack-0.20.0-gcc-12.1.0/spack-installation/share/spack/setup-env.sh
-          spack load python
+          spack load python@3.10.10
+          spack load go
           python -m venv dbt-pyvenv
           source dbt-pyvenv/bin/activate
           python -m pip install -r $GITHUB_WORKSPACE/pyvenv_requirements.txt
@@ -77,7 +79,7 @@ jobs:
       run: |
           cd $GITHUB_WORKSPACE/workdir
           source /cvmfs/dunedaq.opensciencegrid.org/spack/externals/ext-v1.1/spack-0.20.0-gcc-12.1.0/spack-installation/share/spack/setup-env.sh
-          spack load python
+          spack load python@3.10.10
           source dbt-pyvenv/bin/activate
           pip freeze > $GITHUB_WORKSPACE/pip-freeze.txt
 

--- a/.github/workflows/nightly-update-pypi-repo.yml
+++ b/.github/workflows/nightly-update-pypi-repo.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
           mkdir -p $GITHUB_WORKSPACE/workdir
           cd $GITHUB_WORKSPACE/workdir
-          source /cvmfs/dunedaq.opensciencegrid.org/spack/externals/ext-v1.0/spack-0.18.1-gcc-12.1.0/spack-installation/share/spack/setup-env.sh
+          source /cvmfs/dunedaq.opensciencegrid.org/spack/externals/ext-v1.1/spack-0.20.0-gcc-12.1.0/spack-installation/share/spack/setup-env.sh
           spack load python
           python -m venv pypi-repo-venv
           source pypi-repo-venv/bin/activate
@@ -45,7 +45,7 @@ jobs:
     - name: parse release_manifest and install all pkgs
       run: |
           cd $GITHUB_WORKSPACE/workdir
-          source /cvmfs/dunedaq.opensciencegrid.org/spack/externals/ext-v1.0/spack-0.18.1-gcc-12.1.0/spack-installation/share/spack/setup-env.sh
+          source /cvmfs/dunedaq.opensciencegrid.org/spack/externals/ext-v1.1/spack-0.20.0-gcc-12.1.0/spack-installation/share/spack/setup-env.sh
           spack load python
           source pypi-repo-venv/bin/activate
           manifest_file="$GITHUB_WORKSPACE/daq-release/configs/fddaq/fddaq-develop/release.yaml"
@@ -67,7 +67,7 @@ jobs:
       run: |
           cd $GITHUB_WORKSPACE/workdir
           python3 $GITHUB_WORKSPACE/daq-release/scripts/spack/make-release-repo.py -o  $GITHUB_WORKSPACE --pyvenv-requirements -i $GITHUB_WORKSPACE/daq-release/configs/fddaq/fddaq-develop/release.yaml
-          source /cvmfs/dunedaq.opensciencegrid.org/spack/externals/ext-v1.0/spack-0.18.1-gcc-12.1.0/spack-installation/share/spack/setup-env.sh
+          source /cvmfs/dunedaq.opensciencegrid.org/spack/externals/ext-v1.1/spack-0.20.0-gcc-12.1.0/spack-installation/share/spack/setup-env.sh
           spack load python
           python -m venv dbt-pyvenv
           source dbt-pyvenv/bin/activate
@@ -76,7 +76,7 @@ jobs:
     - name: generaete pip freeze
       run: |
           cd $GITHUB_WORKSPACE/workdir
-          source /cvmfs/dunedaq.opensciencegrid.org/spack/externals/ext-v1.0/spack-0.18.1-gcc-12.1.0/spack-installation/share/spack/setup-env.sh
+          source /cvmfs/dunedaq.opensciencegrid.org/spack/externals/ext-v1.1/spack-0.20.0-gcc-12.1.0/spack-installation/share/spack/setup-env.sh
           spack load python
           source dbt-pyvenv/bin/activate
           pip freeze > $GITHUB_WORKSPACE/pip-freeze.txt


### PR DESCRIPTION
Last night it was discovered that the "Update pypi-repo" Action failed. The immediate reason for this is that the update from `actions/checkout@v3` to `actions/checkout@v4` failed in the SL7-based container we use. I rolled back to `actions/checkout@v3`, and then also discovered that we need `go` for the installation of the `gojsonnet` package, so I switched over to the `ghcr.io/dune-daq/sl7-slim-externals:v1.1` container which contains `go`, unlike `ghcr.io/dune-daq/sl7-slim-externals:latest` which was being used. 