### PR TITLE
Extend nightly integration tests to work on candidate or frozen builds

### DIFF
--- a/.github/workflows/nightly-v5-integtest.yml
+++ b/.github/workflows/nightly-v5-integtest.yml
@@ -13,33 +13,60 @@ on:
       override-nightly-tag:
         description: 'manually specify the nightly tag (optional)'
         required: false
+      candidate-release-tag:
+        description: 'manually specify a candidate release tag (optional)'
+        required: false
+        default: ""
+      frozen-release-tag:
+        description: 'manually specify a frozen release tag (optional)'
+        required: false
+        default: ""
 
 jobs:
-  make_nightly_tag:
+  make_release_tag:
     name: create nightly tag
     runs-on: ubuntu-latest
     outputs:
-      tag: ${{ steps.create_nightly_tag.outputs.nightly_tag }} 
+      tag: ${{ steps.create_release_tag.outputs.release_tag }} 
+      is_candidate_release: ${{ steps.create_release_tag.outputs.is_candidate }} 
+      is_frozen_release: ${{ steps.create_release_tag.outputs.is_frozen }} 
     defaults:
       run:
         shell: bash
     steps:
-      - id: create_nightly_tag
+      - id: create_release_tag
         run: |
+          is_candidate=false
+          is_frozen=false
+          if [[ -n "${{ github.event.inputs.candidate-release-tag }}" && -n "${{ github.event.inputs.frozen-release-tag }}" ]]; then
+            echo "Error: You cannot specify both a candidate tag and a frozen tag. Please choose one and try again. Exiting..."
+            exit 1
+          fi
           if [ -n "${{ github.event.inputs.override-nightly-tag }}" ]; then
-            nightly_tag="${{ github.event.inputs.override-nightly-tag }}"
+            release_tag="${{ github.event.inputs.override-nightly-tag }}"
+            if [[ -n "${{ github.event.inputs.candidate-release-tag }}" || -n "${{ github.event.inputs.frozen-release-tag }}" ]]; then
+              echo "WARNING: The provided nightly tag will supercede the provided candidate or frozen release tag."
+            fi
+          elif [ -n "${{ github.event.inputs.candidate-release-tag }}" ]; then
+            release_tag="${{ github.event.inputs.candidate-release-tag }}"
+            is_candidate=true
+          elif [ -n "${{ github.event.inputs.frozen-release-tag }}" ]; then
+            release_tag="${{ github.event.inputs.frozen-release-tag }}"
+            is_frozen=true
           else
             date_tag=$(date +%y%m%d)
-            nightly_tag="NFD_DEV_${date_tag}_A9"
+            release_tag="NFD_DEV_${date_tag}_A9"
           fi
-          echo "nightly_tag=${nightly_tag}"  >>  "$GITHUB_OUTPUT"
+          echo "release_tag=${release_tag}"  >>  "$GITHUB_OUTPUT"
+          echo "is_candidate=${is_candidate}"  >>  "$GITHUB_OUTPUT"
+          echo "is_frozen=${is_frozen}"  >>  "$GITHUB_OUTPUT"
           cat "$GITHUB_OUTPUT"
 
   integration_tests:
     name: integration_tests
     runs-on: daq
     timeout-minutes: 30
-    needs: make_nightly_tag
+    needs: make_release_tag
     strategy:
         fail-fast: false
         matrix:
@@ -60,22 +87,34 @@ jobs:
     steps:
     - name: setup release and run tests
       env:
-        NIGHTLY_TAG: ${{needs.make_nightly_tag.outputs.tag}}
+        RELEASE_TAG: ${{needs.make_release_tag.outputs.tag}}
+        IS_CANDIDATE_RELEASE: ${{needs.make_release_tag.outputs.is_candidate_release}}
+        IS_FROZEN_RELEASE: ${{needs.make_release_tag.outputs.is_frozen_release}}
       run: |
         DET=fd
-        mkdir -p $GITHUB_WORKSPACE/integration_tests_$NIGHTLY_TAG
-        cd $GITHUB_WORKSPACE/integration_tests_$NIGHTLY_TAG
+        mkdir -p $GITHUB_WORKSPACE/integration_tests_$RELEASE_TAG
+        cd $GITHUB_WORKSPACE/integration_tests_$RELEASE_TAG
         source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
         setup_dbt latest_v5
-        [[ -e /cvmfs/dunedaq-development.opensciencegrid.org/nightly/$NIGHTLY_TAG/daq_app_rte.sh ]]
-        dbt-setup-release -n $NIGHTLY_TAG
-        export DBT_INSTALL_DIR=/cvmfs/dunedaq-development.opensciencegrid.org/nightly/$NIGHTLY_TAG
+        if [[ "$IS_CANDIDATE_RELEASE" == "true" ]]; then
+          echo "dbt-setup-release -b candidate $RELEASE_TAG"
+          [[ -e /cvmfs/dunedaq-development.opensciencegrid.org/candidates/$RELEASE_TAG/daq_app_rte.sh ]]
+          dbt-setup-release -b candidate $RELEASE_TAG
+        elif [[ "$IS_FROZEN_RELEASE" == "true" ]]; then
+          echo "dbt-setup-release $RELEASE_TAG"
+          [[ -e /cvmfs/dunedaq.opensciencegrid.org/spack/releases/$RELEASE_TAG/daq_app_rte.sh ]]
+          dbt-setup-release $RELEASE_TAG
+        else
+          echo "dbt-setup-release -n $RELEASE_TAG"
+          [[ -e /cvmfs/dunedaq-development.opensciencegrid.org/nightly/$RELEASE_TAG/daq_app_rte.sh ]]
+          dbt-setup-release -n $RELEASE_TAG
+        fi
+        export DBT_INSTALL_DIR=/cvmfs/dunedaq-development.opensciencegrid.org/nightly/$RELEASE_TAG
         TEST_PATH=""
         if [[ "${{ matrix.test_name }}" == "listrev_test" ]]; then
           TEST_PATH=$LISTREV_SHARE/integtest
         else
           TEST_PATH=$DAQSYSTEMTEST_SHARE/integtest
-          export DUNEDAQ_DB_PATH=$DAQSYSTEMTEST_SHARE:$DUNEDAQ_DB_PATH
         fi
         pytest -v -s --junit-xml=${{ matrix.test_name }}_results.xml \
                 $TEST_PATH/${{ matrix.test_name }}.py
@@ -84,15 +123,15 @@ jobs:
   parse_results:
     runs-on: daq
     if: always()
-    needs: [make_nightly_tag, integration_tests]
+    needs: [make_release_tag, integration_tests]
     steps:
     - name: Surface failing tests
       #uses: pmeier/pytest-results-action@8104ed7b3d3ba4bb0d550e406fc26aa756630fcc
       uses: andrewmogan/pytest-results-action@8b7955ab36427dc46b0f00ea7d4e66a75b7cc943
       env:
-        NIGHTLY_TAG: ${{ needs.make_nightly_tag.outputs.tag}}
+        RELEASE_TAG: ${{ needs.make_release_tag.outputs.tag}}
       with:
-        path: ${{ github.workspace }}/integration_tests_${{ env.NIGHTLY_TAG }}/*_results.xml
+        path: ${{ github.workspace }}/integration_tests_${{ env.RELEASE_TAG }}/*_results.xml
         summary: true
         display-options: fEX
         fail-on-empty: true
@@ -100,13 +139,13 @@ jobs:
   cleanup_xml_files:
     runs-on: daq
     if: always()
-    needs: [make_nightly_tag, parse_results]
+    needs: [make_release_tag, parse_results]
     steps:
       - name: Remove xml files
         env:
-          NIGHTLY_TAG: ${{ needs.make_nightly_tag.outputs.tag }}
+          RELEASE_TAG: ${{ needs.make_release_tag.outputs.tag }}
         run: |
-          rm -rf ${{ github.workspace }}/integration_tests_${{ env.NIGHTLY_TAG }}
+          rm -rf ${{ github.workspace }}/integration_tests_${{ env.RELEASE_TAG }}
 
   # Integration tests can sometimes collide with stale processes, leading to timeout
   cleanup_stale_gunicorn_processes:

--- a/.github/workflows/nightly-v5-integtest.yml
+++ b/.github/workflows/nightly-v5-integtest.yml
@@ -109,7 +109,6 @@ jobs:
           [[ -e /cvmfs/dunedaq-development.opensciencegrid.org/nightly/$RELEASE_TAG/daq_app_rte.sh ]]
           dbt-setup-release -n $RELEASE_TAG
         fi
-        export DBT_INSTALL_DIR=/cvmfs/dunedaq-development.opensciencegrid.org/nightly/$RELEASE_TAG
         TEST_PATH=""
         if [[ "${{ matrix.test_name }}" == "listrev_test" ]]; then
           TEST_PATH=$LISTREV_SHARE/integtest


### PR DESCRIPTION
Addresses #416. Successful run on `fddaq-v5.2.1-rc1-a9` [here](https://github.com/DUNE-DAQ/daq-release/actions/runs/12508478729), and another run on `fddaq-v5.2.0-a9` [here](https://github.com/DUNE-DAQ/daq-release/actions/runs/12471713114). Note that the latter was performed on a branch that was mistakenly based on a non-develop branch, but this non-develop branch didn't affect the nightly integration test workflow. 