### PR TITLE
Add pytests to nightly code checks

### DIFF
--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -116,7 +116,7 @@ jobs:
     steps:
     - name: Generate summary tables
       run: |
-        cd daq-release-integtest/scripts/github-ci/
+        cd daq-release-unittests/scripts/github-ci/
         python integtest_xml_parser.py --input-directory ${{ needs.run_unittests.outputs.pytest_log_dir }}
         cat pytest_summary_table.md >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -29,6 +29,8 @@ jobs:
     name: Run unit tests
     runs-on: daq
     needs: make_nightly_tag
+    outputs:
+      pytest_log_dir: ${{ steps.pytests.outputs.pytest_log_dir }}
     defaults:
       run:
         shell: bash
@@ -90,6 +92,7 @@ jobs:
         echo -e "$markdown_content" >> $GITHUB_STEP_SUMMARY
 
     - name: Run pytest tests
+      id: pytests
       run: |
         cd $DBT_AREA_ROOT
         source env.sh
@@ -98,6 +101,7 @@ jobs:
         # Log directory is the last non-empty line of output
         pytest_log_dir=$(readlink -f $DBT_AREA_ROOT/log/pytest_tests_* | tail -n 1)
         echo "pytest_log_dir=${pytest_log_dir}" >> "$GITHUB_OUTPUT"
+        echo "pytest_log_dir: $pytest_log_dir"
     - name: Run clang formatting
       run: |
         cd $DBT_AREA_ROOT
@@ -106,9 +110,19 @@ jobs:
         dbt-clang-format.sh . --view-differences-only --markdown-summary
         cat clang_format_summary_table.md >> $GITHUB_STEP_SUMMARY
 
+  parse_pytest_results:
+    runs-on: daq
+    needs: run_unittests
+    steps:
+    - name: Generate summary tables
+      run: |
+        cd daq-release-integtest/scripts/github-ci/
+        python integtest_xml_parser.py --input-directory ${{ needs.run_unittests.outputs.pytest_log_dir }}
+        cat pytest_summary_table.md >> $GITHUB_STEP_SUMMARY
+
   send_slack_message:
     if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')
-    needs: run_unittests
+    needs: parse_pytest_results
     uses: ./.github/workflows/slack-notification.yml
     secrets: 
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -116,10 +130,9 @@ jobs:
   cleanup_test_area:
     runs-on: daq
     if: always()
-    needs: [make_nightly_tag, run_unittests]
+    needs: [make_nightly_tag, parse_pytest_results]
     steps:
-      - name: Remove test directory
+      - name: Remove test directory and daq-release
         run: |
           rm -rf daq-release-unittests
-          rm -rf daq-buildtools-markdown-feature
           rm -rf ${{ needs.make_nightly_tag.outputs.tag }}

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -89,6 +89,15 @@ jobs:
         done < "$log_summary_file"
         echo -e "$markdown_content" >> $GITHUB_STEP_SUMMARY
 
+    - name: Run pytest tests
+      run: |
+        cd $DBT_AREA_ROOT
+        source env.sh
+        dbt-workarea-env
+        dbt-build --pytest | tee pytest_full_output.log
+        # Log directory is the last non-empty line of output
+        pytest_log_dir=$(readlink -f $DBT_AREA_ROOT/log/pytest_tests_* | tail -n 1)
+        echo "pytest_log_dir=${pytest_log_dir}" >> "$GITHUB_OUTPUT"
     - name: Run clang formatting
       run: |
         cd $DBT_AREA_ROOT

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -91,17 +91,6 @@ jobs:
         done < "$log_summary_file"
         echo -e "$markdown_content" >> $GITHUB_STEP_SUMMARY
 
-    - name: Run pytest tests
-      id: pytests
-      run: |
-        cd $DBT_AREA_ROOT
-        source env.sh
-        dbt-workarea-env
-        dbt-build --pytest | tee pytest_full_output.log
-        # Log directory is the last non-empty line of output
-        pytest_log_dir=$(readlink -f $DBT_AREA_ROOT/log/pytest_tests_* | tail -n 1)
-        echo "pytest_log_dir=${pytest_log_dir}" >> "$GITHUB_OUTPUT"
-        echo "pytest_log_dir: $pytest_log_dir"
     - name: Run clang formatting
       run: |
         cd $DBT_AREA_ROOT
@@ -109,6 +98,21 @@ jobs:
         cd sourcecode
         dbt-clang-format.sh . --view-differences-only --markdown-summary
         cat clang_format_summary_table.md >> $GITHUB_STEP_SUMMARY
+
+    - name: Run pytest tests
+      id: pytests
+      run: |
+        cd $DBT_AREA_ROOT
+        # daqsystemtest and listrev tests are already run as part of the nightly integration tests
+        rm -rf sourcecode/daqsystemtest
+        rm -rf sourcecode/listrev
+        source env.sh
+        dbt-workarea-env
+        dbt-build --pytest | tee pytest_full_output.log
+        # Log directory is the last non-empty line of output
+        pytest_log_dir=$(readlink -f $DBT_AREA_ROOT/log/pytest_tests_* | tail -n 1)
+        echo "pytest_log_dir=${pytest_log_dir}" >> "$GITHUB_OUTPUT"
+        echo "pytest_log_dir: $pytest_log_dir"
 
   parse_pytest_results:
     runs-on: daq

--- a/.github/workflows/nightly-pytests.yml
+++ b/.github/workflows/nightly-pytests.yml
@@ -39,6 +39,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: daq-release-pytests
+        ref: amogan/pytest_workflow
     - name: Checkout daq-buildtools
       uses: actions/checkout@v4
       with:
@@ -56,6 +57,10 @@ jobs:
         cd ../daq-release-pytests/scripts
         ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        # daqsystemtest and listrev tests are already run in the nightly integration tests
+        cd ${DBT_AREA_ROOT}/sourcecode
+        rm -rf daqsystemtest
+        rm -rf listrev
         #./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         #./checkout-daq-package.py -p flxlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
@@ -70,11 +75,8 @@ jobs:
         # Run tests while capturing output
         dbt-build --pytest | tee pytest_full_output.log
         # Log directory is the last non-empty line of output
-        #pytest_log_dir=$(grep . pytest_full_output.log | tail -n 1)
         pytest_log_dir=$(readlink -f $DBT_AREA_ROOT/log/pytest_tests_* | tail -n 1)
         echo "pytest_log_dir=${pytest_log_dir}" >> "$GITHUB_OUTPUT"
-        echo "PYTEST_LOG_DIR: $pytest_log_dir"
-        echo "GITHUB_OUTPUT: $GITHUB_OUTPUT"
 
   parse_results:
     runs-on: daq

--- a/.github/workflows/nightly-pytests.yml
+++ b/.github/workflows/nightly-pytests.yml
@@ -39,7 +39,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: daq-release-pytests
-        ref: amogan/pytest_workflow
     - name: Checkout daq-buildtools
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/nightly-pytests.yml
+++ b/.github/workflows/nightly-pytests.yml
@@ -52,7 +52,7 @@ jobs:
         dbt-create -n ${{ needs.make_nightly_tag.outputs.tag }}
         cd ${{ needs.make_nightly_tag.outputs.tag }}
         source env.sh
-        source ~/daq-buildtools-pytests/env.sh
+        source $GITHUB_WORKSPACE/daq-buildtools-pytests/env.sh
         cd ../daq-release-pytests/scripts
         ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
@@ -64,7 +64,7 @@ jobs:
       run: |
         cd $DBT_AREA_ROOT/
         source env.sh
-        source ~/daq-buildtools-pytests/env.sh
+        source $GITHUB_WORKSPACE/daq-buildtools-pytests/env.sh
         dbt-workarea-env
         spack load dbe
         # Run tests while capturing output

--- a/.github/workflows/nightly-pytests.yml
+++ b/.github/workflows/nightly-pytests.yml
@@ -70,7 +70,8 @@ jobs:
         # Run tests while capturing output
         dbt-build --pytest | tee pytest_full_output.log
         # Log directory is the last non-empty line of output
-        pytest_log_dir=$(grep . pytest_full_output.log | tail -n 1)
+        #pytest_log_dir=$(grep . pytest_full_output.log | tail -n 1)
+        pytest_log_dir=$(readlink -f $DBT_AREA_ROOT/log/pytest_tests_* | tail -n 1)
         echo "pytest_log_dir=${pytest_log_dir}" >> "$GITHUB_OUTPUT"
         echo "PYTEST_LOG_DIR: $pytest_log_dir"
         echo "GITHUB_OUTPUT: $GITHUB_OUTPUT"

--- a/.github/workflows/nightly-pytests.yml
+++ b/.github/workflows/nightly-pytests.yml
@@ -71,7 +71,7 @@ jobs:
         dbt-build --pytest | tee pytest_full_output.log
         # Log directory is the last non-empty line of output
         pytest_log_dir=$(grep . pytest_full_output.log | tail -n 1)
-        echo "pytest_log_dir=${pytest_log_dir}" >> GITHUB_OUTPUT
+        echo "pytest_log_dir=${pytest_log_dir}" >> "$GITHUB_OUTPUT"
         echo "PYTEST_LOG_DIR: $pytest_log_dir"
         echo "GITHUB_OUTPUT: $GITHUB_OUTPUT"
 

--- a/.github/workflows/nightly-pytests.yml
+++ b/.github/workflows/nightly-pytests.yml
@@ -42,6 +42,7 @@ jobs:
     - name: Checkout daq-buildtools
       uses: actions/checkout@v4
       with:
+        repository: DUNE-DAQ/daq-buildtools
         path: daq-buildtools-pytests
         ref: amogan/issue295_dbt_build_pytest
     - name: Create build area

--- a/.github/workflows/nightly-v5-integtest.yml
+++ b/.github/workflows/nightly-v5-integtest.yml
@@ -162,7 +162,6 @@ jobs:
       with:
         repository: DUNE-DAQ/daq-release
         path: daq-release-integtest
-        ref: amogan/pytest_workflow
     - name: Generate summary tables
       env:
         RELEASE_TAG: ${{needs.make_variables.outputs.tag}}

--- a/.github/workflows/nightly-v5-integtest.yml
+++ b/.github/workflows/nightly-v5-integtest.yml
@@ -162,6 +162,7 @@ jobs:
       with:
         repository: DUNE-DAQ/daq-release
         path: daq-release-integtest
+        ref: amogan/pytest_workflow
     - name: Generate summary tables
       env:
         RELEASE_TAG: ${{needs.make_variables.outputs.tag}}

--- a/.github/workflows/nightly-v5-integtest.yml
+++ b/.github/workflows/nightly-v5-integtest.yml
@@ -126,15 +126,18 @@ jobs:
           dbt-setup-release -n $RELEASE_TAG
         fi
         TEST_PATH=""
+        TEST_SOURCE=""
         if [[ "${{ matrix.test_name }}" == "listrev_test" ]]; then
           TEST_PATH=$LISTREV_SHARE/integtest
+          TEST_SOURCE=listrev
         else
           TEST_PATH=$DAQSYSTEMTEST_SHARE/integtest
+          TEST_SOURCE=daqsystemtest
         fi
         echo "INTEGTEST_OUTPUT_PATH=$INTEGTEST_OUTPUT_PATH" >> "$GITHUB_OUTPUT"
 
         pytest_retval=0
-        pytest -v -s --junit-xml=${{ matrix.test_name }}_results.xml \
+        pytest -v -s --junit-xml=${TEST_SOURCE}_${{ matrix.test_name }}_results.xml \
                 $TEST_PATH/${{ matrix.test_name }}.py || { pytest_retval=$?; true; }
 
         mkdir -p $PERSISTENT_LOG_DIR

--- a/scripts/github-ci/integtest_xml_parser.py
+++ b/scripts/github-ci/integtest_xml_parser.py
@@ -74,17 +74,11 @@ class JUnitXMLParser:
 
     def generate_markdown_table(self):
         with open(self.output_filename, 'w') as f:
-            previous_package_name = ''
             for idx, result in enumerate(self.test_results):
                 if not result: continue
-                this_package_name = result[idx]['package_name']
-                print('This package is', this_package_name)
-                # Write header lines for each new package
-                if this_package_name != previous_package_name:
-                    f.write(f"# {result[idx]['package_name']} Results\n")
-                    previous_package_name = this_package_name
-                    f.write("| Test Case | Status |\n")
-                    f.write("|-----------|--------|\n")
+                f.write(f"# {result[0]['package_name']} {result[0]['pytest_name']} Results\n")
+                f.write("| Test Case | Status |\n")
+                f.write("|-----------|--------|\n")
                 f.writelines(self.format_markdown_row(test) for test in result)
 
         if not os.path.exists(self.output_filename):

--- a/scripts/github-ci/integtest_xml_parser.py
+++ b/scripts/github-ci/integtest_xml_parser.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import re
 import argparse
 import html
 from pathlib import Path
@@ -22,16 +23,18 @@ class JUnitXMLParser:
             raise FileNotFoundError(f"Error: No xml files found in {directory}.")
         return xml_files
 
-    def get_test_name(self, file_path):
+    def get_package_and_pytest_name_from_file(self, file_path):
         file_name = os.path.basename(file_path)
-        # Results file names should look like "minimal_system_quick_test_results.xml"
-        return file_name.replace('_results.xml', '')
+        # Junit xml files should be structured as <package_name>_<pytest_name>_results.xml
+        package_and_pytest_name = file_name.replace('_results.xml', '')
+        package_name, pytest_name = package_and_pytest_name.split("_", 1)
+        return package_name, pytest_name
 
     def parse_junit_xml(self, file_path):
         tree = ET.parse(file_path)
         root = tree.getroot()
 
-        test_suite_name = self.get_test_name(file_path)
+        package_name, pytest_name = self.get_package_and_pytest_name_from_file(file_path)
 
         results = []
         for testcase in root.findall(".//testcase"):
@@ -48,7 +51,8 @@ class JUnitXMLParser:
                 result = "skipped"
 
             results.append({
-                "test_suite_name": test_suite_name,
+                "package_name": package_name,
+                "pytest_name": pytest_name,
                 "test_name": test_name,
                 "result": result,
                 "failure_message": failure_message
@@ -59,7 +63,8 @@ class JUnitXMLParser:
         emoji_map = {
             'passed': ':white_check_mark:',
             'failed': ':x:',
-            'skipped': ':grey_question:'
+            'skipped': ':fast_forward:',
+            'error': ':warning:'
         }
         return emoji_map.get(test_status, ':shrug:')
 
@@ -68,19 +73,18 @@ class JUnitXMLParser:
         return f"| {test['test_name']} | {emoji} {test['result']} |\n"
 
     def generate_markdown_table(self):
-        print("Results:", self.test_results)
-        print("Results[0]:", self.test_results[0])
         with open(self.output_filename, 'w') as f:
+            previous_package_name = ''
             for idx, result in enumerate(self.test_results):
                 if not result: continue
-                print('------', idx, '---------')
-                print('result:', result)
-                print('result type:', type(result))
-                print('len result:', len(result))
-                print('result[0]:', result[0])
-                f.write(f"# {result[0]['test_suite_name']} Results\n")
-                f.write("| Test Case | Status |\n")
-                f.write("|-----------|--------|\n")
+                this_package_name = result[idx]['package_name']
+                print('This package is', this_package_name)
+                # Write header lines for each new package
+                if this_package_name != previous_package_name:
+                    f.write(f"# {result[idx]['package_name']} Results\n")
+                    previous_package_name = this_package_name
+                    f.write("| Test Case | Status |\n")
+                    f.write("|-----------|--------|\n")
                 f.writelines(self.format_markdown_row(test) for test in result)
 
         if not os.path.exists(self.output_filename):
@@ -92,6 +96,7 @@ class JUnitXMLParser:
         num_passed = 0
         num_failed = 0
         num_skipped = 0
+        num_errors = 0
         total_tests = 0
         with open(self.output_filename, 'r') as ifile:
             original_lines = ifile.readlines()
@@ -106,11 +111,20 @@ class JUnitXMLParser:
                 elif 'skipped' in line:
                     num_skipped += 1
                     total_tests += 1
+                elif 'error' in line:
+                    num_errors += 1
+                    total_tests += 1
 
         print('Passed:', num_passed)
+        print('Skipped:', num_skipped)
         print('Failed:', num_failed)
+        print('Errors:', num_errors)
 
-        summary = f"{num_passed} passed and {num_failed} failed of {total_tests} total tests.\n"
+        summary = f"""There were {total_tests} total tests run. 
+           {num_passed} passed {self.which_emoji('passed')}, 
+           {num_failed} failed {self.which_emoji('failed')}, 
+           {num_skipped} were skipped {self.which_emoji('skipped')}, and
+           {num_errors} had errors {self.which_emoji('error')} which prevented the test from completing.\n"""
         new_lines = [summary] + original_lines
         with open(self.output_filename, 'w') as ofile:
             ofile.writelines(new_lines)

--- a/scripts/github-ci/integtest_xml_parser.py
+++ b/scripts/github-ci/integtest_xml_parser.py
@@ -59,9 +59,9 @@ class JUnitXMLParser:
         emoji_map = {
             'passed': ':white_check_mark:',
             'failed': ':x:',
-            'skipped': ':grey_question:'
+            'skipped': ':fast_forward:'
         }
-        return emoji_map.get(test_status, ':shrug:')
+        return emoji_map.get(test_status, ':question:')
 
     def format_markdown_row(self, test):
         emoji = self.which_emoji(test['result'])

--- a/scripts/github-ci/integtest_xml_parser.py
+++ b/scripts/github-ci/integtest_xml_parser.py
@@ -68,16 +68,9 @@ class JUnitXMLParser:
         return f"| {test['test_name']} | {emoji} {test['result']} |\n"
 
     def generate_markdown_table(self):
-        print("Results:", self.test_results)
-        print("Results[0]:", self.test_results[0])
         with open(self.output_filename, 'w') as f:
             for idx, result in enumerate(self.test_results):
                 if not result: continue
-                print('------', idx, '---------')
-                print('result:', result)
-                print('result type:', type(result))
-                print('len result:', len(result))
-                print('result[0]:', result[0])
                 f.write(f"# {result[0]['test_suite_name']} Results\n")
                 f.write("| Test Case | Status |\n")
                 f.write("|-----------|--------|\n")


### PR DESCRIPTION
With the introduction of the [`--pytest` option to dbt-build](https://github.com/DUNE-DAQ/daq-buildtools/pull/298), we can now run python integration tests outside of `daqsystemtest` and `listrev` as part of the nightly code checks. This PR adds a step that does just that to the nightly code check workflow, along with a step for parsing the pytest results using `integtest_xml_parser.py`. 

In order for the parsing to be consistent between this new workflow and the existing nightly integration tests, I changed the name of the output junit xml files in the nightly integration tests to prepend the package name to the beginning of the file. This way, `integtest_xml_parser.py` can separate tests by package name. I also modified the xml parser to count the number of tests with errors that prevent them from running. 