### PR TITLE
Add Slack message logic for success vs. failure

### DIFF
--- a/.github/workflows/build-nightly-release-alma9.yml
+++ b/.github/workflows/build-nightly-release-alma9.yml
@@ -280,9 +280,10 @@ jobs:
 
   send_slack_message:
     if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')
-    needs: [make_nightly_tag, build_the_develop_release_spack, update_image, generate_dbt_setup_release_env, publish_to_cvmfs]
+    needs: [generate_dbt_setup_release_env, publish_to_cvmfs]
     uses: ./.github/workflows/slack-notification.yml
     with:
-      workflow_success: ${{ needs.make_nightly_tag.result == 'success' && needs.build_the_develop_release_spack.result == 'success' && needs.update_image.result == 'success' && needs.generate_dbt_setup_release_env.result == 'success' && needs.publish_to_cvmfs.result != 'failure'}}
+      # cvmfs != failure logic accounts for the fact that the publish step is optional and might be skipped
+      workflow_success: ${{ needs.generate_dbt_setup_release_env.result == 'success' && needs.publish_to_cvmfs.result != 'failure'}}
     secrets: 
       slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}

--- a/.github/workflows/build-nightly-release-alma9.yml
+++ b/.github/workflows/build-nightly-release-alma9.yml
@@ -280,10 +280,10 @@ jobs:
 
   send_slack_message:
     if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')
-    needs: [generate_dbt_setup_release_env, publish_to_cvmfs]
+    needs: publish_to_cvmfs
     uses: ./.github/workflows/slack-notification.yml
     with:
       # cvmfs != failure logic accounts for the fact that the publish step is optional and might be skipped
-      workflow_success: ${{ needs.generate_dbt_setup_release_env.result == 'success' && needs.publish_to_cvmfs.result != 'failure'}}
+      workflow_success: ${{ needs.publish_to_cvmfs.result == 'success' }}
     secrets: 
       slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}

--- a/.github/workflows/build-nightly-release-alma9.yml
+++ b/.github/workflows/build-nightly-release-alma9.yml
@@ -283,14 +283,14 @@ jobs:
     if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')
     runs-on: daq
     name: send slack message
-    needs: publish_to_cvmfs
+    needs: [build_the_develop_release_spack, update_image, generate_dbt_setup_release_env, publish_to_cvmfs]
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TEST_WEBHOOK }}
       SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
     steps:
     - name: Send failure message to Slack
       uses: slackapi/slack-github-action@v1.27.0
-      if: needs.publish_to_cvmfs.result == 'failure'
+      if: needs.build_the_develop_release_spack.result == 'failure' || needs.update_image.result == 'failre' || needs.generate_dbt_setup_release_env.result == 'failure' || needs.publish_to_cvmfs.result == 'failure'
       with:
         # For posting a rich message using Block Kit
         payload: |

--- a/.github/workflows/build-nightly-release-alma9.yml
+++ b/.github/workflows/build-nightly-release-alma9.yml
@@ -286,4 +286,4 @@ jobs:
       # cvmfs != failure logic accounts for the fact that the publish step is optional and might be skipped
       workflow_success: ${{ needs.publish_to_cvmfs.result == 'success' }}
     secrets: 
-      slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/build-nightly-release-alma9.yml
+++ b/.github/workflows/build-nightly-release-alma9.yml
@@ -55,6 +55,7 @@ jobs:
       env:
         NIGHTLY_TAG: ${{needs.make_nightly_tag.outputs.tag}}
       run: |
+          exit 1
           export BASE_RELEASE_DIR=/cvmfs/dunedaq-development.opensciencegrid.org/nightly/NB${NIGHTLY_TAG}
           export DET_RELEASE_DIR=/cvmfs/dunedaq-development.opensciencegrid.org/nightly/NFD${NIGHTLY_TAG}
           export OS=almalinux9

--- a/.github/workflows/build-nightly-release-alma9.yml
+++ b/.github/workflows/build-nightly-release-alma9.yml
@@ -283,10 +283,13 @@ jobs:
     runs-on: daq
     name: send slack message
     needs: publish_to_cvmfs
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
     steps:
-    - name: Send JSON data to Slack workflow
-      id: slack
+    - name: Send failure message to Slack
       uses: slackapi/slack-github-action@v1.27.0
+      if: needs.publish_to_cvmfs.result == 'failure'
       with:
         # For posting a rich message using Block Kit
         payload: |
@@ -309,7 +312,28 @@ jobs:
               }
             ]
           }
-
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+    - name: Send success message to Slack
+      uses: slackapi/slack-github-action@v1.27.0
+      if: needs.publish_to_cvmfs.result == 'success'
+      with:
+        # For posting a rich message using Block Kit
+        payload: |
+          {
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": ":white_check_mark: Success: ${{ github.workflow }} :white_check_mark:",
+                  "emoji": true
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "Full report: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|link>."
+                }
+              }
+            ]
+          }

--- a/.github/workflows/build-nightly-release-alma9.yml
+++ b/.github/workflows/build-nightly-release-alma9.yml
@@ -280,60 +280,9 @@ jobs:
 
   send_slack_message:
     if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')
-    runs-on: daq
-    name: send slack message
-    needs: [build_the_develop_release_spack, update_image, generate_dbt_setup_release_env, publish_to_cvmfs]
-    env:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TEST_WEBHOOK }}
-      SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-    steps:
-    - name: Send failure message to Slack
-      uses: slackapi/slack-github-action@v1.27.0
-      if: needs.build_the_develop_release_spack.result == 'failure' || needs.update_image.result == 'failre' || needs.generate_dbt_setup_release_env.result == 'failure' || needs.publish_to_cvmfs.result == 'failure'
-      with:
-        # For posting a rich message using Block Kit
-        payload: |
-          {
-            "blocks": [
-              {
-                "type": "header",
-                "text": {
-                  "type": "plain_text",
-                  "text": ":rotating_light: Failed: ${{ github.workflow }} :rotating_light:",
-                  "emoji": true
-                }
-              },
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "Full report: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|link>."
-                }
-              }
-            ]
-          }
-    - name: Send success message to Slack
-      uses: slackapi/slack-github-action@v1.27.0
-      if: (github.event.inputs.cvmfs-deployment == 'yes' && needs.publish_to_cvmfs.result == 'success') || (github.event.inputs.cvmfs-deployment == 'no' && needs.generate_dbt_setup_release_env == 'success')
-      with:
-        # For posting a rich message using Block Kit
-        payload: |
-          {
-            "blocks": [
-              {
-                "type": "header",
-                "text": {
-                  "type": "plain_text",
-                  "text": ":white_check_mark: Success: ${{ github.workflow }} :white_check_mark:",
-                  "emoji": true
-                }
-              },
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "Full report: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|link>."
-                }
-              }
-            ]
-          }
+    needs: [make_nightly_tag, build_the_develop_release_spack, update_image, generate_dbt_setup_release_env, publish_to_cvmfs]
+    uses: ./.github/workflows/slack-notification.yml
+    with:
+      workflow_success: ${{ needs.make_nightly_tag.result == 'success' && needs.build_the_develop_release_spack.result == 'success' && needs.update_image.result == 'success' && needs.generate_dbt_setup_release_env.result == 'success' && needs.publish_to_cvmfs.result != 'failure'}}
+    secrets: 
+      slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}

--- a/.github/workflows/build-nightly-release-alma9.yml
+++ b/.github/workflows/build-nightly-release-alma9.yml
@@ -55,7 +55,6 @@ jobs:
       env:
         NIGHTLY_TAG: ${{needs.make_nightly_tag.outputs.tag}}
       run: |
-          exit 1
           export BASE_RELEASE_DIR=/cvmfs/dunedaq-development.opensciencegrid.org/nightly/NB${NIGHTLY_TAG}
           export DET_RELEASE_DIR=/cvmfs/dunedaq-development.opensciencegrid.org/nightly/NFD${NIGHTLY_TAG}
           export OS=almalinux9

--- a/.github/workflows/build-nightly-release-alma9.yml
+++ b/.github/workflows/build-nightly-release-alma9.yml
@@ -16,7 +16,7 @@ on:
         description: 'whether to deploy the release to cvmfs'
         default: 'no'
       send-slack-message:
-        description: 'whether to send a message to #daq-release-notifications on failure'
+        description: 'whether to send a message to #daq-release-notifications on completion'
         default: 'no'
 
 jobs:

--- a/.github/workflows/build-nightly-release-alma9.yml
+++ b/.github/workflows/build-nightly-release-alma9.yml
@@ -314,7 +314,7 @@ jobs:
           }
     - name: Send success message to Slack
       uses: slackapi/slack-github-action@v1.27.0
-      if: needs.publish_to_cvmfs.result == 'success'
+      if: (github.event.inputs.cvmfs-deployment == 'yes' && needs.publish_to_cvmfs.result == 'success') || (github.event.inputs.cvmfs-deployment == 'no' && needs.generate_dbt_setup_release_env == 'success')
       with:
         # For posting a rich message using Block Kit
         payload: |

--- a/.github/workflows/build-nightly-release-alma9.yml
+++ b/.github/workflows/build-nightly-release-alma9.yml
@@ -55,6 +55,7 @@ jobs:
       env:
         NIGHTLY_TAG: ${{needs.make_nightly_tag.outputs.tag}}
       run: |
+          exit 1
           export BASE_RELEASE_DIR=/cvmfs/dunedaq-development.opensciencegrid.org/nightly/NB${NIGHTLY_TAG}
           export DET_RELEASE_DIR=/cvmfs/dunedaq-development.opensciencegrid.org/nightly/NFD${NIGHTLY_TAG}
           export OS=almalinux9
@@ -284,7 +285,7 @@ jobs:
     name: send slack message
     needs: publish_to_cvmfs
     env:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TEST_WEBHOOK }}
       SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
     steps:
     - name: Send failure message to Slack

--- a/.github/workflows/build-v4-release-alma9.yml
+++ b/.github/workflows/build-v4-release-alma9.yml
@@ -285,4 +285,4 @@ jobs:
       # cvmfs != failure logic accounts for the fact that the publish step is optional and might be skipped
       workflow_success: ${{ needs.publish_to_cvmfs.result == 'success' }}
     secrets: 
-      slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/build-v4-release-alma9.yml
+++ b/.github/workflows/build-v4-release-alma9.yml
@@ -13,7 +13,7 @@ on:
         description: 'whether to deploy the release to cvmfs'
         default: 'no'
       send-slack-message:
-        description: 'whether to send a message to #daq-release-notifications on failure'
+        description: 'whether to send a message to #daq-release-notifications on completion'
         default: 'no'
 
 jobs:

--- a/.github/workflows/build-v4-release-alma9.yml
+++ b/.github/workflows/build-v4-release-alma9.yml
@@ -278,14 +278,17 @@ jobs:
         rm -rf $unique_name
 
   send_slack_message:
-    if: failure() || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')
+    if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')
     runs-on: daq
     name: send slack message
     needs: publish_to_cvmfs
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
     steps:
-    - name: Send JSON data to Slack workflow
-      id: slack
+    - name: Send failure message to Slack
       uses: slackapi/slack-github-action@v1.27.0
+      if: needs.publish_to_cvmfs.result == 'failure'
       with:
         # For posting a rich message using Block Kit
         payload: |
@@ -308,7 +311,28 @@ jobs:
               }
             ]
           }
-
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+    - name: Send success message to Slack
+      uses: slackapi/slack-github-action@v1.27.0
+      if: needs.publish_to_cvmfs.result == 'success'
+      with:
+        # For posting a rich message using Block Kit
+        payload: |
+          {
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": ":white_check_mark: Success: ${{ github.workflow }} :white_check_mark:",
+                  "emoji": true
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "Full report: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|link>."
+                }
+              }
+            ]
+          }

--- a/.github/workflows/build-v4-release-alma9.yml
+++ b/.github/workflows/build-v4-release-alma9.yml
@@ -279,60 +279,10 @@ jobs:
 
   send_slack_message:
     if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')
-    runs-on: daq
-    name: send slack message
     needs: publish_to_cvmfs
-    env:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-    steps:
-    - name: Send failure message to Slack
-      uses: slackapi/slack-github-action@v1.27.0
-      if: needs.publish_to_cvmfs.result == 'failure'
-      with:
-        # For posting a rich message using Block Kit
-        payload: |
-          {
-            "blocks": [
-              {
-                "type": "header",
-                "text": {
-                  "type": "plain_text",
-                  "text": ":rotating_light: Failed: ${{ github.workflow }} :rotating_light:",
-                  "emoji": true
-                }
-              },
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "Full report: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|link>."
-                }
-              }
-            ]
-          }
-    - name: Send success message to Slack
-      uses: slackapi/slack-github-action@v1.27.0
-      if: needs.publish_to_cvmfs.result == 'success'
-      with:
-        # For posting a rich message using Block Kit
-        payload: |
-          {
-            "blocks": [
-              {
-                "type": "header",
-                "text": {
-                  "type": "plain_text",
-                  "text": ":white_check_mark: Success: ${{ github.workflow }} :white_check_mark:",
-                  "emoji": true
-                }
-              },
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "Full report: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|link>."
-                }
-              }
-            ]
-          }
+    uses: ./.github/workflows/slack-notification.yml
+    with:
+      # cvmfs != failure logic accounts for the fact that the publish step is optional and might be skipped
+      workflow_success: ${{ needs.publish_to_cvmfs.result == 'success' }}
+    secrets: 
+      slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -43,4 +43,4 @@ jobs:
     - name: send slack message
       uses: ./.github/workflows/slack-notification.yml
       with:
-        slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+        slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -29,19 +29,9 @@ jobs:
     if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')
     runs-on: ubuntu-latest
     needs: run_dbt_commands
-    steps:
-    - name: Checkout daq-release
-      uses: actions/checkout@v4
-      with:
-        ref: amogan/slack_success_message
-    - name: Print statements
-      run: |
-        echo "Am in $(pwd)"
-        ls .github/workflows
-    - name: send slack message
-      uses: ./.github/workflows/slack-notification.yml@amogan/slack_success_message
-      with:
-        slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
+    uses: DUNE-DAQ/daq-release/.github/workflows/slack-notification.yml@amogan/slack_success_message
+    secrets:
+      slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
 
   cleanup_test_area:
     runs-on: daq

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -40,6 +40,9 @@ jobs:
     runs-on: daq
     name: send slack message
     needs: run_dbt_commands
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TEST_WEBHOOK }}
+      SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
     steps:
     - name: Send failure message to Slack
       uses: slackapi/slack-github-action@v1.27.0
@@ -91,7 +94,3 @@ jobs:
               }
             ]
           }
-
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TEST_WEBHOOK }}
-        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -21,6 +21,7 @@ jobs:
         path: daq-release-dbt-tests
     - name: Run dbt test script
       run: | 
+        exit 1
         cd daq-release-dbt-tests/scripts
         ./test_daq-buildtools.sh
 

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -26,10 +26,9 @@ jobs:
         ./test_daq-buildtools.sh
 
   send_slack_message:
-    if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')
-    runs-on: ubuntu-latest
-    needs: run_dbt_commands
     uses: ./.github/workflows/slack-notification.yml
+    secrets: 
+      slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
 
   cleanup_test_area:
     runs-on: daq

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -71,7 +71,7 @@ jobs:
           }
     - name: Send success message to Slack
       uses: slackapi/slack-github-action@v1.27.0
-      if: success()
+      if: needs.run_dbt_commands.result == 'success'
       with:
         # For posting a rich message using Block Kit
         payload: |

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -39,7 +39,7 @@ jobs:
         echo "Am in $(pwd)"
         ls
     - name: send slack message
-      uses: slack-notification.yml
+      uses: ./.github/workflows/slack-notification.yml
       with:
         slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
 

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Print statements
       run: |
         echo "Am in $(pwd)"
-        ls
+        ls .github/workflows
     - name: send slack message
       uses: ./.github/workflows/slack-notification.yml
       with:

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -39,7 +39,7 @@ jobs:
         echo "Am in $(pwd)"
         ls
     - name: send slack message
-      uses: .github/workflows/slack-notification.yml
+      uses: slack-notification.yml
       with:
         slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
 

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       send-slack-message:
-        description: 'whether to send a message to #daq-release-notifications on failure'
+        description: 'whether to send a message to #daq-release-notifications on completion'
         default: 'no'
 
 jobs:

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -31,7 +31,7 @@ jobs:
     with:
       workflow_success: ${{ needs.run_dbt_commands.result == 'success' }}
     secrets: 
-      slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   cleanup_test_area:
     runs-on: daq

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -19,7 +19,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: daq-release-dbt-tests
-        ref: amogan/slack_success_message
     - name: Run dbt test script
       run: | 
         exit 1
@@ -28,7 +27,7 @@ jobs:
 
   send_slack_message:
     if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')
-    runs-on: ubuntu-latest
+    runs-on: daq
     needs: run_dbt_commands
     steps:
     - name: send slack message

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -40,9 +40,9 @@ jobs:
     name: send slack message
     needs: run_dbt_commands
     steps:
-    - name: Send custom JSON data to Slack workflow
-      id: slack
+    - name: Send failure message to Slack
       uses: slackapi/slack-github-action@v1.27.0
+      if: failure() 
       with:
         # For posting a rich message using Block Kit
         payload: |
@@ -65,7 +65,32 @@ jobs:
               }
             ]
           }
+    - name: Send success message to Slack
+      uses: slackapi/slack-github-action@v1.27.0
+      if: success()
+      with:
+        # For posting a rich message using Block Kit
+        payload: |
+          {
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": ":white_check_mark: Success: ${{ github.workflow }} :white_check_mark:",
+                  "emoji": true
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "Full report: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|link>."
+                }
+              }
+            ]
+          }
 
       env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TEST_WEBHOOK }}
         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -30,7 +30,7 @@ jobs:
     needs: run_dbt_commands
     uses: ./.github/workflows/slack-notification.yml
     with:
-      workflow_success: ${{ needs.run_dbt_commands.result }} == 'success'
+      workflow_success: ${{ needs.run_dbt_commands.result == 'success' }}
     secrets: 
       slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
 

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
     - name: Send failure message to Slack
       uses: slackapi/slack-github-action@v1.27.0
-      if: failure() 
+      if: needs.run_dbt_commands.result == 'failure'
       with:
         # For posting a rich message using Block Kit
         payload: |

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -26,7 +26,11 @@ jobs:
         ./test_daq-buildtools.sh
 
   send_slack_message:
+    if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')
+    needs: run_dbt_commands
     uses: ./.github/workflows/slack-notification.yml
+    with:
+      result: 
     secrets: 
       slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
 

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -21,7 +21,6 @@ jobs:
         path: daq-release-dbt-tests
     - name: Run dbt test script
       run: | 
-        exit 1
         cd daq-release-dbt-tests/scripts
         ./test_daq-buildtools.sh
 

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -29,9 +29,7 @@ jobs:
     if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')
     runs-on: ubuntu-latest
     needs: run_dbt_commands
-    uses: DUNE-DAQ/daq-release/.github/workflows/slack-notification.yml@amogan/slack_success_message
-    secrets:
-      slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
+    uses: ./.github/workflows/slack-notification.yml
 
   cleanup_test_area:
     runs-on: daq

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -39,7 +39,7 @@ jobs:
         echo "Am in $(pwd)"
         ls .github/workflows
     - name: send slack message
-      uses: ./.github/workflows/slack-notification.yml
+      uses: ./.github/workflows/slack-notification.yml@amogan/slack_success_message
       with:
         slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
 

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -27,11 +27,19 @@ jobs:
 
   send_slack_message:
     if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')
-    runs-on: daq
+    runs-on: ubuntu-latest
     needs: run_dbt_commands
     steps:
+    - name: Checkout daq-release
+      uses: actions/checkout@v4
+      with:
+        ref: amogan/slack_success_message
+    - name: Print statements
+      run: |
+        echo "Am in $(pwd)"
+        ls
     - name: send slack message
-      uses: daq-release-dbt-tests/.github/workflows/slack-notification.yml@amogan/slack_success_message
+      uses: .github/workflows/slack-notification.yml
       with:
         slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
 

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -29,8 +29,6 @@ jobs:
     if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')
     needs: run_dbt_commands
     uses: ./.github/workflows/slack-notification.yml
-    with:
-      result: 
     secrets: 
       slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
 

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -19,13 +19,23 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: daq-release-dbt-tests
+        ref: amogan/slack_success_message
     - name: Run dbt test script
       run: | 
         exit 1
         cd daq-release-dbt-tests/scripts
         ./test_daq-buildtools.sh
 
-  #$LISTREV_SHARE/integtest/listrev_test.py
+  send_slack_message:
+    if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')
+    runs-on: ubuntu-latest
+    needs: run_dbt_commands
+    steps:
+    - name: send slack message
+      uses: daq-release-dbt-tests/.github/workflows/slack-notification.yml
+      with:
+        slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
+
   cleanup_test_area:
     runs-on: daq
     if: always()
@@ -34,13 +44,3 @@ jobs:
       - name: Remove test directory
         run: |
           rm -rf daq-release-dbt-tests
-
-  send_slack_message:
-    if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')
-    runs-on: ubuntu-latest
-    needs: run_dbt_commands
-    steps:
-    - name: send slack message
-      uses: ./.github/workflows/slack-notification.yml
-      with:
-        slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -31,7 +31,7 @@ jobs:
     needs: run_dbt_commands
     steps:
     - name: send slack message
-      uses: daq-release-dbt-tests/.github/workflows/slack-notification.yml
+      uses: daq-release-dbt-tests/.github/workflows/slack-notification.yml@amogan/slack_success_message
       with:
         slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
 

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -29,6 +29,8 @@ jobs:
     if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')
     needs: run_dbt_commands
     uses: ./.github/workflows/slack-notification.yml
+    with:
+      workflow_success: ${{ needs.run_dbt_commands.result }} == 'success'
     secrets: 
       slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
 

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -21,6 +21,7 @@ jobs:
         path: daq-release-dbt-tests
     - name: Run dbt test script
       run: | 
+        exit 1
         cd daq-release-dbt-tests/scripts
         ./test_daq-buildtools.sh
 
@@ -36,60 +37,10 @@ jobs:
 
   send_slack_message:
     if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')
-    runs-on: daq
-    name: send slack message
+    runs-on: ubuntu-latest
     needs: run_dbt_commands
-    env:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TEST_WEBHOOK }}
-      SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
     steps:
-    - name: Send failure message to Slack
-      uses: slackapi/slack-github-action@v1.27.0
-      if: needs.run_dbt_commands.result == 'failure'
+    - name: send slack message
+      uses: ./.github/workflows/slack-notification.yml
       with:
-        # For posting a rich message using Block Kit
-        payload: |
-          {
-            "blocks": [
-              {
-                "type": "header",
-                "text": {
-                  "type": "plain_text",
-                  "text": ":rotating_light: Failed: ${{ github.workflow }} :rotating_light:",
-                  "emoji": true
-                }
-              },
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "Full report: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|link>."
-                }
-              }
-            ]
-          }
-    - name: Send success message to Slack
-      uses: slackapi/slack-github-action@v1.27.0
-      if: needs.run_dbt_commands.result == 'success'
-      with:
-        # For posting a rich message using Block Kit
-        payload: |
-          {
-            "blocks": [
-              {
-                "type": "header",
-                "text": {
-                  "type": "plain_text",
-                  "text": ":white_check_mark: Success: ${{ github.workflow }} :white_check_mark:",
-                  "emoji": true
-                }
-              },
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "Full report: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|link>."
-                }
-              }
-            ]
-          }
+        slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/nightly-v4-integtest.yml
+++ b/.github/workflows/nightly-v4-integtest.yml
@@ -112,7 +112,6 @@ jobs:
     needs: integration_tests
     uses: ./.github/workflows/slack-notification.yml
     with:
-      # cvmfs != failure logic accounts for the fact that the publish step is optional and might be skipped
       workflow_success: ${{ needs.integration_tests.result == 'success' }}
     secrets: 
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/nightly-v4-integtest.yml
+++ b/.github/workflows/nightly-v4-integtest.yml
@@ -109,60 +109,10 @@ jobs:
 
   send_slack_message:
     if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')
-    runs-on: daq
-    name: send slack message
     needs: integration_tests
-    env:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-    steps:
-    - name: Send failure message to Slack
-      uses: slackapi/slack-github-action@v1.27.0
-      if: needs.integration_tests.result == 'failure'
-      with:
-        # For posting a rich message using Block Kit
-        payload: |
-          {
-            "blocks": [
-              {
-                "type": "header",
-                "text": {
-                  "type": "plain_text",
-                  "text": ":rotating_light: Failed: ${{ github.workflow }} :rotating_light:",
-                  "emoji": true
-                }
-              },
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "Full report: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|link>."
-                }
-              }
-            ]
-          }
-    - name: Send success message to Slack
-      uses: slackapi/slack-github-action@v1.27.0
-      if: needs.integration_tests.result == 'success'
-      with:
-        # For posting a rich message using Block Kit
-        payload: |
-          {
-            "blocks": [
-              {
-                "type": "header",
-                "text": {
-                  "type": "plain_text",
-                  "text": ":white_check_mark: Success: ${{ github.workflow }} :white_check_mark:",
-                  "emoji": true
-                }
-              },
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "Full report: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|link>."
-                }
-              }
-            ]
-          }
+    uses: ./.github/workflows/slack-notification.yml
+    with:
+      # cvmfs != failure logic accounts for the fact that the publish step is optional and might be skipped
+      workflow_success: ${{ needs.integration_tests.result == 'success' }}
+    secrets: 
+      slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}

--- a/.github/workflows/nightly-v4-integtest.yml
+++ b/.github/workflows/nightly-v4-integtest.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       send-slack-message:
-        description: 'whether to send a message to #daq-release-notifications on failure'
+        description: 'whether to send a message to #daq-release-notifications on completion'
         default: 'no'
 
 

--- a/.github/workflows/nightly-v4-integtest.yml
+++ b/.github/workflows/nightly-v4-integtest.yml
@@ -115,4 +115,4 @@ jobs:
       # cvmfs != failure logic accounts for the fact that the publish step is optional and might be skipped
       workflow_success: ${{ needs.integration_tests.result == 'success' }}
     secrets: 
-      slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/nightly-v4-integtest.yml
+++ b/.github/workflows/nightly-v4-integtest.yml
@@ -108,14 +108,17 @@ jobs:
           /home/nfs/dunedaq/kill_stale_gunicorn_processes.sh
 
   send_slack_message:
-    if: failure() || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')
+    if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')
     runs-on: daq
     name: send slack message
     needs: integration_tests
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
     steps:
-    - name: Send JSON data to Slack workflow
-      id: slack
+    - name: Send failure message to Slack
       uses: slackapi/slack-github-action@v1.27.0
+      if: needs.integration_tests.result == 'failure'
       with:
         # For posting a rich message using Block Kit
         payload: |
@@ -138,7 +141,28 @@ jobs:
               }
             ]
           }
-
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+    - name: Send success message to Slack
+      uses: slackapi/slack-github-action@v1.27.0
+      if: needs.integration_tests.result == 'success'
+      with:
+        # For posting a rich message using Block Kit
+        payload: |
+          {
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": ":white_check_mark: Success: ${{ github.workflow }} :white_check_mark:",
+                  "emoji": true
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "Full report: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|link>."
+                }
+              }
+            ]
+          }

--- a/.github/workflows/nightly-v5-integtest.yml
+++ b/.github/workflows/nightly-v5-integtest.yml
@@ -113,60 +113,10 @@ jobs:
 
   send_slack_message:
     if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')
-    runs-on: daq
-    name: send slack message
     needs: integration_tests
-    env:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-    steps:
-    - name: Send failure message to Slack
-      uses: slackapi/slack-github-action@v1.27.0
-      if: needs.integration_tests.result == 'failure'
-      with:
-        # For posting a rich message using Block Kit
-        payload: |
-          {
-            "blocks": [
-              {
-                "type": "header",
-                "text": {
-                  "type": "plain_text",
-                  "text": ":rotating_light: Failed: ${{ github.workflow }} :rotating_light:",
-                  "emoji": true
-                }
-              },
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "Full report: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|link>."
-                }
-              }
-            ]
-          }
-    - name: Send success message to Slack
-      uses: slackapi/slack-github-action@v1.27.0
-      if: needs.integration_tests.result == 'success'
-      with:
-        # For posting a rich message using Block Kit
-        payload: |
-          {
-            "blocks": [
-              {
-                "type": "header",
-                "text": {
-                  "type": "plain_text",
-                  "text": ":white_check_mark: Success: ${{ github.workflow }} :white_check_mark:",
-                  "emoji": true
-                }
-              },
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "Full report: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|link>."
-                }
-              }
-            ]
-          }
+    uses: ./.github/workflows/slack-notification.yml
+    with:
+      # cvmfs != failure logic accounts for the fact that the publish step is optional and might be skipped
+      workflow_success: ${{ needs.integration_tests.result == 'success' }}
+    secrets: 
+      slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}

--- a/.github/workflows/nightly-v5-integtest.yml
+++ b/.github/workflows/nightly-v5-integtest.yml
@@ -119,4 +119,4 @@ jobs:
       # cvmfs != failure logic accounts for the fact that the publish step is optional and might be skipped
       workflow_success: ${{ needs.integration_tests.result == 'success' }}
     secrets: 
-      slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/nightly-v5-integtest.yml
+++ b/.github/workflows/nightly-v5-integtest.yml
@@ -116,7 +116,6 @@ jobs:
     needs: integration_tests
     uses: ./.github/workflows/slack-notification.yml
     with:
-      # cvmfs != failure logic accounts for the fact that the publish step is optional and might be skipped
       workflow_success: ${{ needs.integration_tests.result == 'success' }}
     secrets: 
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/nightly-v5-integtest.yml
+++ b/.github/workflows/nightly-v5-integtest.yml
@@ -116,10 +116,13 @@ jobs:
     runs-on: daq
     name: send slack message
     needs: integration_tests
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
     steps:
-    - name: Send custom JSON data to Slack workflow
-      id: slack
+    - name: Send failure message to Slack
       uses: slackapi/slack-github-action@v1.27.0
+      if: needs.integration_tests.result == 'failure'
       with:
         # For posting a rich message using Block Kit
         payload: |
@@ -142,7 +145,28 @@ jobs:
               }
             ]
           }
-
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+    - name: Send success message to Slack
+      uses: slackapi/slack-github-action@v1.27.0
+      if: needs.integration_tests.result == 'success'
+      with:
+        # For posting a rich message using Block Kit
+        payload: |
+          {
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": ":white_check_mark: Success: ${{ github.workflow }} :white_check_mark:",
+                  "emoji": true
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "Full report: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|link>."
+                }
+              }
+            ]
+          }

--- a/.github/workflows/nightly-v5-integtest.yml
+++ b/.github/workflows/nightly-v5-integtest.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       send-slack-message:
-        description: 'whether to send a message to #daq-release-notifications on failure'
+        description: 'whether to send a message to #daq-release-notifications on completion'
         default: 'no'
 
 

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -1,0 +1,68 @@
+# .github/workflows/slack-notification.yml
+name: Slack Notification
+
+on:
+  workflow_call:
+    inputs:
+      slack_webhook_url:
+        required: true
+        type: string
+
+jobs:
+  notify:
+    name: Send Slack Notification
+    runs-on: ubuntu-latest
+    env:
+      SLACK_WEBHOOK_URL: ${{ inputs.slack_webhook_url }}
+      SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+    steps:
+    - name: Send failure message to Slack
+      uses: slackapi/slack-github-action@v1.27.0
+      if: ${{ failure() }}
+      with:
+        # For posting a rich message using Block Kit
+        payload: |
+          {
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": ":rotating_light: Failed: ${{ github.workflow }} :rotating_light:",
+                  "emoji": true
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "Full report: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|link>."
+                }
+              }
+            ]
+          }
+    - name: Send success message to Slack
+      uses: slackapi/slack-github-action@v1.27.0
+      if: ${{ success() }}
+      with:
+        # For posting a rich message using Block Kit
+        payload: |
+          {
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": ":white_check_mark: Success: ${{ github.workflow }} :white_check_mark:",
+                  "emoji": true
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "Full report: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|link>."
+                }
+              }
+            ]
+          }

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -2,13 +2,16 @@ name: Slack Notification
 
 on:
   workflow_call:
+    inputs:
+      workflow_success: 
+        required: true
+        type: boolean
     secrets:
       slack_webhook_url:
         required: true
 
 jobs:
   notify:
-    if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')
     name: Send Slack Notification
     runs-on: ubuntu-latest
     env:
@@ -17,7 +20,7 @@ jobs:
     steps:
     - name: Send failure message to Slack
       uses: slackapi/slack-github-action@v1.27.0
-      if: failure()
+      if: ${{ ! inputs.workflow_success }}
       with:
         # For posting a rich message using Block Kit
         payload: |
@@ -42,7 +45,7 @@ jobs:
           }
     - name: Send success message to Slack
       uses: slackapi/slack-github-action@v1.27.0
-      if: success()
+      if: ${{ inputs.workflow_success }}
       with:
         payload: |
           {

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -2,17 +2,16 @@ name: Slack Notification
 
 on:
   workflow_call:
-    inputs:
+    secrets:
       slack_webhook_url:
         required: true
-        type: string
 
 jobs:
   notify:
     name: Send Slack Notification
     runs-on: ubuntu-latest
     env:
-      SLACK_WEBHOOK_URL: ${{ inputs.slack_webhook_url }}
+      SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_url }}
       SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
     steps:
     - name: Send failure message to Slack

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -1,4 +1,3 @@
-# .github/workflows/slack-notification.yml
 name: Slack Notification
 
 on:
@@ -18,7 +17,7 @@ jobs:
     steps:
     - name: Send failure message to Slack
       uses: slackapi/slack-github-action@v1.27.0
-      if: ${{ failure() }}
+      if: failure()
       with:
         # For posting a rich message using Block Kit
         payload: |
@@ -43,9 +42,8 @@ jobs:
           }
     - name: Send success message to Slack
       uses: slackapi/slack-github-action@v1.27.0
-      if: ${{ success() }}
+      if: success()
       with:
-        # For posting a rich message using Block Kit
         payload: |
           {
             "blocks": [

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   notify:
+    if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')
     name: Send Slack Notification
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
Addresses #403. This turned into a good opportunity to reduce repeated code in the workflows that send Slack messages, since they were previously 90% copy-pasted from each other, and some had already fallen out of sync. 

To address this, I looked into [reusable workflows](https://docs.github.com/en/actions/sharing-automations/reusing-workflows) and factorized the repeated Slack message job into the reusable `slack-notification.yml`. Each workflow that wants to send a Slack message only needs to provide a `workflow_success` condition which determines whether it sends a success or failure message. I tested this with intentional failures to the nightly builds, integration tests, and the new `dbt` workflow. It's always possible that I missed a corner case, but everything seems to behave as expected. At the very least, the workflows no longer always report a failure. 

The success and failure messages are shown in the screenshot below for test nightly workflows. 

<img width="435" alt="Screenshot 2024-10-29 at 5 38 25 PM" src="https://github.com/user-attachments/assets/e4ed898f-5574-48e7-82c6-3d8da50a093b">
