### PR TITLE
Add a `doxygen_mainpage.md` for Doxygen

### DIFF
--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -950,6 +950,7 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = README.md \
+                         doxygen_mainpage.md \
                          @INPUT_LIST
 
 # This tag can be used to specify the character encoding of the source files
@@ -1161,7 +1162,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE =
+USE_MDFILE_AS_MAINPAGE = doxygen_mainpage.md
 
 # The Fortran standard specifies that for fixed formatted Fortran code all
 # characters from position 72 are to be considered as comment. A common

--- a/docs/doxygen_mainpage.md
+++ b/docs/doxygen_mainpage.md
@@ -1,0 +1,6 @@
+@mainpage DUNE DAQ Doxygen Homepage
+
+# Overview
+Welcome to the Doxygen homepage for DUNE-DAQ. This page is designed to help you find source code and related documentation for the various DUNE DAQ packages.
+
+If you want a guide on how to get started developing in DUNE DAQ, see the [readthedocs](https://dune-daq-sw.readthedocs.io/en/latest/) page. 


### PR DESCRIPTION
Today, Alessandro noticed that the Doxygen main page was pointing to the README of `daphnemodules`. This was because that README had the `@mainpage` Doxygen signifier where no other README did. This proved to be good motivation to finally create a proper main page for our Doxygen site, so this PR does exactly that. In this case, the `@mainpage` bit in `daq-release/docs/doxygen_mainpage.md` is listed first in the Doxyfile `INPUT` field, and therefore takes precedence over the one in the `daphnemodules` README. 