### PR TITLE
Slack webhook integration

### DIFF
--- a/.github/workflows/nightly-v5-integtest.yml
+++ b/.github/workflows/nightly-v5-integtest.yml
@@ -112,17 +112,25 @@ jobs:
         # For posting a rich message using Block Kit
         payload: |
           {
-            "text": "!!!GitHub Action Failure!!!",
             "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": :rotating_light: "GitHub Action Failed: ${{ github.workflow }} :rotating_light:",
+                  "emoji": true
+                }
+              },
               {
                 "type": "section",
                 "text": {
                   "type": "mrkdwn",
-                  "text": "The GitHub Action ${{ github.workflow }} has failed! For more information, see ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  "text": "The GitHub Action *${{ github.workflow }}* failed for commit `${{ github.sha }}` in repository *${{ github.repository }}*.\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View GitHub Actions output>"
                 }
               }
             ]
           }
+
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_INCOMING_WEBHOOK_URL }}
         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/nightly-v5-integtest.yml
+++ b/.github/workflows/nightly-v5-integtest.yml
@@ -43,7 +43,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: DUNE-DAQ/listrev
-        ref: develop
+        ref: amogan/intentional_integtest_failure
         path: listrev
     
     - name: setup release and run tests
@@ -104,15 +104,24 @@ jobs:
     name: send slack message
     needs: integration_tests
     steps:
-    - name: Send JSON data to Slack workflow
+    - name: Send custom JSON data to Slack workflow
       id: slack
-      uses: slackapi/slack-github-action@v1.26.0
+      uses: slackapi/slack-github-action@v1.27.0
       with:
-        # Variables used by the Slack workflow
+        # For posting a rich message using Block Kit
         payload: |
           {
-            "workflow_name": "${{ github.workflow }}",
-            "workflow_url":  "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            "text": "!!!GitHub Action Failure!!!",
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "The GitHub Action ${{ github.workflow }} has failed! For more information, see ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                }
+              }
+            ]
           }
       env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_INCOMING_WEBHOOK_URL }}
+        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/nightly-v5-integtest.yml
+++ b/.github/workflows/nightly-v5-integtest.yml
@@ -59,8 +59,9 @@ jobs:
           dbt-setup-release -n $NIGHTLY_TAG
           export DBT_INSTALL_DIR=/cvmfs/dunedaq-development.opensciencegrid.org/nightly/$NIGHTLY_TAG
           pytest -v -s --junit-xml=${{ matrix.test_name }}_test_results.xml \
-                 $LISTREV_SHARE/integtest/listrev_test.py
+                 /home/nfs/amogan/listrev_intentional_failure/sourcecode/listrev/integtest/listrev_test.py
 
+  #$LISTREV_SHARE/integtest/listrev_test.py
   parse_results:
     runs-on: daq
     if: always()

--- a/.github/workflows/nightly-v5-integtest.yml
+++ b/.github/workflows/nightly-v5-integtest.yml
@@ -122,10 +122,13 @@ jobs:
                 }
               },
               {
+                "type": "divider"
+              },
+              {
                 "type": "section",
                 "text": {
                   "type": "mrkdwn",
-                  "text": "The GitHub Action *${{ github.workflow }}* failed for commit `${{ github.sha }}` in repository *${{ github.repository }}*.\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View GitHub Actions output>"
+                  "text": " For more information, see the full output <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
                 }
               }
             ]

--- a/.github/workflows/nightly-v5-integtest.yml
+++ b/.github/workflows/nightly-v5-integtest.yml
@@ -117,7 +117,7 @@ jobs:
                 "type": "header",
                 "text": {
                   "type": "plain_text",
-                  "text": :rotating_light: "GitHub Action Failed: ${{ github.workflow }} :rotating_light:",
+                  "text": ":rotating_light: GitHub Action Failed: ${{ github.workflow }} :rotating_light:",
                   "emoji": true
                 }
               },

--- a/.github/workflows/nightly-v5-integtest.yml
+++ b/.github/workflows/nightly-v5-integtest.yml
@@ -117,7 +117,7 @@ jobs:
                 "type": "header",
                 "text": {
                   "type": "plain_text",
-                  "text": ":rotating_light: GitHub Action Failed: ${{ github.workflow }} :rotating_light:",
+                  "text": ":rotating_light: Failed: ${{ github.workflow }} :rotating_light:",
                   "emoji": true
                 }
               },

--- a/.github/workflows/nightly-v5-integtest.yml
+++ b/.github/workflows/nightly-v5-integtest.yml
@@ -128,7 +128,7 @@ jobs:
                 "type": "section",
                 "text": {
                   "type": "mrkdwn",
-                  "text": " For more information, see the full output <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
+                  "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Full report>"
                 }
               }
             ]

--- a/.github/workflows/nightly-v5-integtest.yml
+++ b/.github/workflows/nightly-v5-integtest.yml
@@ -140,5 +140,5 @@ jobs:
           }
 
       env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_INCOMING_WEBHOOK_URL }}
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
This PR adds a step to the nightly v5 build and integration tests that posts a Slack message to the channel `daq-release-notifications' if a workflow fails. This has been successfully tested in the private channel `gha-webhook-test` (now defunct). 