### PR TITLE
Add nightly dbt workflow

### DIFF
--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run_dbt_commands:
-    name: run_dbt
+    name: Run dbt test script
     runs-on: daq
     defaults:
       run:
@@ -38,7 +38,7 @@ jobs:
         run: |
           echo "Am in $(pwd)"
           echo "$(ls)"
-          rm -rf daq-release
+          rm -rf daq-release-dbt-tests
 
   send_slack_message:
     if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -16,13 +16,12 @@ jobs:
         shell: bash
 
     steps:
-    - name: Checkout daq-release
-      uses: actions/checkout@v4
-      with:
-        path: daq-release
-
     - name: Run dbt test script
       run: | 
+        echo "Am in $(pwd)"
+        echo "ls: $(ls)"
+        echo "ls daq-release: $(ls daq-release)"
+        echo "ls daq-release again: $(ls daq-release/daq-release)"
         cd daq-release/scripts || exit 1
         ./test_daq-buildtools.sh
 

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -14,7 +14,6 @@ jobs:
     defaults:
       run:
         shell: bash
-
     steps:
     - name: Run dbt test script
       run: | 
@@ -23,6 +22,7 @@ jobs:
         echo "ls daq-release: $(ls daq-release)"
         echo "ls daq-release again: $(ls daq-release/daq-release)"
         cd daq-release/scripts || exit 1
+        git pull origin develop
         ./test_daq-buildtools.sh
 
   #$LISTREV_SHARE/integtest/listrev_test.py

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -15,14 +15,17 @@ jobs:
       run:
         shell: bash
     steps:
+    - name: Checkout daq-release
+      uses: actions/checkout@v4
+      with:
+        path: daq-release-dbt-tests
     - name: Run dbt test script
       run: | 
         echo "Am in $(pwd)"
         echo "ls: $(ls)"
         echo "ls daq-release: $(ls daq-release)"
         echo "ls daq-release again: $(ls daq-release/daq-release)"
-        cd daq-release/scripts || exit 1
-        git pull origin develop
+        cd daq-release-dbt-tests/scripts || exit 1
         ./test_daq-buildtools.sh
 
   #$LISTREV_SHARE/integtest/listrev_test.py

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -1,57 +1,42 @@
-name: Nightly v5 integration tests
+name: Nightly dbt regression tests
 
 on:
   workflow_dispatch:
+    inputs:
+      send-slack-message:
+        description: 'whether to send a message to #daq-release-notifications on failure'
+        default: 'no'
 
 jobs:
-  make_nightly_tag:
-    name: create nightly tag
-    runs-on: ubuntu-latest
-    outputs:
-      tag: ${{ steps.create_nightly_tag.outputs.nightly_tag }} 
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - id: create_nightly_tag
-        run: |
-          date_tag=$(date +%y%m%d)
-          echo "nightly_tag=NFD_DEV_${date_tag}_A9"  >>  "$GITHUB_OUTPUT"
-          cat "$GITHUB_OUTPUT"
-
   run_dbt_commands:
     name: run_dbt
     runs-on: daq
-    needs: make_nightly_tag
-    env:
-      NIGHTLY_TAG: ${{needs.make_nightly_tag.outputs.tag}}
-      TEST_DIR: ${{ github.workspace }}/dbt_tests_${{needs.make_nightly_tag.outputs.tag}}
     defaults:
       run:
         shell: bash
 
     steps:
-    - name: Setup test area
-      run: |
-        DET=fd
-        mkdir -p ${{ env.TEST_DIR }}
-        cd ${{ env.TEST_DIR }}
-        source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
-        setup_dbt latest_v5
-        [[ -e /cvmfs/dunedaq-development.opensciencegrid.org/nightly/$NIGHTLY_TAG/daq_app_rte.sh ]]
+    - name: Checkout daq-release
+      uses: actions/checkout@v4
+      with:
+        path: daq-release
+
+    - name: Run dbt test script
+      run: | 
+        cd daq-release/scripts || exit 1
+        ./test_daq-buildtools.sh
 
   #$LISTREV_SHARE/integtest/listrev_test.py
   cleanup_test_area:
     runs-on: daq
     if: always()
-    needs: [make_nightly_tag, run_dbt_commands]
-    env:
-      NIGHTLY_TAG: ${{needs.make_nightly_tag.outputs.tag}}
-      TEST_DIR: ${{ github.workspace }}/dbt_tests_${{needs.make_nightly_tag.outputs.tag}}
+    needs: run_dbt_commands
     steps:
       - name: Remove test directory
         run: |
-          rm -rf ${{ env.TEST_DIR }}
+          echo "Am in $(pwd)"
+          echo "$(ls)"
+          rm -rf daq-release
 
   send_slack_message:
     if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -21,11 +21,7 @@ jobs:
         path: daq-release-dbt-tests
     - name: Run dbt test script
       run: | 
-        echo "Am in $(pwd)"
-        echo "ls: $(ls)"
-        echo "ls daq-release: $(ls daq-release)"
-        echo "ls daq-release again: $(ls daq-release/daq-release)"
-        cd daq-release-dbt-tests/scripts || exit 1
+        cd daq-release-dbt-tests/scripts
         ./test_daq-buildtools.sh
 
   #$LISTREV_SHARE/integtest/listrev_test.py
@@ -36,8 +32,6 @@ jobs:
     steps:
       - name: Remove test directory
         run: |
-          echo "Am in $(pwd)"
-          echo "$(ls)"
           rm -rf daq-release-dbt-tests
 
   send_slack_message:

--- a/scripts/test_daq-buildtools.sh
+++ b/scripts/test_daq-buildtools.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+repo=appfwk
+
+. /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh || exit 1
+setup_dbt latest_v5 || exit 2
+
+newdir=$( mktemp -d )
+
+mkdir -p $newdir
+cd $newdir
+dbt-create -n last_fddaq || exit 3
+cd $( ls )  # Only thing in the directory will be the work area
+cd sourcecode
+git clone https://github.com/DUNE-DAQ/$repo || exit 4
+cd ..
+. env.sh || exit 5
+dbt-build || exit 6
+dbt-build --lint || exit 7
+dbt-build --unittest || exit 8
+
+cd sourcecode
+dbt-clang-format.sh $repo --view-differences-only || exit 9
+
+rm -rf $newdir
+
+exit 0

--- a/scripts/test_daq-buildtools.sh
+++ b/scripts/test_daq-buildtools.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-repo=appfwk
+repo=ipm
 
 . /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh || exit 1
 setup_dbt latest_v5 || exit 2
@@ -9,18 +9,48 @@ newdir=$( mktemp -d )
 
 mkdir -p $newdir
 cd $newdir
-dbt-create -n last_fddaq || exit 3
+
+echo "*********************************TEST dbt-setup-release *******************************"
+# Check that dbt-setup-release works without altering the environment, thus the (...)
+(dbt-setup-release -n last_fddaq; echo $? > $newdir/dbt-setup-release_result.txt)
+
+test -e $newdir/dbt-setup-release_result.txt || exit 3
+test $( cat $newdir/dbt-setup-release_result.txt ) == 0 || exit 4
+rm -f dbt-setup-release_result.txt
+
+echo "*********************************TEST dbt-create ***************************************"
+dbt-create -s -n last_fddaq || exit 5
 cd $( ls )  # Only thing in the directory will be the work area
 cd sourcecode
-git clone https://github.com/DUNE-DAQ/$repo || exit 4
+git clone https://github.com/DUNE-DAQ/$repo || exit 6
 cd ..
-. env.sh || exit 5
-dbt-build || exit 6
-dbt-build --lint || exit 7
-dbt-build --unittest || exit 8
+. env.sh || exit 7
 
-cd sourcecode
-dbt-clang-format.sh $repo --view-differences-only || exit 9
+echo "**********************************TEST dbt-build ****************************************"
+dbt-build || exit 8
+
+echo "******************************TEST dbt-build --lint *************************************"
+dbt-build --lint || exit 9
+
+echo "******************************TEST dbt-build --unittest *********************************"
+dbt-build --unittest || exit 10
+
+echo "******************************TEST dbt-clang-format.sh **********************************"
+cd $DBT_AREA_ROOT/sourcecode
+dbt-clang-format.sh $repo --view-differences-only || exit 11
+
+# Test building against a sourcecode directory outside of the work area
+echo "***********************TEST dbt-build with external sourcecode **************************"
+cd ..
+mv sourcecode $newdir
+ln -s $newdir/sourcecode
+dbt-build --clean || exit 12
+
+echo "*****************************TEST dbt-build --codegen **********************************"
+dbt-build --codegen || exit 13
+
+echo "********************TEST local workarea Spack package installation **********************"
+spack install py-wesanderson || exit 14
 
 rm -rf $newdir
 


### PR DESCRIPTION
Addresses #400. Runs the new `test_daq-buildtools.sh` script on `daq.fnal.gov` using the "real" CVMFS as seen by users, as opposed to running in a nightly container. Successful test output [here](https://github.com/DUNE-DAQ/daq-release/actions/runs/11561571105). 