### PR TITLE
Improvements to Slack messaging, particularly for lcov workflow

### DIFF
--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -26,7 +26,7 @@ jobs:
         path: daq-release-slack-message
     - name: Get workflow failures from GitHub API
       run: |
-        WORKFLOW_DETAILS=$(gh api /repos/DUNE-DAQ/daq-release/actions/runs/$RUN_ID)
+        WORKFLOW_DETAILS=$(gh api /repos/DUNE-DAQ/daq-release/actions/runs/${{ github.run_id }})
 
         WORKFLOW_NAME=$(echo "$WORKFLOW_DETAILS" | jq -r '.name')
         ACTOR_LOGIN=$(echo "$WORKFLOW_DETAILS" | jq -r '.actor.login')
@@ -34,7 +34,7 @@ jobs:
         HTML_URL=$(echo "$WORKFLOW_DETAILS" | jq -r '.html_url')
 
         # Get failed jobs and merge with workflow details
-        gh api /repos/DUNE-DAQ/daq-release/actions/runs/$RUN_ID/jobs \
+        gh api /repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
         | jq --arg workflow "$WORKFLOW_NAME" --arg actor "$ACTOR_LOGIN" --arg event "$EVENT_TYPE" --arg html_url "$HTML_URL" \
           '{workflow: $workflow, actor: $actor, event: $event, html_url: $html_url, failed_jobs: [ .jobs[] | select(.conclusion != "success") | {job: .name, conclusion: .conclusion, steps: [.steps[] | select(.conclusion == "failure") | {name: .name}]}]}' \
         | tee failed_jobs.json

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -26,8 +26,17 @@ jobs:
         path: daq-release-slack-message
     - name: Get workflow failures from GitHub API
       run: |
-        gh api /repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
-        | jq '[.jobs[] | select(.conclusion != "success") | {job: .name, conclusion: .conclusion, steps: [.steps[] | select(.conclusion == "failure") | {name: .name}]}]' \
+        WORKFLOW_DETAILS=$(gh api /repos/DUNE-DAQ/daq-release/actions/runs/$RUN_ID)
+
+        WORKFLOW_NAME=$(echo "$WORKFLOW_DETAILS" | jq -r '.name')
+        ACTOR_LOGIN=$(echo "$WORKFLOW_DETAILS" | jq -r '.actor.login')
+        EVENT_TYPE=$(echo "$WORKFLOW_DETAILS" | jq -r '.event')
+        HTML_URL=$(echo "$WORKFLOW_DETAILS" | jq -r '.html_url')
+
+        # Get failed jobs and merge with workflow details
+        gh api /repos/DUNE-DAQ/daq-release/actions/runs/$RUN_ID/jobs \
+        | jq --arg workflow "$WORKFLOW_NAME" --arg actor "$ACTOR_LOGIN" --arg event "$EVENT_TYPE" --arg html_url "$HTML_URL" \
+          '{workflow: $workflow, actor: $actor, event: $event, html_url: $html_url, failed_jobs: [ .jobs[] | select(.conclusion != "success") | {job: .name, conclusion: .conclusion, steps: [.steps[] | select(.conclusion == "failure") | {name: .name}]}]}' \
         | tee failed_jobs.json
     - name: Parse GitHub API output
       run: |

--- a/.github/workflows/weekly-code-coverage.yml
+++ b/.github/workflows/weekly-code-coverage.yml
@@ -88,7 +88,7 @@ jobs:
       uses: actions/deploy-pages@v4
 
   send_slack_message:
-    if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')
+    if: (github.event_name != 'workflow_dispatch') || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')
     needs: deploy_to_github_pages
     uses: ./.github/workflows/slack-notification.yml
     secrets: 

--- a/scripts/github-ci/slack_payload_generator.py
+++ b/scripts/github-ci/slack_payload_generator.py
@@ -1,168 +1,130 @@
 import sys, os
-import argparse
 import json
+import argparse
+import sys
 import re
 from pathlib import Path
 from integtest_xml_parser import parse_junit_xml
 
-def get_failed_jobs(api_output_path):
-    """
-    Load the JSON file output from GitHub API call which checks for failed jobs and steps. 
-    """
-    try:
-        with open(api_output_path, "r") as f:
-            return json.load(f)
-    except json.JSONDecodeError as e:
-        print(f"Error decoding JSON: {e}")
+class SlackPayload:
+    """Class to generate a Slack JSON payload for workflow notifications."""
 
-def get_xml_files(directory, pattern):
-    if not os.path.isdir(directory):
-        print(f"Warning: {directory} is not a valid directory.")
-        return []
-
-    path = Path(directory)
-    xml_files = path.rglob(pattern)
-
-    return xml_files
-
-def get_workflow_status(failed_jobs):
-    """
-    Determine the overall workflow status.
-    
-    If any job or step was cancelled, this should take precedence over failure.
-    Defaults to success if there were no cancellations or failures.
-    """
-    has_cancelled = False
-    has_failure = False
-    for job in failed_jobs:
-        if job['conclusion'] == 'cancelled':
-            has_cancelled = True
-        elif job['conclusion'] == 'failure':
-            has_failure = True
-    
-    if has_cancelled:
-        return 'cancelled'
-    if has_failure:
-        return 'failure'
-    return 'success'
-
-def get_header(status):
-    """Generate the header block based on the status."""
-    status_emojis = {
+    STATUS_EMOJIS = {
         "success": ":white_check_mark:",
         "failure": ":rotating_light:",
         "cancelled": ":no_entry:",
     }
-    workflow_name = os.getenv("GITHUB_WORKFLOW", "Unknown Workflow")
-    return {
-        "type": "header",
-        "text": {
-            "type": "plain_text",
-            "text": f"{status_emojis.get(status, ':grey_question:')} {status.capitalize()}: {workflow_name} {status_emojis.get(status, ':grey_question:')}",
-            "emoji": True
-        }
-    }
 
-def get_report_section():
-    """Generate the section block with the link to full GitHub Actions output."""
-    return {
-        "type": "section",
-        "text": {
-            "type": "mrkdwn",
-            "text": "Full report: <https://github.com/${{ github.payload.repository.full_name }}/actions/runs/${{ github.runId }}|link>."
-        }
-    }
+    def __init__(self, workflow_summary, xml_files=None, pytest_log_dir=None):
+        self.workflow_summary = workflow_summary
+        self.failed_jobs = workflow_summary['failed_jobs']
+        self.xml_files = xml_files or []
+        self.pytest_log_dir = pytest_log_dir
+        self.workflow_status = self.get_workflow_status()
+        self.blocks = []
 
-def find_matching_file(test_name, xml_files):
-    """Find junit xml file that matches the job name."""
-    for file in xml_files:
-        if test_name in str(file):
-            return file
-    return None
+    def get_workflow_status(self):
+        """Determine the overall workflow status based on job conclusions."""
+        has_cancelled = any(job['conclusion'] == 'cancelled' for job in self.failed_jobs)
+        has_failure = any(job['conclusion'] == 'failure' for job in self.failed_jobs)
+        if has_cancelled:
+            return 'cancelled'
+        if has_failure:
+            return 'failure'
+        return 'success'
 
-def get_integration_test_failure(test_name, xml_files):
-    """Get the primary failure type from the junit xml file."""
-    xml_file = find_matching_file(test_name, xml_files)
-    if not xml_file:
-        print('WARNING: No matching xml file found for', test_name)
-        return "Unknown failure: could not find results.xml file for this test."
+    def add_header(self):
+        """Add the header block displaying the workflow name and status."""
+        workflow_name = os.getenv("GITHUB_WORKFLOW", "Unknown Workflow")
+        emoji = self.STATUS_EMOJIS.get(self.workflow_status, ":grey_question:")
+        self.blocks.append({
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": f"{emoji} {self.workflow_status.capitalize()}: {workflow_name} {emoji}",
+                "emoji": True
+            }
+        })
 
-    failure = "Unknown failure"
-    results = parse_junit_xml(xml_file)
-    # Lines that failed will be preceeded by a newline followed by ">" and
-    # some number of whitespace characters; search between this and the next
-    # newline to see what the failure was.
-    failed_line_pattern = r"\n>\s+(.*?)\n"
-    failure_summary = ''
-    for result in results:
-        if not result.get('failure_message'): continue
-        failure_summary += f"\n\t\t  *{result['test_name']}* failed"
-        failed_line_match = re.findall(failed_line_pattern, result['failure_message'])
-        if failed_line_match:
-            failure_summary += f" while checking \n\t\t`{failed_line_match[0]}`\n" 
-    return failure_summary
+    def add_report_section(self):
+        """Add the link to full GitHub Actions output."""
+        self.blocks.append({
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "Full report: <https://github.com/${{ github.payload.repository.full_name }}/actions/runs/${{ github.runId }}|link>."
+            }
+        })
 
-def get_failed_jobs_section(failed_jobs, xml_files):
-    """Generate the section block that lists failed jobs and steps."""
-    if not failed_jobs:
+    def add_failed_jobs_section(self):
+        """Sections that lists failed jobs and steps."""
+        if not self.failed_jobs or self.workflow_status != 'failure':
+            return
+        
+        failed_jobs_text = "*Failed jobs and steps:*\n"
+        for job in self.failed_jobs:
+            if job['conclusion'] != 'failure':
+                continue
+            failed_jobs_text += f"- *{job['job']}*\n"
+            for step in job['steps']:
+                failed_jobs_text += f"\t:x: *{step['name']}*\n"
+                if 'integration_tests' in job['job']:
+                    test_name = job['job'].split()[1].strip("()")
+                    failed_jobs_text += self.get_integration_test_failure(test_name)
+
+        self.blocks.append({
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": failed_jobs_text}
+        })
+
+    def get_integration_test_failure(self, test_name):
+        """Parse JUnit XML files output by integration tests to roughly determine failure reason."""
+        xml_file = self.find_matching_file(test_name)
+        if not xml_file:
+            return "\n\t\t  *Unknown failure:* No matching results.xml file found.\n"
+
+        failure_summary = ''
+        results = parse_junit_xml(xml_file)
+        failed_line_pattern = r"\n>\s+(.*?)\n"
+
+        for result in results:
+            if not result.get('failure_message'):
+                continue
+            failure_summary += f"\n\t\t  *{result['test_name']}* failed"
+            failed_line_match = re.findall(failed_line_pattern, result['failure_message'])
+            if failed_line_match:
+                failure_summary += f" while checking \n\t\t`{failed_line_match[0]}`\n"
+        return failure_summary
+
+    def find_matching_file(self, test_name):
+        """Find a JUnit XML file that matches the integration test name."""
+        for file in self.xml_files:
+            if test_name in str(file):
+                return file
         return None
 
-    failed_jobs_text = "*Failed jobs and steps:*\n"
-    for job in failed_jobs:
-        # Jobs may be skipped or have not yet run
-        if not job['conclusion'] == 'failure': continue
-        failed_jobs_text += f"- *{job['job']}*\n"
-        for step in job['steps']:
-            failed_jobs_text += f"\t:x: *{step['name']}*\n"
-            if 'integration_tests' in job['job']:
-                test_name = job['job'].split()[1].strip("()")
-                failed_jobs_text += get_integration_test_failure(test_name, xml_files)
+    def add_pytest_log_section(self):
+        """Add pytest log directory section if available."""
+        if self.pytest_log_dir:
+            self.blocks.append({
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"The pytest logs are stored for 7 days at: `daq.fnal.gov:{self.pytest_log_dir}`.\n"
+                             "You can also download logs from the 'Full report' link above."
+                }
+            })
 
-    return {
-        "type": "section",
-        "text": {
-            "type": "mrkdwn",
-            "text": failed_jobs_text
-        }
-    }
-
-def get_pytest_log_section(pytest_log_dir):
-    """Generate a section showing where the pytest logs are stored."""
-    return {
-        "type": "section",
-        "text": {
-            "type": "mrkdwn",
-            "text": f"The pytest logs will be stored for the next 7 days at: `daq.fnal.gov:{pytest_log_dir}`.\n"
-                     "You can also download the logs from the \"Full report\" link above (scroll to the bottom)."
-        }
-    }
-
-def generate_payload(failed_jobs, xml_files=[], pytest_log_dir=None):
-    """
-    Top-level payload generator function that determines which payload sections to
-    write based on inputs. The message is written such that it can be parsed by
-    Slack's BlockKit format.
-    """
-    slack_payload = {"blocks": []}
-
-    workflow_status = get_workflow_status(failed_jobs)
-    slack_payload["blocks"].append(get_header(workflow_status))
-
-    slack_payload["blocks"].append(get_report_section())
-
-    failed_jobs_section = ''
-    if workflow_status == 'failure':
-        failed_jobs_section = get_failed_jobs_section(failed_jobs, xml_files)
-    if failed_jobs_section:
-        slack_payload["blocks"].append(failed_jobs_section)
-
-    if pytest_log_dir:
-        slack_payload["blocks"].append(get_pytest_log_section(pytest_log_dir))
-    
-    return slack_payload
+    def to_dict(self):
+        """Build and return the final Slack payload."""
+        self.add_header()
+        self.add_report_section()
+        self.add_failed_jobs_section()
+        self.add_pytest_log_section()
+        return {"blocks": self.blocks}
 
 def write_payload_to_file(payload, file_name='slack_payload.json'):
-    """Write the Slack payload to a file which can be seen by slack-github-action."""
+    """Write the Slack payload to a file."""
     try:
         with open(file_name, "w") as file:
             json.dump(payload, file)
@@ -173,24 +135,30 @@ def write_payload_to_file(payload, file_name='slack_payload.json'):
 def main():
     parser = argparse.ArgumentParser(description="Parse a workflow summary and generate a Slack message payload.")
     parser.add_argument("--api-output", required=True,
-                        help="json file containing a summary of failed jobs, obtained from GitHub API call.")
+                        help="JSON file containing a summary of failed jobs from GitHub API.")
     parser.add_argument("--junit-xml-dir", nargs="?", default=None,
-                        help="Optional directory containing junit xml files output by pytests.")
+                        help="Optional directory containing JUnit XML files.")
     parser.add_argument("--pytest-log-dir", nargs="?", default=None,
-                        help="Optional directory containing the full pytest output.")
+                        help="Optional directory for full pytest logs.")
     args = parser.parse_args()
+
     if len(sys.argv) == 1:
         parser.print_usage()
 
-    failed_jobs = get_failed_jobs(args.api_output)
+    try:
+        with open(args.api_output, "r") as f:
+            workflow_summary = json.load(f)
+    except json.JSONDecodeError as e:
+        print(f"Error decoding JSON: {e}")
+        return
 
-    # Nightly integration tests store their output in junit xml files
     xml_files = []
-    if args.junit_xml_dir:
-        xml_files = get_xml_files(args.junit_xml_dir, "*_results.xml")
+    if args.junit_xml_dir and os.path.isdir(args.junit_xml_dir):
+        xml_files = list(Path(args.junit_xml_dir).rglob("*_results.xml"))
 
-    payload = generate_payload(failed_jobs, xml_files, args.pytest_log_dir)
-    write_payload_to_file(payload)
-    
+    slack_payload = SlackPayload(workflow_summary, xml_files, args.pytest_log_dir)
+    write_payload_to_file(slack_payload.to_dict())
+
+
 if __name__ == "__main__":
     main()

--- a/scripts/github-ci/slack_payload_generator.py
+++ b/scripts/github-ci/slack_payload_generator.py
@@ -176,7 +176,7 @@ def main():
         with open(args.api_output, "r") as f:
             workflow_summary = json.load(f)
     except json.JSONDecodeError as e:
-        print(f"Error decoding JSON: {e}")
+        print(f"Error decoding GH API output: {e}")
         return
 
     xml_files = []
@@ -185,7 +185,6 @@ def main():
 
     slack_payload = SlackPayload(workflow_summary, xml_files, args.pytest_log_dir)
     write_payload_to_file(slack_payload.to_dict())
-
 
 if __name__ == "__main__":
     main()

--- a/scripts/github-ci/slack_payload_generator.py
+++ b/scripts/github-ci/slack_payload_generator.py
@@ -16,8 +16,12 @@ class SlackPayload:
     }
 
     def __init__(self, workflow_summary, xml_files=None, pytest_log_dir=None):
-        self.workflow_summary = workflow_summary
-        self.failed_jobs = workflow_summary['failed_jobs']
+        self.workflow_summary  = workflow_summary
+        self.workflow_name     = workflow_summary['workflow']
+        self.workflow_trigger  = workflow_summary['event']
+        self.workflow_actor    = workflow_summary['actor']
+        self.workflow_html_url = workflow_summary['html_url']
+        self.failed_jobs       = workflow_summary['failed_jobs']
         self.xml_files = xml_files or []
         self.pytest_log_dir = pytest_log_dir
         self.workflow_status = self.get_workflow_status()
@@ -35,7 +39,7 @@ class SlackPayload:
 
     def add_header(self):
         """Add the header block displaying the workflow name and status."""
-        workflow_name = os.getenv("GITHUB_WORKFLOW", "Unknown Workflow")
+        workflow_name = self.workflow_summary['workflow']
         emoji = self.STATUS_EMOJIS.get(self.workflow_status, ":grey_question:")
         self.blocks.append({
             "type": "header",
@@ -52,9 +56,18 @@ class SlackPayload:
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": "Full report: <https://github.com/${{ github.payload.repository.full_name }}/actions/runs/${{ github.runId }}|link>."
+                #"text": "Full report: <https://github.com/${{ github.payload.repository.full_name }}/actions/runs/${{ github.runId }}|link>."
+                "text": f"Full report: <{self.workflow_html_url}|link>."
             }
         })
+        if self.workflow_name == "Weekly code coverage workflow":
+            self.blocks.append({
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "You can view the full lcov coverage report <https://dune-daq.github.io/daq-release/|here>."
+                }
+            })
 
     def add_failed_jobs_section(self):
         """Sections that lists failed jobs and steps."""
@@ -116,13 +129,11 @@ class SlackPayload:
             })
 
     def add_footer(self):
-        workflow_trigger = self.workflow_summary['event']
-        workflow_actor = self.workflow_summary['actor']
         footer_text = ""
-        if workflow_trigger == "schedule":
+        if self.workflow_trigger == "schedule":
             footer_text = "This was a scheduled workflow."
-        elif workflow_trigger == "workflow_dispatch":
-            footer_text = f"This workflow was manually triggered by user `{workflow_actor}`"
+        elif self.workflow_trigger == "workflow_dispatch":
+            footer_text = f"This workflow was manually triggered by user `{self.workflow_actor}`"
 
         if footer_text:
             self.blocks.append({

--- a/scripts/github-ci/slack_payload_generator.py
+++ b/scripts/github-ci/slack_payload_generator.py
@@ -115,12 +115,28 @@ class SlackPayload:
                 }
             })
 
+    def add_footer(self):
+        workflow_trigger = self.workflow_summary['event']
+        workflow_actor = self.workflow_summary['actor']
+        footer_text = ""
+        if workflow_trigger == "schedule":
+            footer_text = "This was a scheduled workflow."
+        elif workflow_trigger == "workflow_dispatch":
+            footer_text = f"This workflow was manually triggered by user `{workflow_actor}`"
+
+        if footer_text:
+            self.blocks.append({
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": footer_text}
+            })
+
     def to_dict(self):
         """Build and return the final Slack payload."""
         self.add_header()
         self.add_report_section()
         self.add_failed_jobs_section()
         self.add_pytest_log_section()
+        self.add_footer()
         return {"blocks": self.blocks}
 
 def write_payload_to_file(payload, file_name='slack_payload.json'):


### PR DESCRIPTION
In working to get a link to the lcov results page displayed in the automatic Slack message, I put all the payload generating logic into a `SlackPayload` class and added some extra, useful information to the `gh api` call. In particular, the Slack messages will now
- tell whether the workflow was scheduled or manually triggered, and
- who triggered it (if it was manually triggered), and
- display a link to the lcov results for the lcov workflow.
The last bullet could potentially be extended to other workflows in the future, if we want. 