### PR TITLE
Build Python packages from develop

### DIFF
--- a/configs/fddaq/fddaq-develop/release.yaml
+++ b/configs/fddaq/fddaq-develop/release.yaml
@@ -184,7 +184,7 @@
           version: 1.1.1
           source:  pypi
         - name: integrationtest
-          version: "develop"
+          version: develop
           source:  github_DUNE-DAQ
         - name: itsdangerous
           version: 2.0.1

--- a/configs/fddaq/fddaq-develop/release.yaml
+++ b/configs/fddaq/fddaq-develop/release.yaml
@@ -100,7 +100,7 @@
           version: 5.2.0
           source:  pypi
         - name: connectivityserver
-          version: 1.0.0
+          version: develop
           source:  github_DUNE-DAQ
         - name: deepdiff
           version: 6.3.1
@@ -109,16 +109,16 @@
           version: 5.0.3
           source:  pypi
         - name: daq-assettools
-          version: 1.1.0
+          version: develop
           source:  github_DUNE-DAQ
         - name: drunc
-          version: 0.10.6
+          version: develop
           source:  github_DUNE-DAQ
         - name: druncschema
-          version: 0.8.2
+          version: develop
           source:  github_DUNE-DAQ
         - name: elisa-client-api
-          version: 1.0.0
+          version: develop
           source:  github_DUNE-DAQ
         - name: et-xmlfile
           version: 1.0.1
@@ -229,7 +229,7 @@
           version: 2.0.0
           source:  pypi
         - name: nanorc
-          version: 5.2.0
+          version: develop
           source:  github_DUNE-DAQ
         - name: networkx
           version: 2.6.3

--- a/configs/fddaq/fddaq-develop/release.yaml
+++ b/configs/fddaq/fddaq-develop/release.yaml
@@ -223,7 +223,7 @@
           version: 0.1.2
           source:  pypi
         - name: moo
-          version: 0.6.7
+          version: develop
           source:  github_brettviren
         - name: nanoid
           version: 2.0.0

--- a/configs/fddaq/fddaq-develop/release.yaml
+++ b/configs/fddaq/fddaq-develop/release.yaml
@@ -184,7 +184,7 @@
           version: 1.1.1
           source:  pypi
         - name: integrationtest
-          version: 3.0.1
+          version: "develop"
           source:  github_DUNE-DAQ
         - name: itsdangerous
           version: 2.0.1

--- a/configs/fddaq/fddaq-develop/release.yaml
+++ b/configs/fddaq/fddaq-develop/release.yaml
@@ -223,7 +223,7 @@
           version: 0.1.2
           source:  pypi
         - name: moo
-          version: develop
+          version: 0.6.7
           source:  github_brettviren
         - name: nanoid
           version: 2.0.0

--- a/scripts/spack/make-release-repo.py
+++ b/scripts/spack/make-release-repo.py
@@ -9,7 +9,7 @@ import tempfile
 import re
 
 from dr_tools import parse_yaml_file
-from mappings import cmake_to_spack, pyvenv_url_names, packages_without_develop
+from mappings import cmake_to_spack, pyvenv_url_names
 
 class MyDumper(yaml.Dumper):
 

--- a/scripts/spack/make-release-repo.py
+++ b/scripts/spack/make-release-repo.py
@@ -306,6 +306,8 @@ class DAQRelease:
                         iline = f"git+https://github.com/{iuser}/elisa_client_api@v{iversion}#egg={iname}"
                     elif iname == "connectivityserver":
                         iline = f"git+https://github.com/{iuser}/{iname}@v{iversion}#egg=connection-service"
+                    elif iversion == "develop"
+                        iline = f"git+https://github.com/{iuser}/{iname}@{iversion}#egg={iname}"
                     else:
                         iline = f"git+https://github.com/{iuser}/{iname}@v{iversion}#egg={iname}"
                 f.write(iline + '\n')

--- a/scripts/spack/make-release-repo.py
+++ b/scripts/spack/make-release-repo.py
@@ -299,7 +299,6 @@ class DAQRelease:
                 if i["source"] == "pypi":
                     iline = f'{iname}=={iversion}'
                 if i["source"].startswith("github"):
-                    iline = f"git+https://github.com/"
                     iuser = i["source"].replace("github_", "")
                     if iname == "moo":
                         iline = f"git+https://github.com/{iuser}/{iname}@{iversion}#egg={iname}"

--- a/scripts/spack/make-release-repo.py
+++ b/scripts/spack/make-release-repo.py
@@ -9,7 +9,7 @@ import tempfile
 import re
 
 from dr_tools import parse_yaml_file
-from mappings import cmake_to_spack
+from mappings import cmake_to_spack, pyvenv_url_names
 
 class MyDumper(yaml.Dumper):
 
@@ -302,12 +302,14 @@ class DAQRelease:
                     iline = f'{iname}=={iversion}'
                 if i["source"].startswith("github"):
                     iuser = i["source"].replace("github_", "")
-                    if iname == "elisa-client-api":
-                        repo_name = "elisa_client_api"
-                    if iname == "connectivityserver":
-                        egg_name = "connection-service"
+                    # Special cases are handled using mappings.py
+                    repo_name = pyvenv_url_names.get(iname, {}).get("repo_name", iname)
+                    egg_name = pyvenv_url_names.get(iname, {}).get("egg_name", repo_name)
+                    # The main branch for moo is called master, not develop
+                    if iname == "moo" and iversion == "develop":
+                        iversion = pyvenv_url_names["moo"]["develop"]
 
-                    if iversion == "develop" or iname == "moo":
+                    if iversion == "develop":
                         iline = f"git+https://github.com/{iuser}/{repo_name}@{iversion}#egg={egg_name}"
                     else:
                         iline = f"git+https://github.com/{iuser}/{repo_name}@v{iversion}#egg={egg_name}"

--- a/scripts/spack/make-release-repo.py
+++ b/scripts/spack/make-release-repo.py
@@ -300,13 +300,11 @@ class DAQRelease:
                     iline = f'{iname}=={iversion}'
                 if i["source"].startswith("github"):
                     iuser = i["source"].replace("github_", "")
-                    # Special cases are handled using dictionaries in mappings.py
+                    # Special cases are handled using a dictionary in mappings.py
                     repo_name = pyvenv_url_names.get(iname, {}).get("repo_name", iname)
                     egg_name = pyvenv_url_names.get(iname, {}).get("egg_name", repo_name)
-                    if iname in packages_without_develop:
-                        iversion = packages_without_develop[iname]
 
-                    if iversion == "develop" or iversion in packages_without_develop.values():
+                    if iversion == "develop":
                         iline = f"git+https://github.com/{iuser}/{repo_name}@{iversion}#egg={egg_name}"
                     else:
                         iline = f"git+https://github.com/{iuser}/{repo_name}@v{iversion}#egg={egg_name}"

--- a/scripts/spack/make-release-repo.py
+++ b/scripts/spack/make-release-repo.py
@@ -304,7 +304,7 @@ class DAQRelease:
                     repo_name = pyvenv_url_names.get(iname, {}).get("repo_name", iname)
                     egg_name = pyvenv_url_names.get(iname, {}).get("egg_name", repo_name)
 
-                    if iversion == "develop":
+                    if iversion == "develop" or iname == "moo":
                         iline = f"git+https://github.com/{iuser}/{repo_name}@{iversion}#egg={egg_name}"
                     else:
                         iline = f"git+https://github.com/{iuser}/{repo_name}@v{iversion}#egg={egg_name}"

--- a/scripts/spack/make-release-repo.py
+++ b/scripts/spack/make-release-repo.py
@@ -296,20 +296,21 @@ class DAQRelease:
             for i in self.rdict['pymodules']:
                 iname = i["name"]
                 iversion = i["version"]
+                repo_name = iname
+                egg_name = iname
                 if i["source"] == "pypi":
                     iline = f'{iname}=={iversion}'
                 if i["source"].startswith("github"):
                     iuser = i["source"].replace("github_", "")
-                    if iname == "moo":
-                        iline = f"git+https://github.com/{iuser}/{iname}@{iversion}#egg={iname}"
-                    elif iname == "elisa-client-api":
-                        iline = f"git+https://github.com/{iuser}/elisa_client_api@v{iversion}#egg={iname}"
-                    elif iname == "connectivityserver":
-                        iline = f"git+https://github.com/{iuser}/{iname}@v{iversion}#egg=connection-service"
-                    elif iversion == "develop":
-                        iline = f"git+https://github.com/{iuser}/{iname}@{iversion}#egg={iname}"
+                    if iname == "elisa-client-api":
+                        repo_name = "elisa_client_api"
+                    if iname == "connectivityserver":
+                        egg_name = "connection-service"
+
+                    if iversion == "develop" or iname == "moo":
+                        iline = f"git+https://github.com/{iuser}/{repo_name}@{iversion}#egg={egg_name}"
                     else:
-                        iline = f"git+https://github.com/{iuser}/{iname}@v{iversion}#egg={iname}"
+                        iline = f"git+https://github.com/{iuser}/{repo_name}@v{iversion}#egg={egg_name}"
                 f.write(iline + '\n')
         return
 

--- a/scripts/spack/make-release-repo.py
+++ b/scripts/spack/make-release-repo.py
@@ -306,7 +306,7 @@ class DAQRelease:
                         iline = f"git+https://github.com/{iuser}/elisa_client_api@v{iversion}#egg={iname}"
                     elif iname == "connectivityserver":
                         iline = f"git+https://github.com/{iuser}/{iname}@v{iversion}#egg=connection-service"
-                    elif iversion == "develop"
+                    elif iversion == "develop":
                         iline = f"git+https://github.com/{iuser}/{iname}@{iversion}#egg={iname}"
                     else:
                         iline = f"git+https://github.com/{iuser}/{iname}@v{iversion}#egg={iname}"

--- a/scripts/spack/mappings.py
+++ b/scripts/spack/mappings.py
@@ -17,5 +17,8 @@ cmake_to_spack = {
 pyvenv_url_names = {
     "elisa-client-api": {"repo_name": "elisa_client_api"},
     "connectivityserver": {"egg_name": "connection-service"},
-    "moo": {"develop": "master"}
+}
+
+packages_without_develop = {
+    "moo": "master",
 }

--- a/scripts/spack/mappings.py
+++ b/scripts/spack/mappings.py
@@ -18,7 +18,3 @@ pyvenv_url_names = {
     "elisa-client-api": {"repo_name": "elisa_client_api"},
     "connectivityserver": {"egg_name": "connection-service"},
 }
-
-packages_without_develop = {
-    "moo": "master",
-}

--- a/scripts/spack/mappings.py
+++ b/scripts/spack/mappings.py
@@ -13,3 +13,9 @@ cmake_to_spack = {
     'pkgconfig': 'pkgconf',
     'tbb': 'intel-tbb',
 }
+
+pyvenv_url_names = {
+    "elisa-client-api": {"repo_name": "elisa_client_api"},
+    "connectivityserver": {"egg_name": "connection-service"},
+    "moo": {"develop": "master"}
+}


### PR DESCRIPTION
Addresses #388. The test nightly `NFDT2_DEV_240925_A9` was built using this PR. To summarize:
- Python packages in `configs/fddaq/fddaq-develop/release.yaml` which used a GitHub URL as the source have had their versions switched to `develop`
- Special cases are handled using a dictionary in `mappings.py`, similar to how we handle automated dependency inference in `generate_depends_on_list`