### PR TITLE
JCF: have build-release.sh fail immediately with a nonzero return val…

### DIFF
--- a/scripts/spack/build-release.sh
+++ b/scripts/spack/build-release.sh
@@ -139,7 +139,7 @@ if [[ "$DET" == "fd" || "$DET" == "nd" ]]; then
     python -m venv --prompt dbt ${SPACK_AREA}/.venv
     source ${SPACK_AREA}/.venv/bin/activate
 
-    python -m pip install -r ${SPACK_AREA}/pyvenv_requirements.txt
+    python -m pip install -r ${SPACK_AREA}/pyvenv_requirements.txt || exit 11
 
     pushd $DET_RELEASE_DIR
     cp $DAQ_RELEASE_REPO/$( dirname $release_yaml )/dbt-build-order.cmake .


### PR DESCRIPTION
…ue if pip installation fails

To test this, fork off a (very temporary) branch from this feature branch, sabotage a version number for a Python package for a detector's `release.yaml` file (e.g. can just recreate the issue with the second candidate build for `fddaq-v4.4.0`), then run the relevant build workflow _on your forked branch_.

If the Workflow fails because of the failed pip installation, the test succeeded, and you can merge in this PR as well as delete the branch which you forked off. 