### PR TITLE
Fix how nightly integration tests remove xml output files

### DIFF
--- a/.github/workflows/nightly-v4-integtest.yml
+++ b/.github/workflows/nightly-v4-integtest.yml
@@ -56,7 +56,7 @@ jobs:
           setup_dbt latest|| true
           dbt-setup-release -n $NIGHTLY_TAG
           #dbt-setup-release -n last_${DET}daq
-          rm -f $GITHUB_WORKSPACE/*_test_results.xml
+          rm -f $GITHUB_WORKSPACE/${{ matrix.test_name }}_test_results.xml
           pytest --junit-xml=$GITHUB_WORKSPACE/${{ matrix.test_name }}_test_results.xml $GITHUB_WORKSPACE/daqsystemtest/integtest/${{ matrix.test_name }}_test.py
           cd $GITHUB_WORKSPACE
           rm -rf integration_tests_$NIGHTLY_TAG

--- a/.github/workflows/nightly-v5-integtest.yml
+++ b/.github/workflows/nightly-v5-integtest.yml
@@ -57,7 +57,7 @@ jobs:
           setup_dbt latest_v5 || true
           dbt-setup-release -n $NIGHTLY_TAG
           #dbt-setup-release -n last_${DET}daq
-          rm -f $GITHUB_WORKSPACE/*_test_results.xml
+          rm -f $GITHUB_WORKSPACE/${{ matrix.test_name }}_test_results.xml
           pytest --junit-xml=$GITHUB_WORKSPACE/${{ matrix.test_name }}_test_results.xml \
                  $GITHUB_WORKSPACE/listrev/integtest/${{ matrix.test_name }}_test.py \
                  --nanorc-option partition-number 6


### PR DESCRIPTION
This fixes a minor bug where the xml files output by the integration tests&mdash;which are used by the "surface failing tests" action&mdash;were getting removed in a way that the summary table wouldn't see them all. 