### PR TITLE
Add release name to slack message

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,4 +1,4 @@
-name: Nightly v5 integration tests
+name: Integration test workflow
 
 on:
   schedule:

--- a/.github/workflows/nightly-v5-integtest.yml
+++ b/.github/workflows/nightly-v5-integtest.yml
@@ -83,16 +83,16 @@ jobs:
         matrix:
 
             test_name: [
-                        "listrev_test",
-                        "3ru_1df_multirun_test",
-                        "3ru_3df_multirun_test",
-                        "example_system_test",
-                        "fake_data_producer_test",
-                        "long_window_readout_test",
+                        #"listrev_test",
+                        #"3ru_1df_multirun_test",
+                        #"3ru_3df_multirun_test",
+                        #"example_system_test",
+                        #"fake_data_producer_test",
+                        #"long_window_readout_test",
                         "minimal_system_quick_test",
-                        "readout_type_scan",
-                        "small_footprint_quick_test",
-                        "tpstream_writing_test"
+                        #"readout_type_scan",
+                        #"small_footprint_quick_test",
+                        #"tpstream_writing_test"
                        ]
     defaults:
       run:
@@ -197,10 +197,11 @@ jobs:
     needs: [make_variables, store_and_upload_logs]
     uses: ./.github/workflows/slack-notification.yml
     with:
+      release_tag: ${{ needs.make_variables.outputs.tag }}
       integtest_xml_dir: ${{ needs.make_variables.outputs.integtest_output_path }}
       integtest_log_dir: ${{ needs.make_variables.outputs.persistent_log_dir }}
     secrets: 
-      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+      slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
 
   cleanup_files:
     runs-on: daq

--- a/.github/workflows/nightly-v5-integtest.yml
+++ b/.github/workflows/nightly-v5-integtest.yml
@@ -83,16 +83,16 @@ jobs:
         matrix:
 
             test_name: [
-                        #"listrev_test",
-                        #"3ru_1df_multirun_test",
-                        #"3ru_3df_multirun_test",
-                        #"example_system_test",
-                        #"fake_data_producer_test",
-                        #"long_window_readout_test",
+                        "listrev_test",
+                        "3ru_1df_multirun_test",
+                        "3ru_3df_multirun_test",
+                        "example_system_test",
+                        "fake_data_producer_test",
+                        "long_window_readout_test",
                         "minimal_system_quick_test",
-                        #"readout_type_scan",
-                        #"small_footprint_quick_test",
-                        #"tpstream_writing_test"
+                        "readout_type_scan",
+                        "small_footprint_quick_test",
+                        "tpstream_writing_test"
                        ]
     defaults:
       run:
@@ -201,7 +201,7 @@ jobs:
       integtest_xml_dir: ${{ needs.make_variables.outputs.integtest_output_path }}
       integtest_log_dir: ${{ needs.make_variables.outputs.persistent_log_dir }}
     secrets: 
-      slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   cleanup_files:
     runs-on: daq

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -3,6 +3,10 @@ name: Slack Notification
 on:
   workflow_call:
     inputs:
+      release_tag:
+        type: string
+        default: ''
+        description: Name of the release used in the caller workflow.
       integtest_xml_dir:
         type: string
         default: ''

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -46,6 +46,7 @@ jobs:
       run: |
         python daq-release-slack-message/scripts/github-ci/slack_payload_generator.py \
                --api-output failed_jobs.json \
+               --release-name ${{ inputs.release_tag }} \
                --junit-xml-dir ${{ inputs.integtest_xml_dir }} \
                --pytest-log-dir ${{ inputs.integtest_log_dir }}
         cat slack_payload.json

--- a/scripts/github-ci/slack_payload_generator.py
+++ b/scripts/github-ci/slack_payload_generator.py
@@ -15,13 +15,14 @@ class SlackPayload:
         "cancelled": ":no_entry:",
     }
 
-    def __init__(self, workflow_summary, junit_xml_dir=None, pytest_log_dir=None):
+    def __init__(self, workflow_summary, release_name=None, junit_xml_dir=None, pytest_log_dir=None):
         self.workflow_summary  = workflow_summary
         self.workflow_name     = workflow_summary['workflow']
         self.workflow_trigger  = workflow_summary['event']
         self.workflow_actor    = workflow_summary['actor']
         self.workflow_html_url = workflow_summary['html_url']
         self.failed_jobs       = workflow_summary['failed_jobs']
+        self.release_name = release_name
         self.pytest_log_dir = pytest_log_dir
         self.workflow_status = self.get_workflow_status()
         self.blocks = []
@@ -49,6 +50,23 @@ class SlackPayload:
                 "type": "plain_text",
                 "text": f"{emoji} {self.workflow_status.capitalize()}: {workflow_name} {emoji}",
                 "emoji": True
+            }
+        })
+
+    def add_release_section(self):
+        """State which release the workflow was run on."""
+        if not self.release_name:
+            return
+        release_type = 'stable'
+        if 'rc' in self.release_name:
+            release_type = 'candidate'
+        elif 'NFD' in self.release_name:
+            release_type = 'nightly'
+        self.blocks.append({
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"This workflow was run using the {release_type} release `{self.release_name}`."
             }
         })
 
@@ -147,6 +165,7 @@ class SlackPayload:
         """Build and return the final Slack payload."""
         self.blocks = []
         self.add_header()
+        self.add_release_section()
         self.add_report_section()
         self.add_failed_jobs_section()
         if shorten_failed_jobs_section:
@@ -181,6 +200,8 @@ def main():
     parser = argparse.ArgumentParser(description="Parse a workflow summary and generate a Slack message payload.")
     parser.add_argument("--api-output", required=True,
                         help="JSON file containing a summary of failed jobs from GitHub API.")
+    parser.add_argument("--release-name", nargs="?", default=None,
+                        help="Optional name of the release used in the caller workflow.")
     parser.add_argument("--junit-xml-dir", nargs="?", default=None,
                         help="Optional directory containing JUnit XML files.")
     parser.add_argument("--pytest-log-dir", nargs="?", default=None,
@@ -202,7 +223,7 @@ def main():
         xml_files = list(Path(args.junit_xml_dir).rglob("*_results.xml"))
 
     print('args.pytest_log_dir:', args.pytest_log_dir)
-    slack_payload = SlackPayload(workflow_summary, args.junit_xml_dir, args.pytest_log_dir)
+    slack_payload = SlackPayload(workflow_summary, args.release_name, args.junit_xml_dir, args.pytest_log_dir)
     json_payload = slack_payload.to_json()
     write_payload_to_file(json_payload)
 


### PR DESCRIPTION
This PR adds a line to the Slack message output by the integration test workflow to include the name of the release on which the workflow was run. This also removes the "nightly v5" bit from the workflow name, since we now use this on candidate and stable releases. 