### PR TITLE
AJM: Check release tags exist when generating repos

### DIFF
--- a/scripts/checkout-daq-package.py
+++ b/scripts/checkout-daq-package.py
@@ -42,7 +42,7 @@ def checkout_tag(repo, commit, outdir):
 git clone https://github.com/DUNE-DAQ/{repo}.git; \
 cd {repo}; \
 if ! git show-ref --tags --verify --quiet "refs/tags/{commit}"; then \
-  echo "{tag_or_branch} does not exist for package {repo}. Exiting..."; \
+  echo "{commit} does not exist for package {repo}. Exiting..."; \
   exit 1; \
 fi; \
 git checkout {commit}; \

--- a/scripts/checkout-daq-package.py
+++ b/scripts/checkout-daq-package.py
@@ -41,6 +41,7 @@ def checkout_tag(repo, commit, outdir):
     cmd = f"""\nmkdir -p {outdir}; cd {outdir}; \
 git clone https://github.com/DUNE-DAQ/{repo}.git; \
 cd {repo}; \
+if ! git show-ref --tags --verify --quiet "refs/tags/{commit}"; then exit 1; fi
 git checkout {commit}; \
 cmake_version=`grep "^project" CMakeLists.txt |grep ")$"|grep -oP "(([[:digit:]]+\.)([[:digit:]]+\.)([[:digit:]]+))"`; \
 tag=v"$cmake_version"; \

--- a/scripts/checkout-daq-package.py
+++ b/scripts/checkout-daq-package.py
@@ -41,7 +41,10 @@ def checkout_tag(repo, commit, outdir):
     cmd = f"""\nmkdir -p {outdir}; cd {outdir}; \
 git clone https://github.com/DUNE-DAQ/{repo}.git; \
 cd {repo}; \
-if ! git show-ref --tags --verify --quiet "refs/tags/{commit}"; then exit 1; fi
+if ! git show-ref --tags --verify --quiet "refs/tags/{commit}"; then \
+  echo "{tag_or_branch} does not exist for package {repo}. Exiting..."; \
+  exit 1; \
+fi; \
 git checkout {commit}; \
 cmake_version=`grep "^project" CMakeLists.txt |grep ")$"|grep -oP "(([[:digit:]]+\.)([[:digit:]]+\.)([[:digit:]]+))"`; \
 tag=v"$cmake_version"; \

--- a/scripts/spack/make-release-repo.py
+++ b/scripts/spack/make-release-repo.py
@@ -44,6 +44,13 @@ def get_commit_hash(repo, tag_or_branch, fall_back_tag="develop"):
             fi"""
         output = check_output(cmd)
         tag_or_branch = output[0].decode('utf-8').strip()
+    else: # Check if tag exists
+        cmd = f"""cd {tmp_dir}/{repo}; \
+            if ! git show-ref --tags --verify --quiet "refs/tags/{tag_or_branch}"; then \
+              echo "{tag_or_branch} does not exist for package {repo}. Exiting..."; \
+              exit 1; \
+            fi;""" 
+        output = check_output(cmd)
     cmd = f"""cd {tmp_dir}/{repo}; \
         git checkout --quiet {tag_or_branch}; \
         git rev-parse --short HEAD"""


### PR DESCRIPTION
In response to Issue #366, this PR adds a couple of explicit checks that a tag listed in a release yaml exists and fails loudly if it does not. I added two such checks, one to `make-release-repo.py`'s `get_commit_hash` function, and one in `checkout-daq-package.py`'s `checkout_tag` function. I've tested that these work by changing an arbitrary tag in, for example, the `fddaq-v4.4.0` release yaml to something that doesn't exist. I also checked that things still work normally when generating repos based on the `develop` branch, like during a nightly build. 