### PR TITLE
Issue #375: Add sourcecode to release env

### DIFF
--- a/.github/workflows/build-candidate-release-alma9.yml
+++ b/.github/workflows/build-candidate-release-alma9.yml
@@ -40,6 +40,7 @@ jobs:
           export OS=almalinux9
           source daq-release/.github/workflows/wf-setup-tools.sh
 
+          daq-release/scripts/checkout-daq-package.py -i daq-release/configs/coredaq/coredaq-${{ github.event.inputs.base-release }}/release.yaml -a -c -o $DET_RELEASE_DIR/sourcecode
           daq-release/scripts/spack/build-release.sh $BASE_RELEASE_DIR $DET_RELEASE_DIR core $OS
 
           cd $BASE_RELEASE_DIR/..
@@ -59,6 +60,7 @@ jobs:
           export OS=almalinux9
           source daq-release/.github/workflows/wf-setup-tools.sh
 
+          daq-release/scripts/checkout-daq-package.py -i daq-release/configs/fddaq/fddaq-${{ github.event.inputs.det-release }}/release.yaml -a -c -o $DET_RELEASE_DIR/sourcecode
           daq-release/scripts/spack/build-release.sh $BASE_RELEASE_DIR $DET_RELEASE_DIR $DET $OS
 
           cd $DET_RELEASE_DIR/..

--- a/.github/workflows/build-candidate-release-sl7.yml
+++ b/.github/workflows/build-candidate-release-sl7.yml
@@ -40,6 +40,7 @@ jobs:
           export OS=scientific7
           source daq-release/.github/workflows/wf-setup-tools.sh
 
+          daq-release/scripts/checkout-daq-package.py -i daq-release/configs/coredaq/coredaq-${{ github.event.inputs.base-release }}/release.yaml -a -c -o $DET_RELEASE_DIR/sourcecode
           daq-release/scripts/spack/build-release.sh $BASE_RELEASE_DIR $DET_RELEASE_DIR core $OS
 
           cd $BASE_RELEASE_DIR/..
@@ -59,6 +60,7 @@ jobs:
           export OS=scientific7
           source daq-release/.github/workflows/wf-setup-tools.sh
 
+          daq-release/scripts/checkout-daq-package.py -i daq-release/configs/fddaq/fddaq-${{ github.event.inputs.det-release }}/release.yaml -a -c -o $DET_RELEASE_DIR/sourcecode
           daq-release/scripts/spack/build-release.sh $BASE_RELEASE_DIR $DET_RELEASE_DIR $DET $OS
 
           cd $DET_RELEASE_DIR/..

--- a/.github/workflows/build-frozen-release-alma9.yml
+++ b/.github/workflows/build-frozen-release-alma9.yml
@@ -40,6 +40,7 @@ jobs:
           export OS=almalinux9
           source daq-release/.github/workflows/wf-setup-tools.sh
 
+          daq-release/scripts/checkout-daq-package.py -i daq-release/configs/coredaq/coredaq-${{ github.event.inputs.base-release }}/release.yaml -a -c -o $DET_RELEASE_DIR/sourcecode
           daq-release/scripts/spack/build-release.sh $BASE_RELEASE_DIR $DET_RELEASE_DIR core $OS
 
           cd $BASE_RELEASE_DIR/..
@@ -59,6 +60,7 @@ jobs:
           export OS=almalinux9
           source daq-release/.github/workflows/wf-setup-tools.sh
 
+          daq-release/scripts/checkout-daq-package.py -i daq-release/configs/fddaq/fddaq-${{ github.event.inputs.det-release }}/release.yaml -a -c -o $DET_RELEASE_DIR/sourcecode
           daq-release/scripts/spack/build-release.sh $BASE_RELEASE_DIR $DET_RELEASE_DIR $DET $OS
 
           cd $DET_RELEASE_DIR/..

--- a/.github/workflows/build-frozen-release-sl7.yml
+++ b/.github/workflows/build-frozen-release-sl7.yml
@@ -41,6 +41,7 @@ jobs:
           export OS=scientific7
           source daq-release/.github/workflows/wf-setup-tools.sh
 
+          daq-release/scripts/checkout-daq-package.py -i daq-release/configs/coredaq/coredaq-${{ github.event.inputs.base-release }}/release.yaml -a -c -o $DET_RELEASE_DIR/sourcecode
           daq-release/scripts/spack/build-release.sh $BASE_RELEASE_DIR $DET_RELEASE_DIR core $OS
 
           cd $BASE_RELEASE_DIR/..
@@ -60,6 +61,7 @@ jobs:
           export OS=scientific7
           source daq-release/.github/workflows/wf-setup-tools.sh
 
+          daq-release/scripts/checkout-daq-package.py -i daq-release/configs/fddaq/fddaq-${{ github.event.inputs.det-release }}/release.yaml -a -c -o $DET_RELEASE_DIR/sourcecode
           daq-release/scripts/spack/build-release.sh $BASE_RELEASE_DIR $DET_RELEASE_DIR $DET $OS
 
           cd $DET_RELEASE_DIR/..

--- a/.github/workflows/build-nightly-release-alma9.yml
+++ b/.github/workflows/build-nightly-release-alma9.yml
@@ -59,9 +59,7 @@ jobs:
 
           daq-release/scripts/spack/build-release.sh $BASE_RELEASE_DIR $DET_RELEASE_DIR core $OS ${{ github.event.inputs.feature-branch }}
           packages_to_checkout=$(daq-release/scripts/list_packages.py develop coredaq)
-          for package in $packages_to_checkout; do 
-            git clone https://github.com/DUNE-DAQ/$package -b develop $DET_RELEASE_DIR/sourcecode/$package; 
-          done;
+          daq-release/scripts/checkout-daq-package.py -i daq-release/configs/coredaq/coredaq-develop/release.yaml -a -o $DET_RELEASE_DIR/sourcecode
 
           cd $BASE_RELEASE_DIR/../
           tar_and_stage_release ${BASE_RELEASE_TAG}
@@ -82,10 +80,7 @@ jobs:
           source daq-release/.github/workflows/wf-setup-tools.sh
 
           daq-release/scripts/spack/build-release.sh $BASE_RELEASE_DIR $DET_RELEASE_DIR fd $OS ${{ github.event.inputs.feature-branch }}
-          packages_to_checkout=$(daq-release/scripts/list_packages.py develop fddaq)
-          for package in $packages_to_checkout; do 
-            git clone https://github.com/DUNE-DAQ/$package -b develop $DET_RELEASE_DIR/sourcecode/$package; 
-          done;
+          daq-release/scripts/checkout-daq-package.py -i daq-release/configs/fddaq/fddaq-develop/release.yaml -a -o $DET_RELEASE_DIR/sourcecode
 
           cd $DET_RELEASE_DIR/../
           tar_and_stage_release ${DET_RELEASE_TAG}

--- a/.github/workflows/build-nightly-release-alma9.yml
+++ b/.github/workflows/build-nightly-release-alma9.yml
@@ -58,6 +58,7 @@ jobs:
           source daq-release/.github/workflows/wf-setup-tools.sh
 
           daq-release/scripts/spack/build-release.sh $BASE_RELEASE_DIR $DET_RELEASE_DIR core $OS ${{ github.event.inputs.feature-branch }}
+          daq-release/scripts/checkout-daq-package.py -i daq-release/configs/coredaq/coredaq-develop/release.yaml -a -c -o $BASE_RELEASE_DIR/sourcecode
 
           cd $BASE_RELEASE_DIR/../
           tar_and_stage_release ${BASE_RELEASE_TAG}
@@ -78,6 +79,7 @@ jobs:
           source daq-release/.github/workflows/wf-setup-tools.sh
 
           daq-release/scripts/spack/build-release.sh $BASE_RELEASE_DIR $DET_RELEASE_DIR fd $OS ${{ github.event.inputs.feature-branch }}
+          daq-release/scripts/checkout-daq-package.py -i daq-release/configs/fddaq/fddaq-develop/release.yaml -a -c -o $DET_RELEASE_DIR/sourcecode
 
           cd $DET_RELEASE_DIR/../
           tar_and_stage_release ${DET_RELEASE_TAG}

--- a/.github/workflows/build-nightly-release-alma9.yml
+++ b/.github/workflows/build-nightly-release-alma9.yml
@@ -79,8 +79,8 @@ jobs:
           export OS=almalinux9
           source daq-release/.github/workflows/wf-setup-tools.sh
 
-          daq-release/scripts/spack/build-release.sh $BASE_RELEASE_DIR $DET_RELEASE_DIR fd $OS ${{ github.event.inputs.feature-branch }}
           daq-release/scripts/checkout-daq-package.py -i daq-release/configs/fddaq/fddaq-develop/release.yaml -a -o $DET_RELEASE_DIR/sourcecode
+          daq-release/scripts/spack/build-release.sh $BASE_RELEASE_DIR $DET_RELEASE_DIR fd $OS ${{ github.event.inputs.feature-branch }}
 
           cd $DET_RELEASE_DIR/../
           tar_and_stage_release ${DET_RELEASE_TAG}

--- a/.github/workflows/build-nightly-release-alma9.yml
+++ b/.github/workflows/build-nightly-release-alma9.yml
@@ -58,7 +58,10 @@ jobs:
           source daq-release/.github/workflows/wf-setup-tools.sh
 
           daq-release/scripts/spack/build-release.sh $BASE_RELEASE_DIR $DET_RELEASE_DIR core $OS ${{ github.event.inputs.feature-branch }}
-          daq-release/scripts/checkout-daq-package.py -i daq-release/configs/coredaq/coredaq-develop/release.yaml -a -c -o $BASE_RELEASE_DIR/sourcecode
+          packages_to_checkout=$(daq-release/scripts/list_packages.py develop coredaq)
+          for package in $packages_to_checkout; do 
+            git clone https://github.com/DUNE-DAQ/$package -b develop $BASE_RELEASE_DIR/sourcecode/$package; 
+          done;
 
           cd $BASE_RELEASE_DIR/../
           tar_and_stage_release ${BASE_RELEASE_TAG}
@@ -79,7 +82,10 @@ jobs:
           source daq-release/.github/workflows/wf-setup-tools.sh
 
           daq-release/scripts/spack/build-release.sh $BASE_RELEASE_DIR $DET_RELEASE_DIR fd $OS ${{ github.event.inputs.feature-branch }}
-          daq-release/scripts/checkout-daq-package.py -i daq-release/configs/fddaq/fddaq-develop/release.yaml -a -c -o $DET_RELEASE_DIR/sourcecode
+          packages_to_checkout=$(daq-release/scripts/list_packages.py develop fddaq)
+          for package in $packages_to_checkout; do 
+            git clone https://github.com/DUNE-DAQ/$package -b develop $DET_RELEASE_DIR/sourcecode/$package; 
+          done;
 
           cd $DET_RELEASE_DIR/../
           tar_and_stage_release ${DET_RELEASE_TAG}

--- a/.github/workflows/build-nightly-release-alma9.yml
+++ b/.github/workflows/build-nightly-release-alma9.yml
@@ -60,7 +60,7 @@ jobs:
           daq-release/scripts/spack/build-release.sh $BASE_RELEASE_DIR $DET_RELEASE_DIR core $OS ${{ github.event.inputs.feature-branch }}
           packages_to_checkout=$(daq-release/scripts/list_packages.py develop coredaq)
           for package in $packages_to_checkout; do 
-            git clone https://github.com/DUNE-DAQ/$package -b develop $BASE_RELEASE_DIR/sourcecode/$package; 
+            git clone https://github.com/DUNE-DAQ/$package -b develop $DET_RELEASE_DIR/sourcecode/$package; 
           done;
 
           cd $BASE_RELEASE_DIR/../

--- a/.github/workflows/build-nightly-release-alma9.yml
+++ b/.github/workflows/build-nightly-release-alma9.yml
@@ -57,9 +57,8 @@ jobs:
           export OS=almalinux9
           source daq-release/.github/workflows/wf-setup-tools.sh
 
-          daq-release/scripts/spack/build-release.sh $BASE_RELEASE_DIR $DET_RELEASE_DIR core $OS ${{ github.event.inputs.feature-branch }}
-          packages_to_checkout=$(daq-release/scripts/list_packages.py develop coredaq)
           daq-release/scripts/checkout-daq-package.py -i daq-release/configs/coredaq/coredaq-develop/release.yaml -a -o $DET_RELEASE_DIR/sourcecode
+          daq-release/scripts/spack/build-release.sh $BASE_RELEASE_DIR $DET_RELEASE_DIR core $OS ${{ github.event.inputs.feature-branch }}
 
           cd $BASE_RELEASE_DIR/../
           tar_and_stage_release ${BASE_RELEASE_TAG}

--- a/.github/workflows/build-nightly-release-sl7.yml
+++ b/.github/workflows/build-nightly-release-sl7.yml
@@ -58,6 +58,7 @@ jobs:
           export OS=scientific7
           source daq-release/.github/workflows/wf-setup-tools.sh
 
+          daq-release/scripts/checkout-daq-package.py -i daq-release/configs/coredaq/coredaq-develop/release.yaml -a -o $DET_RELEASE_DIR/sourcecode
           daq-release/scripts/spack/build-release.sh $BASE_RELEASE_DIR $DET_RELEASE_DIR core $OS ${{ github.event.inputs.feature-branch }}
 
           cd $BASE_RELEASE_DIR/../
@@ -78,6 +79,7 @@ jobs:
           export OS=scientific7
           source daq-release/.github/workflows/wf-setup-tools.sh
 
+          daq-release/scripts/checkout-daq-package.py -i daq-release/configs/fddaq/fddaq-develop/release.yaml -a -o $DET_RELEASE_DIR/sourcecode
           daq-release/scripts/spack/build-release.sh $BASE_RELEASE_DIR $DET_RELEASE_DIR fd $OS ${{ github.event.inputs.feature-branch }}
 
           cd $DET_RELEASE_DIR/../

--- a/.github/workflows/build-v4-candidate-release-alma9.yml
+++ b/.github/workflows/build-v4-candidate-release-alma9.yml
@@ -40,6 +40,7 @@ jobs:
           export OS=almalinux9
           source daq-release/.github/workflows/wf-setup-tools.sh
 
+          daq-release/scripts/checkout-daq-package.py -i daq-release/configs/coredaq/coredaq-${{ github.event.inputs.base-release }}/release.yaml -a -c -o $DET_RELEASE_DIR/sourcecode
           daq-release/scripts/spack/build-release.sh $BASE_RELEASE_DIR $DET_RELEASE_DIR core $OS
 
           cd $BASE_RELEASE_DIR/..
@@ -59,6 +60,7 @@ jobs:
           export OS=almalinux9
           source daq-release/.github/workflows/wf-setup-tools.sh
 
+          daq-release/scripts/checkout-daq-package.py -i daq-release/configs/fddaq/fddaq-${{ github.event.inputs.det-release }}/release.yaml -a -c -o $DET_RELEASE_DIR/sourcecode
           daq-release/scripts/spack/build-release.sh $BASE_RELEASE_DIR $DET_RELEASE_DIR $DET $OS
 
           cd $DET_RELEASE_DIR/..

--- a/.github/workflows/build-v4-frozen-release-alma9.yml
+++ b/.github/workflows/build-v4-frozen-release-alma9.yml
@@ -40,6 +40,7 @@ jobs:
           export OS=almalinux9
           source daq-release/.github/workflows/wf-setup-tools.sh
 
+          daq-release/scripts/checkout-daq-package.py -i daq-release/configs/coredaq/coredaq-${{ github.event.inputs.base-release }}/release.yaml -a -c -o $DET_RELEASE_DIR/sourcecode
           daq-release/scripts/spack/build-release.sh $BASE_RELEASE_DIR $DET_RELEASE_DIR core $OS
 
           cd $BASE_RELEASE_DIR/..
@@ -59,6 +60,7 @@ jobs:
           export OS=almalinux9
           source daq-release/.github/workflows/wf-setup-tools.sh
 
+          daq-release/scripts/checkout-daq-package.py -i daq-release/configs/fddaq/fddaq-${{ github.event.inputs.det-release }}/release.yaml -a -c -o $DET_RELEASE_DIR/sourcecode
           daq-release/scripts/spack/build-release.sh $BASE_RELEASE_DIR $DET_RELEASE_DIR $DET $OS
 
           cd $DET_RELEASE_DIR/..

--- a/.github/workflows/build-v4-release-alma9.yml
+++ b/.github/workflows/build-v4-release-alma9.yml
@@ -54,6 +54,7 @@ jobs:
           export OS=almalinux9
           source daq-release/.github/workflows/wf-setup-tools.sh
 
+          daq-release/scripts/checkout-daq-package.py -i daq-release/configs/coredaq/coredaq-production_v4/release.yaml -a -o $DET_RELEASE_DIR/sourcecode
           daq-release/scripts/spack/build-release.sh $BASE_RELEASE_DIR $DET_RELEASE_DIR core $OS production/v4
 
           cd $BASE_RELEASE_DIR/../
@@ -74,6 +75,7 @@ jobs:
           export OS=almalinux9
           source daq-release/.github/workflows/wf-setup-tools.sh
 
+          daq-release/scripts/checkout-daq-package.py -i daq-release/configs/fddaq/fddaq-production_v4/release.yaml -a -o $DET_RELEASE_DIR/sourcecode
           daq-release/scripts/spack/build-release.sh $BASE_RELEASE_DIR $DET_RELEASE_DIR fd $OS production/v4
 
           cd $DET_RELEASE_DIR/../

--- a/.github/workflows/build-v4-release-sl7.yml
+++ b/.github/workflows/build-v4-release-sl7.yml
@@ -55,6 +55,7 @@ jobs:
           export OS=scientific7
           source daq-release/.github/workflows/wf-setup-tools.sh
 
+          daq-release/scripts/checkout-daq-package.py -i daq-release/configs/coredaq/coredaq-production_v4/release.yaml -a -o $DET_RELEASE_DIR/sourcecode
           daq-release/scripts/spack/build-release.sh $BASE_RELEASE_DIR $DET_RELEASE_DIR core $OS production/v4
 
           cd $BASE_RELEASE_DIR/../
@@ -75,6 +76,7 @@ jobs:
           export OS=scientific7
           source daq-release/.github/workflows/wf-setup-tools.sh
 
+          daq-release/scripts/checkout-daq-package.py -i daq-release/configs/fddaq/fddaq-production_v4/release.yaml -a -o $DET_RELEASE_DIR/sourcecode
           daq-release/scripts/spack/build-release.sh $BASE_RELEASE_DIR $DET_RELEASE_DIR fd $OS production/v4
 
           cd $DET_RELEASE_DIR/../

--- a/configs/coredaq/coredaq-v2.7.1/release.yaml
+++ b/configs/coredaq/coredaq-v2.7.1/release.yaml
@@ -1,0 +1,245 @@
+---
+    release: coredaq-v4.5.3
+
+    type: coredaq
+
+    externals:
+        - name: boost
+          version: 1.77.0
+          variant: "+context+container cxxstd=2a"
+        - name: cetlib
+          version: 3.18.01
+          variant: "+lite"
+        - name: trace
+          version: 3.17.11
+          variant: ~
+        - name: nlohmann-json
+          version: 3.9.0
+          variant: ~
+        - name: pistache
+          version: dunedaq-v2.8.0
+          variant: ~
+        - name: highfive
+          version: 2.7.1
+          variant: "+mpi"
+        - name: hdf5
+          version: 1.12.0
+          variant: "+mpi+threadsafe"
+        - name: libarchive
+          version: 3.6.2
+          variant: ~
+        - name: libzmq
+          version: 4.3.4
+          variant: ~
+        - name: cppzmq
+          version: 4.8.1
+          variant: ~
+        - name: msgpack-c
+          version: 3.3.0
+          variant: ~
+        - name: py-pybind11
+          version: 2.6.2
+          variant: ~
+        - name: uhal
+          version: 2.8.1
+          variant: ~
+        - name: cpr
+          version: 1.5.2
+          variant: ~
+        - name: librdkafka
+          version: 1.7.0
+          variant: ~
+        - name: protobuf
+          version: 4.24.4
+          variant: ~
+        - name: grpc
+          version: 1.56.2
+          variant: "cxxstd=17"
+        - name: felix-software
+          version: dunedaq-v4.2.0
+          variant: ~
+        - name: folly
+          version: 2021.12.13.00
+          variant: "cxxstd=2a"
+        - name: fftw
+          version: 3.3.10
+          variant: "~mpi"
+        - name: cli11
+          version: 2.1.2
+          variant: ~
+        - name: krb5
+          version: 1.19.2
+          variant: ~
+        - name: intel-tbb
+          version: 2020.3
+          variant: ~
+        - name: dpdk
+          version: 22.11
+          variant: ~
+        - name: fmt
+          version: 8.1.1
+          variant: "cxxstd=17 shared=True"
+        - name: py-moo
+          version: 0.6.7
+          variant: ~
+        - name: py-anyconfig
+          version: 0.9.11
+          variant: ~
+        - name: py-jsonnet
+          version: 0.16.0
+          variant: ~
+        - name: py-fastjsonschema
+          version: 2.14.5
+          variant: ~
+        - name: rclone
+          version: 1.64.0
+          variant: ~
+        - name: libtorrent
+          version: 2.0.9
+          variant: ~
+
+    devtools:
+        - name: cmake
+          version: 3.26.3
+          variant: ~
+        - name: gdb
+          version: 13.1 
+          variant: "~python"
+        - name: ninja
+          version: 1.10.0
+          variant: ~
+
+    systems:
+        - name: python
+          version: 3.10.4
+          variant: ~
+        - name: gcc
+          version: 12.1.0
+          variant: "+binutils"
+        - name: openssh
+          version: 8.7p1
+          variant: ~
+
+    coredaq:
+        - name: daq-cmake
+          version: v2.7.1
+          commit: null
+        - name: ers
+          version: v1.5.1
+          commit: null
+        - name: logging
+          version: v1.1.3
+          commit: null
+        - name: cmdlib
+          version: v1.1.7
+          commit: null
+        - name: restcmd
+          version: v1.2.1
+          commit: null
+        - name: opmonlib
+          version: v1.3.6
+          commit: null
+        - name: rcif
+          version: v1.3.0
+          commit: null
+        - name: appfwk
+          version: v2.10.0
+          commit: null
+        - name: listrev
+          version: v3.4.0
+          commit: null
+        - name: utilities
+          version: v2.4.1
+          commit: null
+        - name: erskafka
+          version: v2.0.0
+          commit: null
+        - name: kafkaopmon
+          version: v1.5.1
+          commit: null
+        - name: ipm
+          version: v2.7.0
+          commit: null
+        - name: serialization
+          version: v1.3.1
+          commit: null
+        - name: iomanager
+          version: v1.5.0
+          commit: null
+        - name: dfmessages
+          version: v2.7.0
+          commit: null
+        - name: detdataformats
+          version: v4.0.0
+          commit: null
+        - name: trgdataformats
+          version: v1.2.3
+          commit: null
+        - name: detchannelmaps
+          version: v1.6.2
+          commit: null
+        - name: daqdataformats
+          version: v3.7.0
+          commit: null
+        - name: readoutlibs
+          version: v1.7.2
+          commit: null
+        - name: readoutmodules
+          version: v1.4.0
+          commit: null
+        - name: dfmodules
+          version: v2.14.2
+          commit: null
+        - name: hsilibs
+          version: v3.1.0
+          commit: null
+        - name: timing
+          version: v7.7.3
+          commit: null
+        - name: timinglibs
+          version: v4.0.3
+          commit: null
+        - name: daqconf
+          version: v7.3.4
+          commit: null
+        - name: trigger
+          version: v1.8.4
+          commit: null
+        - name: triggeralgs
+          version: v1.3.2
+          commit: null
+        - name: trgtools
+          version: v1.1.3
+          commit: null
+        - name: hdf5libs
+          version: v2.8.4
+          commit: null
+
+    others:
+        - name: daq-release
+          version: v2.5.4
+          commit: null
+        - name: daq-buildtools
+          version: v8.3.0
+          commit: null
+        - name: daqsystemtest
+          version: v2.3.4
+          commit: null
+        - name: justintime
+          version: v1.3.0
+          commit: null
+        - name: dqmtools
+          version: v0.4.0
+          commit: null
+        - name: pocket
+          version: "develop"
+          commit: null
+        - name: microservices
+          version: "develop"
+          commit: null
+        - name: dqm-backend
+          version: "develop"
+          commit: null
+        - name: grafana-dashboards
+          version: v1.13.0
+          commit: null

--- a/configs/fddaq/fddaq-v2.7.1/dbt-build-order.cmake
+++ b/configs/fddaq/fddaq-v2.7.1/dbt-build-order.cmake
@@ -1,0 +1,77 @@
+# "build_order" lists packages in the order you'd want CMake to see
+# them (via "add_subdirectory") during a simultaneous build. This is
+# due to their dependencies: e.g., you'd want CMake to see
+# daq-buildtools first in order to create daq-buildtoolsConfig.cmake
+# so "find_package(daq-builtools)" will work for all the other
+# packages, and so on. If a new package is introduced into the
+# development area, the developer is encouraged to add it to its
+# appropriate place in this list
+
+
+set(build_order "daq-cmake"
+                "ers"
+                "erskafka"
+                "logging"
+                "opmonlib"
+                "cmdlib"
+                "rcif"
+                "restcmd"
+                "utilities"
+                "ipm"
+                "serialization"
+                "iomanager"
+		"okssystem"
+		"oksdbinterfaces"
+		"oks"
+		"genconfig"
+		"oksutils"
+		"dal"
+		"coredal"
+                "appdal"
+		"oksconfig"
+		"dbe"
+                "appfwk"
+                "daphnemodules"
+		"hermesmodules"
+                "daqconf"
+                "fddaqconf"
+                "nddaqconf"
+                "listrev"
+                "detdataformats"
+		"trgdataformats"
+                "daqdataformats"
+                "detchannelmaps"
+                "dfmessages"
+                "triggeralgs"
+                "timing"
+                "timinglibs"
+                "hdf5libs"
+                "trgtools"
+                "readoutlibs"
+                "hsilibs"
+                "trigger"
+                "readoutmodules"
+                "dfmodules"
+                "kafkaopmon"
+		# FD packages
+                "fddetdataformats"
+                "fdreadoutlibs"
+                "fdreadoutmodules"
+                "tpgtools"
+                "flxlibs"
+                "dqm"
+                "wibmod"
+                "sspmodules"
+                "uhallibs"
+                "rawdatautils"
+                "ctbmodules"
+                "dpdklibs"
+		"snbmodules"
+		"daqsystemtest"
+		# ND packages
+                "nddetdataformats"
+                "ndreadoutlibs"
+                "ndreadoutmodules"
+                "lbrulibs"
+)
+

--- a/configs/fddaq/fddaq-v2.7.1/release.yaml
+++ b/configs/fddaq/fddaq-v2.7.1/release.yaml
@@ -1,0 +1,368 @@
+---
+    release: fddaq-v4.4.3
+
+    type: fddaq
+
+    base_release: coredaq-v4.5.3
+
+    fddaq:
+        - name: cibmodules
+          version: v1.0.0
+          commit: null
+        - name: ctbmodules
+          version: v2.3.0
+          commit: null
+        - name: daqsystemtest
+          version: v2.3.4
+          commit: null
+        - name: daphnemodules
+          version: v1.3.3
+          commit: null
+        - name: dpdklibs
+          version: v1.3.1
+          commit: null
+        - name: fddaqconf
+          version: v1.2.3
+          commit: null
+        - name: fddetdataformats
+          version: v1.2.1
+          commit: null
+        - name: fdreadoutlibs
+          version: v1.9.4
+          commit: null
+        - name: fdreadoutmodules
+          version: v1.0.2
+          commit: null
+        - name: flxlibs
+          version: v1.8.5
+          commit: null
+        - name: hermesmodules
+          version: v1.1.0
+          commit: null
+        - name: rawdatautils
+          version: v1.5.7
+          commit: null
+        - name: snbmodules
+          version: v1.0.1
+          commit: null
+        - name: sspmodules
+          version: v1.3.2
+          commit: null
+        - name: tpgtools
+          version: v1.1.1
+          commit: null
+        - name: uhallibs
+          version: v1.2.0
+          commit: null
+        - name: wibmod
+          version: v1.5.1
+          commit: null
+
+
+    pymodules:
+        - name: pip
+          version: 23.2.1
+          source:  pypi
+        - name: aniso8601
+          version: 9.0.1
+          source:  pypi
+        - name: anyconfig
+          version: 0.9.11
+          source:  pypi
+        - name: anyio
+          version: 3.6.2
+          source:  pypi
+        - name: anytree
+          version: 2.8.0
+          source:  pypi
+        - name: attrs
+          version: 22.2.0
+          source:  pypi
+        - name: bidict
+          version: 0.21.4
+          source:  pypi
+        - name: bitarray
+          version: 2.3.4
+          source:  pypi
+        - name: cachetools
+          version: 5.1.0
+          source:  pypi
+        - name: certifi
+          version: 2020.12.5
+          source:  pypi
+        - name: chardet
+          version: 3.0.4
+          source:  pypi
+        - name: click
+          version: 8.1.2
+          source:  pypi
+        - name: click-configfile
+          version: 0.2.3
+          source:  pypi
+        - name: click-didyoumean
+          version: 0.3.0
+          source:  pypi
+        - name: click-shell
+          version: 2.1
+          source:  pypi
+        - name: colorama
+          version: 0.4.4
+          source:  pypi
+        - name: commonmark
+          version: 0.9.1
+          source:  pypi
+        - name: configparser
+          version: 5.2.0
+          source:  pypi
+        - name: connectivityserver
+          version: 1.0.0
+          source:  github_DUNE-DAQ
+        - name: deepdiff
+          version: 6.3.1
+          source:  pypi
+        - name: docker
+          version: 5.0.3
+          source:  pypi
+        - name: daq-assettools
+          version: 1.1.0
+          source:  github_DUNE-DAQ
+        - name: elisa-client-api
+          version: 1.0.0
+          source:  github_DUNE-DAQ
+        - name: et-xmlfile
+          version: 1.0.1
+          source:  pypi
+        - name: fastjsonschema
+          version: 2.14.5
+          source:  pypi
+        - name: Flask
+          version: 2.1.1
+          source:  pypi
+        - name: Flask-Cors
+          version: 3.0.10
+          source:  pypi
+        - name: Flask-HTTPAuth
+          version: 4.6.0
+          source:  pypi
+        - name: Flask-RESTful
+          version: 0.3.9
+          source:  pypi
+        - name: future
+          version: 0.18.2
+          source:  pypi
+        - name: gevent
+          version: 22.10.2
+          source:  pypi
+        - name: gojsonnet
+          version: 0.20.0
+          source:  pypi
+        - name: google-auth
+          version: 2.6.6
+          source:  pypi
+        - name: graphviz
+          version: 0.16
+          source:  pypi
+        - name: greenlet
+          version: 2.0.2
+          source:  pypi
+        - name: gunicorn
+          version: 20.1.0
+          source:  pypi
+        - name: h11
+          version: 0.14.0
+          source:  pypi
+        - name: h5py
+          version: 3.7.0
+          source:  pypi
+        - name: httpcore
+          version: 0.16.3
+          source:  pypi
+        - name: httpx
+          version: 0.23.3
+          source:  pypi
+        - name: idna
+          version: "2.10"
+          source:  pypi
+        - name: importlib-metadata
+          version: 4.11.3
+          source:  pypi
+        - name: iniconfig
+          version: 1.1.1
+          source:  pypi
+        - name: integrationtest
+          version: 1.10.0
+          source:  github_DUNE-DAQ
+        - name: itsdangerous
+          version: 2.0.1
+          source:  pypi
+        - name: lxml
+          version: 5.1.0
+          source: pypi
+        - name: jdcal
+          version: 1.4.1
+          source:  pypi
+        - name: Jinja2
+          version: 3.1.1
+          source:  pypi
+        - name: jsonnet
+          version: 0.16.0
+          source:  pypi
+        - name: jsonpointer
+          version: "2.0"
+          source:  pypi
+        - name: jsonschema
+          version: 4.17.3
+          source:  pypi
+        - name: kafka-python
+          version: 2.0.2
+          source:  pypi
+        - name: kubernetes
+          version: 23.6.0
+          source:  pypi
+        - name: markdown-it-py
+          version: 2.2.0
+          source:  pypi
+        - name: MarkupSafe
+          version: 2.0.1
+          source:  pypi
+        - name: mdurl
+          version: 0.1.2
+          source:  pypi
+        - name: moo
+          version: 0.6.7
+          source:  github_brettviren
+        - name: nanoid
+          version: 2.0.0
+          source:  pypi
+        - name: nanorc
+          version: 5.2.5
+          source:  github_DUNE-DAQ
+        - name: networkx
+          version: 2.6.3
+          source:  pypi
+        - name: numpy
+          version: 1.24.0
+          source:  pypi
+        - name: oauthlib
+          version: 3.2.0
+          source:  pypi
+        - name: openpyxl
+          version: 3.1.2
+          source:  pypi
+        - name: ordered-set
+          version: 4.1.0
+          source:  pypi
+        - name: packaging
+          version: "21.0"
+          source:  pypi
+        - name: pexpect
+          version: 4.8.0
+          source:  pypi
+        - name: pluggy
+          version: 0.13.1
+          source:  pypi
+        - name: protobuf
+          version: 4.24.4
+          source:  pypi
+        - name: psutil
+          version: 5.9.0
+          source:  pypi
+        - name: ptyprocess
+          version: 0.7.0
+          source:  pypi
+        - name: py
+          version: 1.10.0
+          source:  pypi
+        - name: pyasn1
+          version: 0.4.8
+          source:  pypi
+        - name: pyasn1-modules
+          version: 0.2.8
+          source:  pypi
+        - name: pydot
+          version: 1.4.2
+          source:  pypi
+        - name: Pygments
+          version: 2.14.0
+          source:  pypi
+        - name: pyparsing
+          version: 2.4.7
+          source:  pypi
+        - name: pyrsistent
+          version: 0.17.3
+          source:  pypi
+        - name: PySocks
+          version: 1.7.1
+          source:  pypi
+        - name: pytest
+          version: 7.3.2
+          source:  pypi
+        - name: python-dateutil
+          version: 2.8.2
+          source:  pypi
+        - name: python-ipmi
+          version: 0.5.1
+          source:  pypi
+        - name: pytz
+          version: 2022.1
+          source:  pypi
+        - name: PyYAML
+          version: "6.0"
+          source:  pypi
+        - name: pyzmq
+          version: 22.3.0
+          source:  pypi
+        - name: requests
+          version: 2.25.0
+          source:  pypi
+        - name: requests-oauthlib
+          version: 1.3.1
+          source:  pypi
+        - name: rfc3986
+          version: 1.5.0
+          source:  pypi
+        - name: rich
+          version: 13.3.2
+          source:  pypi
+        - name: rsa
+          version: 4.8
+          source:  pypi
+        - name: sh
+          version: 1.14.1
+          source:  pypi
+        - name: six
+          version: 1.16.0
+          source:  pypi
+        - name: sniffio
+          version: 1.3.0
+          source:  pypi
+        - name: textual
+          version: 0.10.1
+          source:  pypi
+        - name: toml
+          version: 0.10.2
+          source:  pypi
+        - name: transitions
+          version: 0.8.10
+          source:  pypi
+        - name: urllib3
+          version: 1.26.5
+          source:  pypi
+        - name: websocket-client
+          version: 1.3.2
+          source:  pypi
+        - name: Werkzeug
+          version: 2.1.1
+          source:  pypi
+        - name: zipp
+          version: 3.8.0
+          source:  pypi
+        - name: zmq
+          version: 0.0.0
+          source:  pypi
+        - name: zope.event
+          version: 4.6
+          source:  pypi
+        - name: zope.interface
+          version: 5.5.2
+          source:  pypi


### PR DESCRIPTION
This PR modifies the candidate, frozen, and nightly build workflows to use `checkout-daq-package.py` to add all sourcecode packages to the `/cvmfs` release area as requested in Issue #375. The corresponding PR in `daq-buildtools` will implement the environment variable `DUNE_DAQ_RELEASE_SOURCE` that points to this area, e.g., 
```/cvmfs/dunedaq-development.opensciencegrid.org/nightly/NFDT_DEV_240624_A9/sourcecode``` 