### PR TITLE
Add `daqsystemtest` tests to v5 integtests

### DIFF
--- a/.github/workflows/nightly-v5-integtest.yml
+++ b/.github/workflows/nightly-v5-integtest.yml
@@ -32,7 +32,13 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-            test_name: ["listrev", "minimal_system_quick"]
+            test_name: ["listrev", 
+                        "minimal_system_quick", 
+                        "3ru_1df_multirun", 
+                        "example_system", 
+                        "long_window_readout", 
+                        "small_footprint_quick", 
+                        "tpstream_writing"]
     defaults:
       run:
         shell: bash

--- a/.github/workflows/nightly-v5-integtest.yml
+++ b/.github/workflows/nightly-v5-integtest.yml
@@ -56,7 +56,7 @@ jobs:
         else
           TEST_PATH=$DAQSYSTEMTEST_SHARE/integtest
         fi
-        pytest -v -s --junit-xml=${{ matrix.test_name }}_test_results.xml 
+        pytest -v -s --junit-xml=${{ matrix.test_name }}_test_results.xml \
                 $TEST_PATH/${{ matrix.test_name }}_test.py
 
   parse_results:

--- a/.github/workflows/nightly-v5-integtest.yml
+++ b/.github/workflows/nightly-v5-integtest.yml
@@ -55,6 +55,7 @@ jobs:
           TEST_PATH=$LISTREV_SHARE/integtest
         else
           TEST_PATH=$DAQSYSTEMTEST_SHARE/integtest
+          export DUNEDAQ_DB_PATH=$DAQSYSTEMTEST_SHARE:$DUNEDAQ_DB_PATH
         fi
         pytest -v -s --junit-xml=${{ matrix.test_name }}_test_results.xml \
                 $TEST_PATH/${{ matrix.test_name }}_test.py

--- a/.github/workflows/nightly-v5-integtest.yml
+++ b/.github/workflows/nightly-v5-integtest.yml
@@ -32,34 +32,32 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-            test_name: ["listrev"]
+            test_name: ["listrev", "minimal_system_quick"]
     defaults:
       run:
         shell: bash
 
     steps:
-
-    - name: Checkout listrev
-      uses: actions/checkout@v4
-      with:
-        repository: DUNE-DAQ/listrev
-        ref: develop
-        path: listrev
-    
     - name: setup release and run tests
       env:
         NIGHTLY_TAG: ${{needs.make_nightly_tag.outputs.tag}}
       run: |
-          DET=fd
-          mkdir -p $GITHUB_WORKSPACE/integration_tests_$NIGHTLY_TAG
-          cd $GITHUB_WORKSPACE/integration_tests_$NIGHTLY_TAG
-          source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
-          setup_dbt latest_v5
-          [[ -e /cvmfs/dunedaq-development.opensciencegrid.org/nightly/$NIGHTLY_TAG/daq_app_rte.sh ]]
-          dbt-setup-release -n $NIGHTLY_TAG
-          export DBT_INSTALL_DIR=/cvmfs/dunedaq-development.opensciencegrid.org/nightly/$NIGHTLY_TAG
-          pytest -v -s --junit-xml=${{ matrix.test_name }}_test_results.xml \
-                 $LISTREV_SHARE/integtest/listrev_test.py
+        DET=fd
+        mkdir -p $GITHUB_WORKSPACE/integration_tests_$NIGHTLY_TAG
+        cd $GITHUB_WORKSPACE/integration_tests_$NIGHTLY_TAG
+        source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
+        setup_dbt latest_v5
+        [[ -e /cvmfs/dunedaq-development.opensciencegrid.org/nightly/$NIGHTLY_TAG/daq_app_rte.sh ]]
+        dbt-setup-release -n $NIGHTLY_TAG
+        export DBT_INSTALL_DIR=/cvmfs/dunedaq-development.opensciencegrid.org/nightly/$NIGHTLY_TAG
+        TEST_PATH=""
+        if [[ "${{ matrix.test_name }}" == "listrev" ]]; then
+          TEST_PATH=$LISTREV_SHARE/integtest
+        else
+          TEST_PATH=$DAQSYSTEMTEST_SHARE/integtest
+        fi
+        pytest -v -s --junit-xml=${{ matrix.test_name }}_test_results.xml 
+                $TEST_PATH/${{ matrix.test_name }}_test.py
 
   parse_results:
     runs-on: daq

--- a/spack-repos/fddaq-repo-template/packages/daqsystemtest/package.py
+++ b/spack-repos/fddaq-repo-template/packages/daqsystemtest/package.py
@@ -30,5 +30,6 @@ class Daqsystemtest(CMakePackage):
     def setup_run_environment(self, env):
         env.set(self.__module__.split(".")[-1].upper().replace("-", "_") + "_SHARE", self.prefix + "/share" )
         env.prepend_path('DUNEDAQ_SHARE_PATH', self.prefix + "/share")
+        env.prepend_path('DUNEDAQ_DB_PATH', self.prefix + "/share")
         env.prepend_path('PYTHONPATH', self.prefix.lib + "64/python")
 


### PR DESCRIPTION
Adds the integration tests from `daqsystemtest` to the nightly v5 integration tests. The results of a test run can be found [here](https://github.com/DUNE-DAQ/daq-release/actions/runs/11076327895). 