### PR TITLE
Factor unit testing into its own workflow

### DIFF
--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -54,7 +54,7 @@ jobs:
         ./checkout-daq-package.py -p flxlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
     - name: Run unit tests
-      uses: ./.github/workflows/unit-tests.yml
+      uses: ./daq-release-code-checks/.github/workflows/unit-tests.yml
       with:
         release_tag: ${{ needs.make_variables.outputs.tag }}
     - name: Run clang formatting

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -39,6 +39,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: daq-release-unittests
+        ref: amogan/factor_unit_test_workflow
     - name: Create build area
       run: |
         source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -57,6 +57,7 @@ jobs:
       uses: ./.github/workflows/unit-tests.yml
       with:
         release_tag: ${{ needs.make_nightly_tag.outputs.tag }}
+        daq_release_path: daq-release-unittests
     - name: Run unit tests
       run: |
         cd $DBT_AREA_ROOT/

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -53,6 +53,10 @@ jobs:
         #./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         #./checkout-daq-package.py -p flxlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
+    - name: Check contents of daq-release area
+      run: |
+        echo "Contents of daq-release-unittests: $(ls -a daq-release-unittests)"
+        echo "Contents of daq-release-unittests workflows: $(ls -a daq-release-unittests/.github/workflows)"
     - name: Run unit tests
       uses: ./daq-release-unittests/.github/workflows/unit-tests.yml
       with:

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -33,7 +33,7 @@ jobs:
   run_checks:
     name: Run linting and integration tests
     runs-on: daq
-    needs: make_variables
+    needs: [make_variables, run_unittests]
     outputs:
       integtest_log_dir: ${{ steps.integtests.outputs.integtest_log_dir }}
     defaults:
@@ -84,12 +84,12 @@ jobs:
 
   parse_integtest_results:
     runs-on: daq
-    needs: [make_variables, run_unittests]
+    needs: [make_variables, run_unittests, run_checks]
     steps:
     - name: Generate summary tables
       run: |
         cd daq-release-code-checks/scripts/github-ci/
-        python integtest_xml_parser.py --input-directory ${{ needs.run_unittests.outputs.integtest_log_dir }}
+        python integtest_xml_parser.py --input-directory ${{ needs.run_checks.outputs.integtest_log_dir }}
         cat pytest_summary_table.md >> $GITHUB_STEP_SUMMARY
 
   send_slack_message:

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -55,7 +55,7 @@ jobs:
         cd ${{ needs.make_variables.outputs.tag }}
         source env.sh
         #cd ../daq-release-unittests/scripts
-        cd $DAQ_RELEASE_PATH/scripts
+        cd ${{ env.DAQ_RELEASE_PATH }}/scripts
         #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -10,11 +10,12 @@ on:
     - cron: "30 10 * * *"
 
 jobs:
-  make_nightly_tag:
+  make_variables:
     name: create nightly tag
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.create_nightly_tag.outputs.nightly_tag }} 
+      daq_release_path: ${{ steps.set_daq_release_path.outputs.nightly_tag }} 
     defaults:
       run:
         shell: bash
@@ -23,14 +24,20 @@ jobs:
         run: |
           date_tag=$(date +%y%m%d)
           echo "nightly_tag=NFD_DEV_${date_tag}_A9"  >>  "$GITHUB_OUTPUT"
+      - id: set_daq_release_path
+        run: |
+          echo "nightly_tag=NFD_DEV_${date_tag}_A9"  >>  "$GITHUB_OUTPUT"
+          echo "daq_release_path=${{ github.workspace }}/daq-release-code-checks" >> "$GITHUB_OUTPUT"
           cat "$GITHUB_OUTPUT"
 
   run_unittests:
     name: Run unit tests
     runs-on: daq
-    needs: make_nightly_tag
+    needs: make_variables
     outputs:
       integtest_log_dir: ${{ steps.integtests.outputs.integtest_log_dir }}
+    env:
+      DAQ_RELEASE_PATH: ${{ needs.make_variables.outputs.daq_release_path }}
     defaults:
       run:
         shell: bash
@@ -38,69 +45,26 @@ jobs:
     - name: Checkout daq-release
       uses: actions/checkout@v4
       with:
-        path: daq-release-unittests
+        path: ${{ needs.make_variables.outputs.daq_release_path }}
         ref: amogan/factor_unit_test_workflow
     - name: Create build area
       run: |
         source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
         setup_dbt latest_v5
-        dbt-create -n ${{ needs.make_nightly_tag.outputs.tag }}
-        cd ${{ needs.make_nightly_tag.outputs.tag }}
+        dbt-create -n ${{ needs.make_variables.outputs.tag }}
+        cd ${{ needs.make_variables.outputs.tag }}
         source env.sh
-        cd ../daq-release-unittests/scripts
-        ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -p flxlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        #cd ../daq-release-unittests/scripts
+        cd $DAQ_RELEASE_PATH/scripts
+        #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -p flxlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
-    - name: Check contents of daq-release area
-      run: |
-        echo "Contents of daq-release-unittests: $(ls -a daq-release-unittests)"
-        echo "Contents of daq-release-unittests workflows: $(ls -a daq-release-unittests/.github/workflows)"
     - name: Run unit tests
-      uses: ./daq-release-unittests/.github/workflows/unit-tests.yml
+      uses: ./.github/workflows/unit-tests.yml
       with:
-        release_tag: ${{ needs.make_nightly_tag.outputs.tag }}
-        daq_release_path: daq-release-unittests
-    - name: Run unit tests
-      run: |
-        cd $DBT_AREA_ROOT/
-        source env.sh
-        dbt-workarea-env
-        spack load dbe
-        dbt-build --unittest
-        echo "# Unit Test Report" > $GITHUB_STEP_SUMMARY
-        #TODO Make this a script in daq-release
-        log_summary_file=$(ls $DBT_AREA_ROOT/log/unit_tests_*/*_summary.log)
-        table_header_line="| Test | Status| \n| --- | --- |\n"
-        previous_package=""
-        markdown_content=""
-        while IFS= read -r line; do
-            # Strip out bash color formatting
-            cleaned_line=$(echo "$line" | sed -E 's/\x1B\[[0-9;]*[a-zA-Z]//g')
-            # Depending on whether the package has tests or not, the package name will be
-            # in different positions
-            if [[ "$cleaned_line" == *"No unit tests"* ]]; then
-              this_package=$(echo "$cleaned_line" | cut -d ' ' -f 9)
-            else
-              this_package=$(echo "$cleaned_line" | cut -d '/' -f 2)
-            fi
-            test_name=$(echo "$line" | cut -d '/' -f 4 | cut -d '.' -f 1)
-            if [[ "$this_package" != "$previous_package" ]]; then
-                markdown_content+="## $this_package \n"
-                markdown_content+="$table_header_line"
-                previous_package=$this_package
-            fi
-            if [[ "$(echo "$line" | grep -o SUCCESS)" == "SUCCESS" ]]; then
-                markdown_content+="| $test_name | :white_check_mark: Passed |\n"
-            elif [[ "$(echo "$line" | grep -o FAILURE)" == "FAILURE" ]]; then
-                markdown_content+="| $test_name | :x: Failed |\n"
-            else
-                markdown_content+="\n:construction: Unit tests have not been written for $this_package\n"
-            fi
-        done < "$log_summary_file"
-        echo -e "$markdown_content" >> $GITHUB_STEP_SUMMARY
-
+        release_tag: ${{ needs.make_variables.outputs.tag }}
     - name: Run clang formatting
       run: |
         cd $DBT_AREA_ROOT
@@ -126,11 +90,11 @@ jobs:
 
   parse_integtest_results:
     runs-on: daq
-    needs: run_unittests
+    needs: [make_variables, run_unittests]
     steps:
     - name: Generate summary tables
       run: |
-        cd daq-release-unittests/scripts/github-ci/
+        cd ${{ needs.make_variables.outputs.daq_release_path }}/scripts/github-ci/
         python integtest_xml_parser.py --input-directory ${{ needs.run_unittests.outputs.integtest_log_dir }}
         cat pytest_summary_table.md >> $GITHUB_STEP_SUMMARY
 
@@ -144,9 +108,9 @@ jobs:
   cleanup_test_area:
     runs-on: daq
     if: always()
-    needs: [make_nightly_tag, parse_integtest_results]
+    needs: [make_variables, parse_integtest_results]
     steps:
       - name: Remove test directory and daq-release
         run: |
-          rm -rf daq-release-unittests
-          rm -rf ${{ needs.make_nightly_tag.outputs.tag }}
+          rm -rf ${{ needs.make_variables.outputs.daq_release_path }}
+          rm -rf ${{ needs.make_variables.outputs.tag }}

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -23,9 +23,15 @@ jobs:
         run: |
           date_tag=$(date +%y%m%d)
           echo "nightly_tag=NFD_DEV_${date_tag}_A9"  >>  "$GITHUB_OUTPUT"
-
+  
   run_unittests:
-    name: Run unit tests
+    needs: make_variables
+    uses: ./.github/workflows/unit-tests.yml
+    with:
+      release_tag: ${{ needs.make_variables.outputs.tag }}
+
+  run_checks:
+    name: Run linting and integration tests
     runs-on: daq
     needs: make_variables
     outputs:
@@ -53,10 +59,6 @@ jobs:
         ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         ./checkout-daq-package.py -p flxlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
-    - name: Run unit tests
-      uses: ./daq-release-code-checks/.github/workflows/unit-tests.yml
-      with:
-        release_tag: ${{ needs.make_variables.outputs.tag }}
     - name: Run clang formatting
       run: |
         cd $DBT_AREA_ROOT

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.create_nightly_tag.outputs.nightly_tag }} 
-      daq_release_path: ${{ steps.set_daq_release_path.outputs.nightly_tag }} 
+      daq_release_path: ${{ steps.set_daq_release_path.outputs.daq_release_path }} 
     defaults:
       run:
         shell: bash
@@ -26,7 +26,6 @@ jobs:
           echo "nightly_tag=NFD_DEV_${date_tag}_A9"  >>  "$GITHUB_OUTPUT"
       - id: set_daq_release_path
         run: |
-          echo "nightly_tag=NFD_DEV_${date_tag}_A9"  >>  "$GITHUB_OUTPUT"
           echo "daq_release_path=${{ github.workspace }}/daq-release-code-checks" >> "$GITHUB_OUTPUT"
           cat "$GITHUB_OUTPUT"
 

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -53,6 +53,10 @@ jobs:
         #./checkout-daq-package.py -p flxlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
     - name: Run unit tests
+      uses: ./.github/workflows/unit-tests.yml
+      with:
+        release_tag: ${{ needs.make_nightly_tag.outputs.tag }}
+    - name: Run unit tests
       run: |
         cd $DBT_AREA_ROOT/
         source env.sh

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -15,7 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.create_nightly_tag.outputs.nightly_tag }} 
-      daq_release_path: ${{ steps.set_daq_release_path.outputs.daq_release_path }} 
     defaults:
       run:
         shell: bash
@@ -24,10 +23,6 @@ jobs:
         run: |
           date_tag=$(date +%y%m%d)
           echo "nightly_tag=NFD_DEV_${date_tag}_A9"  >>  "$GITHUB_OUTPUT"
-      - id: set_daq_release_path
-        run: |
-          echo "daq_release_path=${{ github.workspace }}/daq-release-code-checks" >> "$GITHUB_OUTPUT"
-          cat "$GITHUB_OUTPUT"
 
   run_unittests:
     name: Run unit tests
@@ -35,8 +30,6 @@ jobs:
     needs: make_variables
     outputs:
       integtest_log_dir: ${{ steps.integtests.outputs.integtest_log_dir }}
-    env:
-      DAQ_RELEASE_PATH: ${{ needs.make_variables.outputs.daq_release_path }}
     defaults:
       run:
         shell: bash
@@ -44,7 +37,7 @@ jobs:
     - name: Checkout daq-release
       uses: actions/checkout@v4
       with:
-        path: ${{ needs.make_variables.outputs.daq_release_path }}
+        path: daq-release-code-checks
         ref: amogan/factor_unit_test_workflow
     - name: Create build area
       run: |
@@ -53,8 +46,8 @@ jobs:
         dbt-create -n ${{ needs.make_variables.outputs.tag }}
         cd ${{ needs.make_variables.outputs.tag }}
         source env.sh
-        #cd ../daq-release-unittests/scripts
-        cd ${{ env.DAQ_RELEASE_PATH }}/scripts
+        cd ../daq-release-code-checks/scripts
+        #cd ${{ github.workspace }}/daq-release-code-checks/scripts
         #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
@@ -93,7 +86,7 @@ jobs:
     steps:
     - name: Generate summary tables
       run: |
-        cd ${{ needs.make_variables.outputs.daq_release_path }}/scripts/github-ci/
+        cd daq-release-code-checks/scripts/github-ci/
         python integtest_xml_parser.py --input-directory ${{ needs.run_unittests.outputs.integtest_log_dir }}
         cat pytest_summary_table.md >> $GITHUB_STEP_SUMMARY
 
@@ -111,5 +104,5 @@ jobs:
     steps:
       - name: Remove test directory and daq-release
         run: |
-          rm -rf ${{ needs.make_variables.outputs.daq_release_path }}
+          rm -rf daq-release-code-checks
           rm -rf ${{ needs.make_variables.outputs.tag }}

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -54,7 +54,7 @@ jobs:
         #./checkout-daq-package.py -p flxlibs -b develop -i ../configs/fddaq/fddaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
     - name: Run unit tests
-      uses: ./.github/workflows/unit-tests.yml
+      uses: ./daq-release-unittests/.github/workflows/unit-tests.yml
       with:
         release_tag: ${{ needs.make_nightly_tag.outputs.tag }}
         daq_release_path: daq-release-unittests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -39,7 +39,7 @@ jobs:
           RELEASE_TYPE="nightly"
         elif [[ "$RELEASE_TAG" == *rc* ]]; then
           RELEASE_TYPE="candidate"
-        elif [[ "$RELEASE_TAG" =~ ^fddaq-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        elif [[ "$RELEASE_TAG" =~ ^fddaq-v[0-9]+\.[0-9]+\.[0-9]+-a9 ]]; then
           RELEASE_TYPE="stable"
         else
           echo "Could not determine release type. Exiting..."

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -45,6 +45,7 @@ jobs:
         else
           echo "Could not determine release type. Please check your spelling."
           exit 1
+        fi
 
         echo "RELEASE_TAG=$RELEASE_TAG" >> $GITHUB_ENV
         echo "RELEASE_TYPE=$RELEASE_TYPE" >> $GITHUB_ENV

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -66,6 +66,7 @@ jobs:
         if [[ "$RELEASE_TYPE" == "nightly" ]]; then
           VERSION_TAG="develop"
         else
+          # To find the correct release manifest, extract vX.Y.Z from the release name
           VERSION_TAG=$(echo "$RELEASE_TAG" | grep -oP 'v[0-9]+\.[0-9]+\.[0-9]+')
         fi
         echo "VERSION_TAG: $VERSION_TAG"
@@ -116,13 +117,13 @@ jobs:
         echo -e "$markdown_content" >> $GITHUB_STEP_SUMMARY
 
   send_slack_message:
-    if: (github.event.inputs.send-slack-message == 'yes')
+    if: (success() || failure()) && (github.event.inputs.send-slack-message == 'yes')
     needs: [run_unittests]
     uses: ./.github/workflows/slack-notification.yml
     with:
       release_tag: ${{ inputs.release_tag }}
     secrets: 
-      slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   cleanup_files:
     if: always()
@@ -133,8 +134,5 @@ jobs:
     steps:
     - name: Remove files
       run: |
-        echo "Where am I? $(pwd)"
-        echo "Contents of RELEASE_TAG: $(ls $RELEASE_TAG)"
         rm -rf $RELEASE_TAG
-        echo "Contents of daq-release-unittests: $(ls ${{ github.workspace }}/daq-release-unittests)"
         rm -rf ${{ github.workspace }}/daq-release-unittests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,6 +7,9 @@ on:
         type: string
         required: true
         description: Name of the release used in the caller workflow.
+      daq_release_path:
+        type: string
+        description: Path to daq-release if it's already checked out
   workflow_dispatch:
     inputs:
       release_tag:
@@ -26,8 +29,7 @@ jobs:
         shell: bash
     steps:
     - name: Checkout daq-release
-      # If this workflow is called, daq-release should already be checked out
-      if: github.event_name == 'workflow_dispatch'
+      if: ${{ !inputs.daq_release_path }}
       uses: actions/checkout@v4
       with:
         path: daq-release-unittests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,9 +7,6 @@ on:
         type: string
         required: true
         description: Name of the release used in the caller workflow.
-      daq_release_path:
-        type: string
-        description: Path to daq-release if it's already checked out
   workflow_dispatch:
     inputs:
       release_tag:
@@ -29,7 +26,6 @@ jobs:
         shell: bash
     steps:
     - name: Checkout daq-release
-      if: ${{ !inputs.daq_release_path }}
       uses: actions/checkout@v4
       with:
         path: daq-release-unittests
@@ -46,7 +42,7 @@ jobs:
         elif [[ "$RELEASE_TAG" =~ ^fddaq-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
           RELEASE_TYPE="stable"
         else
-          echo "Could not determine release type. Please check your spelling."
+          echo "Could not determine release type. Exiting..."
           exit 1
         fi
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,7 +17,6 @@ on:
           description: 'whether to send a message to #daq-release-notifications on completion'
           default: 'no'
 
-
 jobs:
   run_unittests:
     name: Run unit tests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -71,10 +71,10 @@ jobs:
         echo "VERSION_TAG: $VERSION_TAG"
 
         cd ../daq-release-unittests/scripts
-        #./checkout-daq-package.py -i ../configs/coredaq/coredaq-${VERSION_TAG}/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -i ../configs/fddaq/fddaq-${VERSION_TAG}/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-${VERSION_TAG}/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -p flxlibs -b develop -i ../configs/fddaq/fddaq-${VERSION_TAG}/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -i ../configs/coredaq/coredaq-${VERSION_TAG}/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -i ../configs/fddaq/fddaq-${VERSION_TAG}/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-${VERSION_TAG}/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -p flxlibs -b develop -i ../configs/fddaq/fddaq-${VERSION_TAG}/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
     - name: Run unit tests
       run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -60,6 +60,7 @@ jobs:
           dbt-create -b candidate "$RELEASE_TAG"
         else
           dbt-create "$RELEASE_TAG"
+        fi
         cd "$RELEASE_TAG"
         source env.sh
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -125,8 +125,7 @@ jobs:
       slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
 
   cleanup_files:
-    # If this workflow was called, the caller workflow should handle cleanup
-    if: (github.event_name == 'workflow_dispatch')
+    if: always()
     needs: run_unittests
     runs-on: daq
     env:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,6 +26,8 @@ jobs:
         shell: bash
     steps:
     - name: Checkout daq-release
+      # If this workflow is called, daq-release should already be checked out
+      if: github.event_name == 'workflow_dispatch'
       uses: actions/checkout@v4
       with:
         path: daq-release-unittests
@@ -71,10 +73,10 @@ jobs:
         echo "VERSION_TAG: $VERSION_TAG"
 
         cd ../daq-release-unittests/scripts
-        ./checkout-daq-package.py -i ../configs/coredaq/coredaq-${VERSION_TAG}/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -i ../configs/fddaq/fddaq-${VERSION_TAG}/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-${VERSION_TAG}/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -p flxlibs -b develop -i ../configs/fddaq/fddaq-${VERSION_TAG}/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -i ../configs/coredaq/coredaq-${VERSION_TAG}/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -i ../configs/fddaq/fddaq-${VERSION_TAG}/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-${VERSION_TAG}/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -p flxlibs -b develop -i ../configs/fddaq/fddaq-${VERSION_TAG}/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
     - name: Run unit tests
       run: |
@@ -123,3 +125,19 @@ jobs:
       release_tag: ${{ inputs.release_tag }}
     secrets: 
       slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
+
+  cleanup_files:
+    # If this workflow was called, the caller workflow should handle cleanup
+    if: (github.event_name == 'workflow_dispatch')
+    needs: run_unittests
+    runs-on: daq
+    env:
+      RELEASE_TAG: ${{ inputs.release_tag }}
+    steps:
+    - name: Remove files
+      run: |
+        echo "Where am I? $(pwd)"
+        echo "Contents of RELEASE_TAG: $(ls $RELEASE_TAG)"
+        rm -rf $RELEASE_TAG
+        echo "Contents of daq-release-unittests: $(ls ${{ github.workspace }}/daq-release-unittests)"
+        rm -rf ${{ github.workspace }}/daq-release-unittests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -58,7 +58,7 @@ jobs:
         elif [[ "$RELEASE_TYPE" == "candidate" ]]; then
           dbt-create -b candidate "$RELEASE_TAG"
         else
-          dbt-create "$RELEASE_TAG"
+          dbt-create "$RELEASE_TAG" "$RELEASE_TAG"
         fi
         cd "$RELEASE_TAG"
         source env.sh


### PR DESCRIPTION
At a recent release prep meeting, we talked about having a unit test workflow which can run on candidate or stable (aka frozen) releases, similar to the current integration test workflow. This PR factors out the unit testing into a reusable workflow which can be called standalone or as part of the nightly code check workflow. 

One quirk of this implementation is that reusable workflows need to be run in their own job, rather than as a step in a job (if we wanted the latter, we'd need to define this as a local action, not a workflow). This means that the unit test workflow creates its own local development area rather than using the same one as the job which runs linting and integration tests. 

I've tested the workflow in its standalone state using a nightly, candidate, and stable release, as well as part of the nightly code check workflow. 