### PR TITLE
Amogan/checkout pymodules to sourcecode so they're available in `DUNE_DAQ_RELEASE_SOURCE`

### DIFF
--- a/.github/workflows/build-candidate-release-alma9.yml
+++ b/.github/workflows/build-candidate-release-alma9.yml
@@ -60,7 +60,7 @@ jobs:
           export OS=almalinux9
           source daq-release/.github/workflows/wf-setup-tools.sh
 
-          daq-release/scripts/checkout-daq-package.py -i daq-release/configs/fddaq/fddaq-${{ github.event.inputs.det-release }}/release.yaml -a -c -o $DET_RELEASE_DIR/sourcecode
+          daq-release/scripts/checkout-daq-package.py -i daq-release/configs/fddaq/fddaq-${{ github.event.inputs.det-release }}/release.yaml -a -c -o $DET_RELEASE_DIR/sourcecode --pymodules
           daq-release/scripts/spack/build-release.sh $BASE_RELEASE_DIR $DET_RELEASE_DIR $DET $OS
 
           cd $DET_RELEASE_DIR/..

--- a/.github/workflows/build-nightly-release-alma9.yml
+++ b/.github/workflows/build-nightly-release-alma9.yml
@@ -86,8 +86,7 @@ jobs:
         input_feature_branch=${{ github.event.inputs.feature-branch }}
         # For automatically triggered workflows where feature-branch is not set, fall back to default branch
         branch=${input_feature_branch:-"develop"}
-        #daq-release/scripts/checkout-daq-package.py -i daq-release/configs/coredaq/coredaq-develop/release.yaml -a -o $DET_RELEASE_DIR/sourcecode -b $branch
-        daq-release/scripts/checkout-daq-package.py -i daq-release/configs/coredaq/coredaq-develop/release.yaml -a -o $DET_RELEASE_DIR/sourcecode -b $branch
+        daq-release/scripts/checkout-daq-package.py -i daq-release/configs/coredaq/coredaq-develop/release.yaml -a -o $DET_RELEASE_DIR/sourcecode -b $branch --pymodules
         daq-release/scripts/spack/build-release.sh $BASE_RELEASE_DIR $DET_RELEASE_DIR core $OS ${{ github.event.inputs.feature-branch }}
 
         cd $BASE_RELEASE_DIR/../
@@ -105,7 +104,7 @@ jobs:
         input_feature_branch=${{ github.event.inputs.feature-branch }}
         # For automatically triggered workflows where feature-branch is not set, fall back to default branch
         branch=${input_feature_branch:-"develop"}
-        daq-release/scripts/checkout-daq-package.py -i daq-release/configs/fddaq/fddaq-develop/release.yaml -a -o $DET_RELEASE_DIR/sourcecode -b $branch
+        daq-release/scripts/checkout-daq-package.py -i daq-release/configs/fddaq/fddaq-develop/release.yaml -a -o $DET_RELEASE_DIR/sourcecode -b $branch --pymodules
         daq-release/scripts/spack/build-release.sh $BASE_RELEASE_DIR $DET_RELEASE_DIR fd $OS ${{ github.event.inputs.feature-branch }}
 
         cd $DET_RELEASE_DIR/../

--- a/.github/workflows/build-nightly-release-alma9.yml
+++ b/.github/workflows/build-nightly-release-alma9.yml
@@ -86,7 +86,7 @@ jobs:
         input_feature_branch=${{ github.event.inputs.feature-branch }}
         # For automatically triggered workflows where feature-branch is not set, fall back to default branch
         branch=${input_feature_branch:-"develop"}
-        daq-release/scripts/checkout-daq-package.py -i daq-release/configs/coredaq/coredaq-develop/release.yaml -a -o $DET_RELEASE_DIR/sourcecode -b $branch --pymodules
+        daq-release/scripts/checkout-daq-package.py -i daq-release/configs/coredaq/coredaq-develop/release.yaml -a -o $DET_RELEASE_DIR/sourcecode -b $branch
         daq-release/scripts/spack/build-release.sh $BASE_RELEASE_DIR $DET_RELEASE_DIR core $OS ${{ github.event.inputs.feature-branch }}
 
         cd $BASE_RELEASE_DIR/../

--- a/.github/workflows/build-stable-release-alma9.yml
+++ b/.github/workflows/build-stable-release-alma9.yml
@@ -60,7 +60,7 @@ jobs:
           export OS=almalinux9
           source daq-release/.github/workflows/wf-setup-tools.sh
 
-          daq-release/scripts/checkout-daq-package.py -i daq-release/configs/fddaq/fddaq-${{ github.event.inputs.det-release }}/release.yaml -a -c -o $DET_RELEASE_DIR/sourcecode
+          daq-release/scripts/checkout-daq-package.py -i daq-release/configs/fddaq/fddaq-${{ github.event.inputs.det-release }}/release.yaml -a -c -o $DET_RELEASE_DIR/sourcecode --pymodules
           daq-release/scripts/spack/build-release.sh $BASE_RELEASE_DIR $DET_RELEASE_DIR $DET $OS
 
           cd $DET_RELEASE_DIR/..


### PR DESCRIPTION
With #470 implemented, this PR just adds the `--pymodules` option to the `checkout-daq-package.py` calls in the detector release steps of the nightly, candidate, and stable builds. This makes them available in `DUNE_DAQ_RELEASE_SOURCE`. The test build `PYFD_DEV_250714_A9` shows this:
```
source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-setup-release -n PYFD_DEV_250714_A9
ls $DUNE_DAQ_RELEASE_SOURCE
```
In the last command, you'll see `drunc`, `druncschema`, etc.