### PR TITLE
JCF: in light of my findings in DUNE-DAQ/dbe#46, make sure to refresh…

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -97,8 +97,8 @@ jobs:
       run: |
         cd $DBT_AREA_ROOT/
         source env.sh
-        dbt-workarea-env
         spack load dbe
+        dbt-workarea-env
         dbt-build --unittest
         log_summary_file=$(ls $DBT_AREA_ROOT/log/unit_tests_*/*_summary.log)
         ../daq-release-unittests/scripts/github-ci/parse_unit_test_summary.sh $log_summary_file | tee $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
… the environment if spack load dbe is run

As described in DUNE-DAQ/dbe#46, one of the `dbe` unit tests fails if `spack load dbe` is run but `dbt-workarea-env` isn't used to refresh the environment. This PR accounts for that. 

Notice that all dbe unit tests pass with this change, https://github.com/DUNE-DAQ/daq-release/actions/runs/17133597478