### PR TITLE
JCF: take advantage of the fact that we now have separate scripts for…

### DIFF
--- a/scripts/spack/build-release-v4.sh
+++ b/scripts/spack/build-release-v4.sh
@@ -96,26 +96,7 @@ if [[ $retval != 0 ]]; then
     exit 20
 fi
 
-build_dbe=false
-if [[ $DET == "core" ]]; then
-    spack spec -l --reuse dbe%gcc@12.1.0 build_type=RelWithDebInfo arch=linux-${OS}-x86_64 > $SPACK_AREA/spec_dbe_log.txt 2>&1
-    retval=$?    
-
-    cat $SPACK_AREA/spec_dbe_log.txt
-
-    if [[ $retval == 0 ]]; then
-	build_dbe=true
-    else
-	build_dbe=false
-        echo "Building dbe does not appear to be possible. As this is not (necessarily) an error, will continue..."
-    fi
-fi
-
 spack install --reuse ${DET}daq@${RELEASE_TAG}%gcc@12.1.0 build_type=RelWithDebInfo arch=linux-${OS}-x86_64 || exit 7
-
-if $build_dbe; then
-    spack install --reuse dbe%gcc@12.1.0 build_type=RelWithDebInfo arch=linux-${OS}-x86_64 || exit 8
-fi
 
 if [[ "$DET" == "fd" || "$DET" == "nd" ]]; then
     # Generate pyvenv_requirements.txt

--- a/scripts/spack/build-release.sh
+++ b/scripts/spack/build-release.sh
@@ -107,7 +107,8 @@ if [[ $DET == "core" ]]; then
 	build_dbe=true
     else
 	build_dbe=false
-        echo "Building dbe does not appear to be possible. As this is not (necessarily) an error, will continue..."
+        echo "Building dbe does not appear to be possible. Will exit..."
+	exit 12
     fi
 fi
 


### PR DESCRIPTION
… v4 and v5 builds by dropping all dbe-related logic from build-release-v4.sh