### PR TITLE
Johnfreeman/save all tests in workflow2

### DIFF
--- a/.github/workflows/nightly-v5-integtest.yml
+++ b/.github/workflows/nightly-v5-integtest.yml
@@ -81,16 +81,17 @@ jobs:
         fail-fast: false
         matrix:
 
-            test_name: ["listrev_test",
-                        "3ru_1df_multirun_test",
-                        "3ru_3df_multirun_test",
-                        "example_system_test",
-                        "fake_data_producer_test",
-                        "long_window_readout_test",
-                        "minimal_system_quick_test",
-                        "readout_type_scan",
-                        "small_footprint_quick_test",
-                        "tpstream_writing_test"
+            test_name: [
+                        #"listrev_test",
+                        #"3ru_1df_multirun_test",
+                        #"3ru_3df_multirun_test",
+                        #"example_system_test",
+                        #"fake_data_producer_test",
+                        #"long_window_readout_test",
+                        #"minimal_system_quick_test",
+                        #"readout_type_scan",
+                        "small_footprint_quick_test"
+                        #"tpstream_writing_test"
                        ]
     defaults:
       run:
@@ -131,8 +132,10 @@ jobs:
           TEST_PATH=$DAQSYSTEMTEST_SHARE/integtest
         fi
         echo "INTEGTEST_OUTPUT_PATH=$INTEGTEST_OUTPUT_PATH" >> "$GITHUB_OUTPUT"
+
+        pytest_retval=0
         pytest -v -s --junit-xml=${{ matrix.test_name }}_results.xml \
-                $TEST_PATH/${{ matrix.test_name }}.py || true
+                $TEST_PATH/${{ matrix.test_name }}.py || { pytest_retval=$?; true; }
 
         mkdir -p $PERSISTENT_LOG_DIR
         cp -rL $(readlink -f /tmp/pytest-of-dunedaq/pytest-current/) $PERSISTENT_LOG_DIR/${{ matrix.test_name }}
@@ -143,6 +146,8 @@ jobs:
           rm -rf $PERSISTENT_LOG_DIR
           exit 2
         fi
+
+        test $pytest_retval == 0 || false
 
   parse_results:
     runs-on: daq

--- a/.github/workflows/nightly-v5-integtest.yml
+++ b/.github/workflows/nightly-v5-integtest.yml
@@ -82,16 +82,16 @@ jobs:
         matrix:
 
             test_name: [
-                        #"listrev_test",
-                        #"3ru_1df_multirun_test",
-                        #"3ru_3df_multirun_test",
-                        #"example_system_test",
-                        #"fake_data_producer_test",
-                        #"long_window_readout_test",
-                        #"minimal_system_quick_test",
-                        #"readout_type_scan",
-                        "small_footprint_quick_test"
-                        #"tpstream_writing_test"
+                        "listrev_test",
+                        "3ru_1df_multirun_test",
+                        "3ru_3df_multirun_test",
+                        "example_system_test",
+                        "fake_data_producer_test",
+                        "long_window_readout_test",
+                        "minimal_system_quick_test",
+                        "readout_type_scan",
+                        "small_footprint_quick_test",
+                        "tpstream_writing_test"
                        ]
     defaults:
       run:


### PR DESCRIPTION
Figure out how to simultaneously ensure that in the event a given integration test fails, the results get logged AND the failure gets registered properly in the Workflow homepage