### PR TITLE
Implement code coverage check workflow

### DIFF
--- a/.github/workflows/weekly-code-coverage.yml
+++ b/.github/workflows/weekly-code-coverage.yml
@@ -62,6 +62,8 @@ jobs:
         # spack load dbe
         dbt-lcov.sh
         echo "coverage_results_dir=${DBT_AREA_ROOT}/code_coverage_results" >> "$GITHUB_OUTPUT"
+        echo "PWD: $(pwd)"
+        echo "ls: $(ls)"
 
   deploy_to_github_pages:
     name: Deploy to GitHub Pages
@@ -77,6 +79,12 @@ jobs:
     steps:
     - name: Configure GitHub Pages
       uses: actions/configure-pages@v5
+    - name: Print debug
+      run: |
+        echo "Where am I? $(pwd)"
+        echo "What's here? $(ls)"
+        echo "Coverage results dir? ${{ needs.generate_code_coverage_report.outputs.coverage_results_dir }}"
+        echo "ls coverage results dir? $(ls ${{ needs.generate_code_coverage_report.outputs.coverage_results_dir }})"
     - name: Upload pages artifact
       uses: actions/upload-pages-artifact@v3
       with:

--- a/.github/workflows/weekly-code-coverage.yml
+++ b/.github/workflows/weekly-code-coverage.yml
@@ -6,8 +6,8 @@ on:
       send-slack-message:
         description: 'whether to send a message to #daq-release-notifications on completion'
         default: 'no'
-  #schedule:
-  #  - cron: "0 18 * * 0"
+  schedule:
+    - cron: "0 18 * * 0"
 
 jobs:
   make_nightly_tag:
@@ -52,7 +52,6 @@ jobs:
         ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         #./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         #./checkout-daq-package.py -p flxlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        echo "DBT_AREA_ROOT: $DBT_AREA_ROOT"
         echo "DBT_AREA_ROOT=${DBT_AREA_ROOT}" >> "$GITHUB_ENV"
     - name: Run dbt-lcov.sh
       id: run_lcov
@@ -64,11 +63,7 @@ jobs:
         dbt-workarea-env
         # spack load dbe
         dbt-lcov.sh
-        echo "DBT_AREA_ROOT: ${DBT_AREA_ROOT}"
         echo "results_dir=${DBT_AREA_ROOT}/code_coverage_results/html" >> "$GITHUB_OUTPUT"
-        echo "PWD: $(pwd)"
-        echo "ls: $(ls)"
-        echo "ls code_coverage_results: $(ls code_coverage_results)"
 
   deploy_to_github_pages:
     name: Deploy to GitHub Pages
@@ -84,12 +79,6 @@ jobs:
     steps:
     - name: Configure GitHub Pages
       uses: actions/configure-pages@v5
-    - name: Print debug
-      run: |
-        echo "Where am I? $(pwd)"
-        echo "What's here? $(ls)"
-        echo "Coverage results dir? ${{ needs.generate_code_coverage_report.outputs.coverage_results_dir }}"
-        echo "ls coverage results dir? $(ls ${{ needs.generate_code_coverage_report.outputs.coverage_results_dir }})"
     - name: Upload pages artifact
       uses: actions/upload-pages-artifact@v3
       with:

--- a/.github/workflows/weekly-code-coverage.yml
+++ b/.github/workflows/weekly-code-coverage.yml
@@ -47,7 +47,7 @@ jobs:
         dbt-create -n ${{ needs.make_nightly_tag.outputs.tag }}
         cd ${{ needs.make_nightly_tag.outputs.tag }}
         source env.sh
-        cd ../daq-release-unittests/scripts
+        cd ../daq-release-lcov/scripts
         #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode

--- a/.github/workflows/weekly-code-coverage.yml
+++ b/.github/workflows/weekly-code-coverage.yml
@@ -65,7 +65,7 @@ jobs:
         # spack load dbe
         dbt-lcov.sh
         echo "DBT_AREA_ROOT: ${DBT_AREA_ROOT}"
-        echo "results_dir=${DBT_AREA_ROOT}/code_coverage_results" >> "$GITHUB_OUTPUT"
+        echo "results_dir=${DBT_AREA_ROOT}/code_coverage_results/html" >> "$GITHUB_OUTPUT"
         echo "PWD: $(pwd)"
         echo "ls: $(ls)"
         echo "ls code_coverage_results: $(ls code_coverage_results)"

--- a/.github/workflows/weekly-code-coverage.yml
+++ b/.github/workflows/weekly-code-coverage.yml
@@ -52,18 +52,23 @@ jobs:
         #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         ./checkout-daq-package.py -p flxlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        echo "DBT_AREA_ROOT: $DBT_AREA_ROOT"
         echo "DBT_AREA_ROOT=${DBT_AREA_ROOT}" >> "$GITHUB_ENV"
     - name: Run dbt-lcov.sh
       id: run_lcov
       run: |
         cd $DBT_AREA_ROOT/
+        echo "Where am I? $(pwd)"
+        echo "DBT_AREA_ROOT in lcov step: $DBT_AREA_ROOT"
         source env.sh
         dbt-workarea-env
         # spack load dbe
         dbt-lcov.sh
-        echo "coverage_results_dir=${DBT_AREA_ROOT}/code_coverage_results" >> "$GITHUB_OUTPUT"
+        echo "DBT_AREA_ROOT: ${DBT_AREA_ROOT}"
+        echo "results_dir=${DBT_AREA_ROOT}/code_coverage_results" >> "$GITHUB_OUTPUT"
         echo "PWD: $(pwd)"
         echo "ls: $(ls)"
+        echo "ls code_coverage_results: $(ls code_coverage_results)"
 
   deploy_to_github_pages:
     name: Deploy to GitHub Pages

--- a/.github/workflows/weekly-code-coverage.yml
+++ b/.github/workflows/weekly-code-coverage.yml
@@ -1,4 +1,4 @@
-name: Nightly code check workflow
+name: Weekly code coverage workflow
 
 on:
   workflow_dispatch:

--- a/.github/workflows/weekly-code-coverage.yml
+++ b/.github/workflows/weekly-code-coverage.yml
@@ -48,10 +48,10 @@ jobs:
         cd ${{ needs.make_nightly_tag.outputs.tag }}
         source env.sh
         cd ../daq-release-lcov/scripts
-        #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -p flxlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -p flxlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT: $DBT_AREA_ROOT"
         echo "DBT_AREA_ROOT=${DBT_AREA_ROOT}" >> "$GITHUB_ENV"
     - name: Run dbt-lcov.sh


### PR DESCRIPTION
Addresses #430. Similar to the weekly linting workflow, this one runs `dbt-lcov.sh` in an area based on the latest nightly. The results are published to the `daq-release` [GitHub Pages](https://docs.github.com/en/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages). 

[GitHub Pages result](https://dune-daq.github.io/daq-release/). 

[Example workflow summary](https://github.com/DUNE-DAQ/daq-release/actions/runs/13443976527).