### PR TITLE
JCF: add tpreplay_test to the standard suite of nightly integration t…

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -91,6 +91,7 @@ jobs:
                         "minimal_system_quick_test",
                         "readout_type_scan",
                         "small_footprint_quick_test",
+                        "tpreplay_test",
                         "tpstream_writing_test"
                        ]
     defaults:


### PR DESCRIPTION
…ests

Successful integration tests with this branch can be found here: https://github.com/DUNE-DAQ/daq-release/actions/runs/16728489853