### PR TITLE
JCF: correct bug where no-longer-set fddaq_tag variable was being use…

### DIFF
--- a/.github/workflows/build-nightly-release-alma9.yml
+++ b/.github/workflows/build-nightly-release-alma9.yml
@@ -164,9 +164,9 @@ jobs:
 
             tar xf ../${DETECTOR_TAG}.tar.gz
             rm -rf ../${DETECTOR_TAG}.tar.gz
-            #test "${NIGHTLY_TAG:0:1}" == "_" && ln -s ${fddaq_tag} last_fddaq
+
             if [[ "${DETECTOR_TAG}" == NFD_* ]]; then
-              ln -s ${fddaq_tag} last_fddaq
+              ln -s ${DETECTOR_TAG} last_fddaq
             fi
 
             cd ..


### PR DESCRIPTION
…d in a softlink, breaking the nightly