### PR TITLE
Add nightly code check workflow

### DIFF
--- a/.github/workflows/nightly-clang-format.yml
+++ b/.github/workflows/nightly-clang-format.yml
@@ -92,7 +92,6 @@ jobs:
         source env.sh
         cd sourcecode
         dbt-clang-format.sh . --view-differences-only --markdown-summary
-        echo "# Clang-Format Report" > $GITHUB_STEP_SUMMARY
         cat clang_format_summary_table.md >> $GITHUB_STEP_SUMMARY
 
   send_slack_message:

--- a/.github/workflows/nightly-clang-format.yml
+++ b/.github/workflows/nightly-clang-format.yml
@@ -59,7 +59,7 @@ jobs:
         dbt-workarea-env
         spack load dbe
         dbt-build --unittest
-        dbt-clang-format.sh . --view-differences-only --output-markdown-file
+        dbt-clang-format.sh . --view-differences-only --markdown-summary
         echo "### Clang-Format Report" > $GITHUB_STEP_SUMMARY
         cat clang_format_summary_table.md >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/nightly-clang-format.yml
+++ b/.github/workflows/nightly-clang-format.yml
@@ -83,8 +83,10 @@ jobs:
             fi
             if [[ "$(echo "$line" | grep -o SUCCESS)" == "SUCCESS" ]]; then
                 markdown_content+="| $test_name | :white_check_mark: Passed |\n"
-            else
+            elif [[ "$(echo "$line" | grep -o FAILURE)" == "FAILURE" ]]; then
                 markdown_content+="| $test_name | :x: Failed |\n"
+            else
+                markdown_content+=":construction: Unit tests have not been written for $this_package"
             fi
         done < "$log_summary_file"
         echo -e "$markdown_content" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/nightly-clang-format.yml
+++ b/.github/workflows/nightly-clang-format.yml
@@ -52,10 +52,10 @@ jobs:
         cd ${{ needs.make_nightly_tag.outputs.tag }}
         source env.sh
         cd ../daq-release-unittests/scripts
-        #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -p fdreadoutlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -p fdreadoutlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
     - name: Run unit tests
       run: |

--- a/.github/workflows/nightly-clang-format.yml
+++ b/.github/workflows/nightly-clang-format.yml
@@ -86,7 +86,7 @@ jobs:
             elif [[ "$(echo "$line" | grep -o FAILURE)" == "FAILURE" ]]; then
                 markdown_content+="| $test_name | :x: Failed |\n"
             else
-                markdown_content+=":construction: Unit tests have not been written for $this_package"
+                markdown_content+=":construction: Unit tests have not been written for $this_package\n"
             fi
         done < "$log_summary_file"
         echo -e "$markdown_content" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/nightly-clang-format.yml
+++ b/.github/workflows/nightly-clang-format.yml
@@ -52,13 +52,13 @@ jobs:
         cd ${{ needs.make_nightly_tag.outputs.tag }}
         source env.sh
         cd ../daq-release-unittests/scripts
-        ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -p fdreadoutlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -p flxlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -p fdreadoutlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -p flxlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
     - name: Run unit tests
       run: |

--- a/.github/workflows/nightly-clang-format.yml
+++ b/.github/workflows/nightly-clang-format.yml
@@ -55,7 +55,7 @@ jobs:
         #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        echo "$DBT_AREA_ROOT" >> "$GITHUB_ENV"
+        echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
     - name: Run unit tests
       run: |
         cd $DBT_AREA_ROOT/

--- a/.github/workflows/nightly-clang-format.yml
+++ b/.github/workflows/nightly-clang-format.yml
@@ -54,8 +54,11 @@ jobs:
         cd ../daq-release-unittests/scripts
         ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         #./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         #./checkout-daq-package.py -p fdreadoutlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -p flxlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
     - name: Run unit tests
       run: |

--- a/.github/workflows/nightly-clang-format.yml
+++ b/.github/workflows/nightly-clang-format.yml
@@ -63,10 +63,6 @@ jobs:
         echo "### Clang-Format Report" > $GITHUB_STEP_SUMMARY
         cat clang_format_summary_table.md >> $GITHUB_STEP_SUMMARY
 
-    - name: Report Formatting Results
-      if: always()
-      run: |
-
   send_slack_message:
     if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')
     needs: run_unittests
@@ -84,4 +80,5 @@ jobs:
       - name: Remove test directory
         run: |
           rm -rf daq-release-unittests
+          rm -rf daq-buildtools-markdown-feature
           rm -rf ${{ needs.make_nightly_tag.outputs.tag }}

--- a/.github/workflows/nightly-clang-format.yml
+++ b/.github/workflows/nightly-clang-format.yml
@@ -55,7 +55,7 @@ jobs:
         #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${dbt_area_root}/sourcecode
-        ./checkout-daq-package.py -p fdreadoutlibs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${dbt_area_root}/sourcecode
+        ./checkout-daq-package.py -p fdreadoutlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${dbt_area_root}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
     - name: Run unit tests
       run: |

--- a/.github/workflows/nightly-clang-format.yml
+++ b/.github/workflows/nightly-clang-format.yml
@@ -54,7 +54,8 @@ jobs:
         cd ../daq-release-unittests/scripts
         #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${dbt_area_root}/sourcecode
+        ./checkout-daq-package.py -p fdreadoutlibs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${dbt_area_root}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
     - name: Run unit tests
       run: |

--- a/.github/workflows/nightly-clang-format.yml
+++ b/.github/workflows/nightly-clang-format.yml
@@ -52,9 +52,9 @@ jobs:
         cd ${{ needs.make_nightly_tag.outputs.tag }}
         source env.sh
         cd ../daq-release-unittests/scripts
-        ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "$DBT_AREA_ROOT" >> "$GITHUB_ENV"
     - name: Run unit tests
       run: |

--- a/.github/workflows/nightly-clang-format.yml
+++ b/.github/workflows/nightly-clang-format.yml
@@ -86,7 +86,7 @@ jobs:
             elif [[ "$(echo "$line" | grep -o FAILURE)" == "FAILURE" ]]; then
                 markdown_content+="| $test_name | :x: Failed |\n"
             else
-                markdown_content+=":construction: Unit tests have not been written for $this_package\n"
+                markdown_content+="\n:construction: Unit tests have not been written for $this_package\n"
             fi
         done < "$log_summary_file"
         echo -e "$markdown_content" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/nightly-clang-format.yml
+++ b/.github/workflows/nightly-clang-format.yml
@@ -42,11 +42,12 @@ jobs:
       with:
         repository: DUNE-DAQ/daq-buildtools
         ref: amogan/clang_format_markdown_summary
-        path: daq-buildtools
+        path: daq-buildtools-markdown-feature
     - name: Create build area
       run: |
         source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
-        setup_dbt latest_v5
+        #setup_dbt latest_v5
+        source daq-buildtools-markdown-feature/env.sh
         dbt-create -n ${{ needs.make_nightly_tag.outputs.tag }}
         cd ${{ needs.make_nightly_tag.outputs.tag }}
         source env.sh
@@ -54,11 +55,17 @@ jobs:
         #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        cd $DBT_AREA_ROOT
+        cd $DBT_AREA_ROOT/sourcecode
         dbt-workarea-env
         spack load dbe
         dbt-build --unittest
-        dbt-clang-format.sh sourcecode/ --view-differences-only 
+        dbt-clang-format.sh . --view-differences-only --output-markdown-file
+        echo "### Clang-Format Report" > $GITHUB_STEP_SUMMARY
+        cat clang_format_summary_table.md >> $GITHUB_STEP_SUMMARY
+
+    - name: Report Formatting Results
+      if: always()
+      run: |
 
   send_slack_message:
     if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')

--- a/.github/workflows/nightly-clang-format.yml
+++ b/.github/workflows/nightly-clang-format.yml
@@ -56,9 +56,9 @@ jobs:
         #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         ./checkout-daq-package.py -p fdreadoutlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         ./checkout-daq-package.py -p flxlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -p uhallibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
     - name: Run unit tests
       run: |

--- a/.github/workflows/nightly-clang-format.yml
+++ b/.github/workflows/nightly-clang-format.yml
@@ -55,12 +55,43 @@ jobs:
         ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         #./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        cd $DBT_AREA_ROOT/sourcecode
+        echo "$DBT_AREA_ROOT" >> "$GITHUB_ENV"
+    - name: Run unit tests
+      run: |
+        cd $DBT_AREA_ROOT/
+        source env.sh
         dbt-workarea-env
         spack load dbe
         dbt-build --unittest
+        echo "# Unit Test Report" > $GITHUB_STEP_SUMMARY
+        #TODO Make this a script in daq-release
+        log_summary_file=$(ls $DBT_AREA_ROOT/log/unit_tests_*/*_summary.log)
+        table_header_line="| Test | Status| \n| --- | --- |\n"
+        previous_package=""
+        markdown_content=""
+        while IFS= read -r line; do
+            this_package=$(echo "$line" | cut -d '/' -f 2)
+            test_name=$(echo "$line" | cut -d '/' -f 4 | cut -d '.' -f 1)
+            if [[ "$this_package" != "$previous_package" ]]; then
+                markdown_content+="## $this_package \n"
+                markdown_content+="$table_header_line"
+                previous_package=$this_package
+            fi
+            if [[ "$(echo "$line" | grep -o SUCCESS)" == "SUCCESS" ]]; then
+                markdown_content+="| $test_name | :white_check_mark: Passed |\n"
+            else
+                markdown_content+="| $test_name | :x: Failed |\n"
+            fi
+        done < "$log_summary_file"
+        echo -e "$markdown_content" >> $GITHUB_STEP_SUMMARY
+
+    - name: Run clang formatting
+      run: |
+        cd $DBT_AREA_ROOT
+        source env.sh
+        cd sourcecode
         dbt-clang-format.sh . --view-differences-only --markdown-summary
-        echo "### Clang-Format Report" > $GITHUB_STEP_SUMMARY
+        echo "# Clang-Format Report" > $GITHUB_STEP_SUMMARY
         cat clang_format_summary_table.md >> $GITHUB_STEP_SUMMARY
 
   send_slack_message:

--- a/.github/workflows/nightly-clang-format.yml
+++ b/.github/workflows/nightly-clang-format.yml
@@ -52,9 +52,9 @@ jobs:
         cd ${{ needs.make_nightly_tag.outputs.tag }}
         source env.sh
         cd ../daq-release-unittests/scripts
-        #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         cd $DBT_AREA_ROOT/sourcecode
         dbt-workarea-env
         spack load dbe

--- a/.github/workflows/nightly-clang-format.yml
+++ b/.github/workflows/nightly-clang-format.yml
@@ -37,6 +37,12 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: daq-release-unittests
+    - name: Checkout daq-buildtools
+      uses: actions/checkout@v4
+      with:
+        repository: DUNE-DAQ/daq-buildtools
+        ref: amogan/clang_format_markdown_summary
+        path: daq-buildtools
     - name: Create build area
       run: |
         source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
@@ -45,14 +51,14 @@ jobs:
         cd ${{ needs.make_nightly_tag.outputs.tag }}
         source env.sh
         cd ../daq-release-unittests/scripts
-        ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -p ipm -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         cd $DBT_AREA_ROOT
         dbt-workarea-env
         spack load dbe
         dbt-build --unittest
-        dbt-clang-format.sh sourcecode/ --view-differences-only
+        dbt-clang-format.sh sourcecode/ --view-differences-only 
 
   send_slack_message:
     if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')

--- a/.github/workflows/nightly-clang-format.yml
+++ b/.github/workflows/nightly-clang-format.yml
@@ -54,8 +54,8 @@ jobs:
         cd ../daq-release-unittests/scripts
         #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${dbt_area_root}/sourcecode
-        ./checkout-daq-package.py -p fdreadoutlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${dbt_area_root}/sourcecode
+        ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -p fdreadoutlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
     - name: Run unit tests
       run: |

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -41,7 +41,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: DUNE-DAQ/daq-buildtools
-        ref: amogan/daq_release_issue375
+        ref: amogan/daq_release_issue405
         path: daq-buildtools-markdown-feature
     - name: Create build area
       run: |

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -72,7 +72,7 @@ jobs:
               CUT_DELIMITER=' '
               CUT_FIELD=9
             else
-              CUT_DELIMITER='/''
+              CUT_DELIMITER='/'
               CUT_FIELD=2
             fi
             this_package=$(echo "$cleaned_line" | cut -d $CUT_DELIMITER -f $CUT_FIELD)

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -52,13 +52,9 @@ jobs:
         cd ${{ needs.make_nightly_tag.outputs.tag }}
         source env.sh
         cd ../daq-release-unittests/scripts
-        #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -p fdreadoutlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -p flxlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -p uhallibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
     - name: Run unit tests
       run: |

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -69,13 +69,11 @@ jobs:
             # Depending on whether the package has tests or not, the package name will be
             # in different positions
             if [[ "$cleaned_line" == *"No unit tests"* ]]; then
-              CUT_DELIMITER=' '
-              CUT_FIELD=9
+              this_package=$(echo "$cleaned_line" | cut -d ' ' -f 9)
             else
-              CUT_DELIMITER='/'
-              CUT_FIELD=2
+              this_package=$(echo "$cleaned_line" | cut -d '/' -f 2)
             fi
-            this_package=$(echo "$cleaned_line" | cut -d $CUT_DELIMITER -f $CUT_FIELD)
+            #this_package=$(echo "$cleaned_line" | cut -d $CUT_DELIMITER -f $CUT_FIELD)
             echo "This package is $this_package"
             test_name=$(echo "$line" | cut -d '/' -f 4 | cut -d '.' -f 1)
             if [[ "$this_package" != "$previous_package" ]]; then

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -65,6 +65,7 @@ jobs:
         markdown_content=""
         while IFS= read -r line; do
             this_package=$(echo "$line" | cut -d '/' -f 2)
+            echo "This package is $this_package"
             test_name=$(echo "$line" | cut -d '/' -f 4 | cut -d '.' -f 1)
             if [[ "$this_package" != "$previous_package" ]]; then
                 markdown_content+="## $this_package \n"

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -64,7 +64,9 @@ jobs:
         previous_package=""
         markdown_content=""
         while IFS= read -r line; do
-            this_package=$(echo "$line" | cut -d '/' -f 2)
+            # Strip out bash color formatting
+            cleaned_line=$(echo "$line" | sed -E 's/\x1B\[[0-9;]*[a-zA-Z]//g')
+            this_package=$(echo "$cleaned_line" | cut -d '/' -f 2)
             echo "This package is $this_package"
             test_name=$(echo "$line" | cut -d '/' -f 4 | cut -d '.' -f 1)
             if [[ "$this_package" != "$previous_package" ]]; then

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -68,7 +68,7 @@ jobs:
             cleaned_line=$(echo "$line" | sed -E 's/\x1B\[[0-9;]*[a-zA-Z]//g')
             # Depending on whether the package has tests or not, the package name will be
             # in different positions
-            if [[ "$claned_line" == *"No unit tests"* ]]; then
+            if [[ "$cleaned_line" == *"No unit tests"* ]]; then
               CUT_DELIMITER=' '
               CUT_FIELD=9
             else

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -37,26 +37,18 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: daq-release-unittests
-    - name: Checkout daq-buildtools
-      uses: actions/checkout@v4
-      with:
-        repository: DUNE-DAQ/daq-buildtools
-        ref: amogan/daq_release_issue405
-        path: daq-buildtools-markdown-feature
     - name: Create build area
       run: |
         source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
-        #setup_dbt latest_v5
-        source daq-buildtools-markdown-feature/env.sh
-        echo "TAG: ${{ needs.make_nightly_tag.outputs.tag }}"
+        setup_dbt v8.7.2
         dbt-create -n ${{ needs.make_nightly_tag.outputs.tag }}
         cd ${{ needs.make_nightly_tag.outputs.tag }}
         source env.sh
         cd ../daq-release-unittests/scripts
-        ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -p flxlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -p flxlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
     - name: Run unit tests
       run: |

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -66,7 +66,16 @@ jobs:
         while IFS= read -r line; do
             # Strip out bash color formatting
             cleaned_line=$(echo "$line" | sed -E 's/\x1B\[[0-9;]*[a-zA-Z]//g')
-            this_package=$(echo "$cleaned_line" | cut -d '/' -f 2)
+            # Depending on whether the package has tests or not, the package name will be
+            # in different positions
+            if [[ "$claned_line" == *"No unit tests"* ]]; then
+              CUT_DELIMITER=' '
+              CUT_FIELD=9
+            else
+              CUT_DELIMITER='/''
+              CUT_FIELD=2
+            fi
+            this_package=$(echo "$cleaned_line" | cut -d $CUT_DELIMITER -f $CUT_FIELD)
             echo "This package is $this_package"
             test_name=$(echo "$line" | cut -d '/' -f 4 | cut -d '.' -f 1)
             if [[ "$this_package" != "$previous_package" ]]; then

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -6,8 +6,8 @@ on:
       send-slack-message:
         description: 'whether to send a message to #daq-release-notifications on completion'
         default: 'no'
-  #schedule:
-  #  - cron: "0 10 * * *"
+  schedule:
+    - cron: "30 10 * * *"
 
 jobs:
   make_nightly_tag:

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -41,7 +41,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: DUNE-DAQ/daq-buildtools
-        ref: amogan/clang_format_markdown_summary
+        ref: amogan/daq_release_issue375
         path: daq-buildtools-markdown-feature
     - name: Create build area
       run: |

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -1,4 +1,4 @@
-name: Nightly clang format workflow
+name: Nightly code check workflow
 
 on:
   workflow_dispatch:

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -48,6 +48,7 @@ jobs:
         source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
         #setup_dbt latest_v5
         source daq-buildtools-markdown-feature/env.sh
+        echo "TAG: ${{ needs.make_nightly_tag.outputs.tag }}"
         dbt-create -n ${{ needs.make_nightly_tag.outputs.tag }}
         cd ${{ needs.make_nightly_tag.outputs.tag }}
         source env.sh

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -56,6 +56,7 @@ jobs:
         #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -p flxlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
     - name: Run unit tests
       run: |

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -53,9 +53,9 @@ jobs:
         cd ${{ needs.make_nightly_tag.outputs.tag }}
         source env.sh
         cd ../daq-release-unittests/scripts
-        ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
     - name: Run unit tests
       run: |

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -53,10 +53,10 @@ jobs:
         cd ${{ needs.make_nightly_tag.outputs.tag }}
         source env.sh
         cd ../daq-release-unittests/scripts
-        #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -p flxlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -p flxlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
     - name: Run unit tests
       run: |

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -45,10 +45,10 @@ jobs:
         cd ${{ needs.make_nightly_tag.outputs.tag }}
         source env.sh
         cd ../daq-release-unittests/scripts
-        #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -p flxlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -p flxlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
     - name: Run unit tests
       run: |
@@ -73,8 +73,6 @@ jobs:
             else
               this_package=$(echo "$cleaned_line" | cut -d '/' -f 2)
             fi
-            #this_package=$(echo "$cleaned_line" | cut -d $CUT_DELIMITER -f $CUT_FIELD)
-            echo "This package is $this_package"
             test_name=$(echo "$line" | cut -d '/' -f 4 | cut -d '.' -f 1)
             if [[ "$this_package" != "$previous_package" ]]; then
                 markdown_content+="## $this_package \n"


### PR DESCRIPTION
Partially addresses #405 by adding a nightly workflow that does unit tests and clang format checks. Linting appears to be computationally intensive enough to warrant its own workflow, likely on a weekly basis instead of nightly. This work depends on a corresponding PR to `daq-buildtools` which will merge `amogan/daq_release_issue405` into `develop`. 