### PR TITLE
Fix name of branch_name variable

### DIFF
--- a/scripts/spack/make-release-repo.py
+++ b/scripts/spack/make-release-repo.py
@@ -105,10 +105,10 @@ class DAQRelease:
                 yaml.dump(self.rdict, outfile, Dumper=MyDumper, default_flow_style=False, sort_keys=False)
         return
 
-    def get_cmake_dependencies(self, package_name, branch_name='develop'):
+    def get_cmake_dependencies(self, package_name, branch_name):
         if self.overwrite_branch != '':
             if check_branch_exists(package_name, self.overwrite_branch):
-                branch = self.overwrite_branch
+                branch_name = self.overwrite_branch
         file_name = "CMakeLists.txt"
         cmakelists_path = f'https://raw.githubusercontent.com/DUNE-DAQ/{package_name}/{branch_name}/{file_name}'
         command = f'curl -o {file_name} --fail {cmakelists_path}'


### PR DESCRIPTION
Responding to issue #362, looks like I just forgot to name `branch` to `branch_name`. I've tested locally that supplying an `overwrite_branch` to `DAQRelease` works as expected, e.g., I can checkout `production/v4` instead of `develop` and generate the repos correctly. 

Also, I realized there's no obvious reason to set a default value for `branch_name`, so it's now a required argument. 