### PR TITLE
Checkout feature branch (if provided) to DUNE_DAQ_RELEASE_SOURCE

### DIFF
--- a/.github/workflows/build-nightly-release-alma9.yml
+++ b/.github/workflows/build-nightly-release-alma9.yml
@@ -60,7 +60,7 @@ jobs:
           export OS=almalinux9
           source daq-release/.github/workflows/wf-setup-tools.sh
 
-          daq-release/scripts/checkout-daq-package.py -i daq-release/configs/coredaq/coredaq-develop/release.yaml -a -o $DET_RELEASE_DIR/sourcecode
+          daq-release/scripts/checkout-daq-package.py -i daq-release/configs/coredaq/coredaq-develop/release.yaml -a -o $DET_RELEASE_DIR/sourcecode -b ${{ github.event.inputs.feature-branch }}
           daq-release/scripts/spack/build-release.sh $BASE_RELEASE_DIR $DET_RELEASE_DIR core $OS ${{ github.event.inputs.feature-branch }}
 
           cd $BASE_RELEASE_DIR/../
@@ -81,7 +81,7 @@ jobs:
           export OS=almalinux9
           source daq-release/.github/workflows/wf-setup-tools.sh
 
-          daq-release/scripts/checkout-daq-package.py -i daq-release/configs/fddaq/fddaq-develop/release.yaml -a -o $DET_RELEASE_DIR/sourcecode
+          daq-release/scripts/checkout-daq-package.py -i daq-release/configs/fddaq/fddaq-develop/release.yaml -a -o $DET_RELEASE_DIR/sourcecode -b ${{ github.event.inputs.feature-branch }}
           daq-release/scripts/spack/build-release.sh $BASE_RELEASE_DIR $DET_RELEASE_DIR fd $OS ${{ github.event.inputs.feature-branch }}
 
           cd $DET_RELEASE_DIR/../


### PR DESCRIPTION
Addresses #408. I ran a test nightly, tagged as `NFDT_DEV_241111_A9`, in which I had it check out the branch `amogan/test_feature_branch_for_dunedaq_release_source` where it existed. In this case, that branch only exists in `daqconf` and all it does is add some extra, blank lines to `CMakeLists.txt`. I created a local area based on `NFDT_DEV_241111_A9` and compared the CMakeLists found in `$DUNE_DAQ_RELEASE_SOURCE/daqconf/` with the one on the `develop` branch and found that the feature branch changes were correctly stored in `DUNE_DAQ_RELEASE_SOURCE`. 