### PR TITLE
Weekly linting workflow

### DIFF
--- a/.github/workflows/weekly-linting.yml
+++ b/.github/workflows/weekly-linting.yml
@@ -56,7 +56,7 @@ jobs:
 
   send_slack_message:
     if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')
-    needs: run_unittests
+    needs: run_linting
     uses: ./.github/workflows/slack-notification.yml
     with:
       workflow_success: ${{ needs.run_unittests.result == 'success' }}

--- a/.github/workflows/weekly-linting.yml
+++ b/.github/workflows/weekly-linting.yml
@@ -53,6 +53,13 @@ jobs:
         cd $DBT_AREA_ROOT
         dbt-workarea-env
         dbt-build --lint
+        tar czf linting_results.tgz log/linting*
+
+    - name: Upload logs
+      uses: actions/upload-artifact@v4
+      with:
+        name: Linting results
+        path: ${{ needs.make_nightly_tag.outputs.tag }}/linting_results.tgz
 
   send_slack_message:
     if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')

--- a/.github/workflows/weekly-linting.yml
+++ b/.github/workflows/weekly-linting.yml
@@ -45,10 +45,10 @@ jobs:
         cd ${{ needs.make_nightly_tag.outputs.tag }}
         source env.sh
         cd ../daq-release-linting/scripts
-        #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -p flxlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -p flxlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         #echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
         cd $DBT_AREA_ROOT
         dbt-workarea-env

--- a/.github/workflows/weekly-linting.yml
+++ b/.github/workflows/weekly-linting.yml
@@ -25,8 +25,8 @@ jobs:
           echo "nightly_tag=NFD_DEV_${date_tag}_A9"  >>  "$GITHUB_OUTPUT"
           cat "$GITHUB_OUTPUT"
 
-  run_unittests:
-    name: Run unit tests
+  run_linting:
+    name: Run linting
     runs-on: daq
     needs: make_nightly_tag
     defaults:
@@ -36,8 +36,8 @@ jobs:
     - name: Checkout daq-release
       uses: actions/checkout@v4
       with:
-        path: daq-release-unittests
-    - name: Create build area
+        path: daq-release-linting
+    - name: Create build area and run linting
       run: |
         source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
         setup_dbt v8.7.2
@@ -45,57 +45,14 @@ jobs:
         cd ${{ needs.make_nightly_tag.outputs.tag }}
         source env.sh
         cd ../daq-release-unittests/scripts
-        ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -p flxlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
-    - name: Run unit tests
-      run: |
-        cd $DBT_AREA_ROOT/
-        source env.sh
-        dbt-workarea-env
-        spack load dbe
-        dbt-build --unittest
-        echo "# Unit Test Report" > $GITHUB_STEP_SUMMARY
-        #TODO Make this a script in daq-release
-        log_summary_file=$(ls $DBT_AREA_ROOT/log/unit_tests_*/*_summary.log)
-        table_header_line="| Test | Status| \n| --- | --- |\n"
-        previous_package=""
-        markdown_content=""
-        while IFS= read -r line; do
-            # Strip out bash color formatting
-            cleaned_line=$(echo "$line" | sed -E 's/\x1B\[[0-9;]*[a-zA-Z]//g')
-            # Depending on whether the package has tests or not, the package name will be
-            # in different positions
-            if [[ "$cleaned_line" == *"No unit tests"* ]]; then
-              this_package=$(echo "$cleaned_line" | cut -d ' ' -f 9)
-            else
-              this_package=$(echo "$cleaned_line" | cut -d '/' -f 2)
-            fi
-            test_name=$(echo "$line" | cut -d '/' -f 4 | cut -d '.' -f 1)
-            if [[ "$this_package" != "$previous_package" ]]; then
-                markdown_content+="## $this_package \n"
-                markdown_content+="$table_header_line"
-                previous_package=$this_package
-            fi
-            if [[ "$(echo "$line" | grep -o SUCCESS)" == "SUCCESS" ]]; then
-                markdown_content+="| $test_name | :white_check_mark: Passed |\n"
-            elif [[ "$(echo "$line" | grep -o FAILURE)" == "FAILURE" ]]; then
-                markdown_content+="| $test_name | :x: Failed |\n"
-            else
-                markdown_content+="\n:construction: Unit tests have not been written for $this_package\n"
-            fi
-        done < "$log_summary_file"
-        echo -e "$markdown_content" >> $GITHUB_STEP_SUMMARY
-
-    - name: Run clang formatting
-      run: |
+        #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -p flxlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        #echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
         cd $DBT_AREA_ROOT
-        source env.sh
-        cd sourcecode
-        dbt-clang-format.sh . --view-differences-only --markdown-summary
-        cat clang_format_summary_table.md >> $GITHUB_STEP_SUMMARY
+        dbt-workarea-env
+        dbt-build --lint
 
   send_slack_message:
     if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')
@@ -109,10 +66,9 @@ jobs:
   cleanup_test_area:
     runs-on: daq
     if: always()
-    needs: [make_nightly_tag, run_unittests]
+    needs: [make_nightly_tag, run_linting]
     steps:
       - name: Remove test directory
         run: |
-          rm -rf daq-release-unittests
-          rm -rf daq-buildtools-markdown-feature
+          rm -rf daq-release-linting
           rm -rf ${{ needs.make_nightly_tag.outputs.tag }}

--- a/.github/workflows/weekly-linting.yml
+++ b/.github/workflows/weekly-linting.yml
@@ -44,7 +44,7 @@ jobs:
         dbt-create -n ${{ needs.make_nightly_tag.outputs.tag }}
         cd ${{ needs.make_nightly_tag.outputs.tag }}
         source env.sh
-        cd ../daq-release-unittests/scripts
+        cd ../daq-release-linting/scripts
         #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
@@ -66,7 +66,7 @@ jobs:
     needs: run_linting
     uses: ./.github/workflows/slack-notification.yml
     with:
-      workflow_success: ${{ needs.run_unittests.result == 'success' }}
+      workflow_success: ${{ needs.run_linting.result == 'success' }}
     secrets: 
       slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
 


### PR DESCRIPTION
Partially addresses #405 by adding a weekly workflow that runs `dbt-build --lint`. The reason for the weekly schedule (as opposed to nightly) is that this workflow is computationally and time intensive, taking about 4.5 hours. As of now, the results are stored in a tarball and uploaded as an artifact of this workflow. 

Successful test run: https://github.com/DUNE-DAQ/daq-release/actions/runs/12052966089