### PR TITLE
Add pymodules functionality to `run-workflow-action.sh`

### DIFF
--- a/scripts/github-ci/repo.sh
+++ b/scripts/github-ci/repo.sh
@@ -14,8 +14,10 @@ fi
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 packages_with_ci_single_string=$( $SCRIPT_DIR/../list_packages.py $DEVLINE coredaq )" "$( $SCRIPT_DIR/../list_packages.py $DEVLINE fddaq )  #" "$( $SCRIPT_DIR/../list_packages.py $DEVLINE nddaq )
+dune_pymodules_single_string=$( $SCRIPT_DIR/../list_packages.py $DEVLINE pymodules )
 
 read -r -a dune_packages_with_ci <<< $packages_with_ci_single_string
+read -r -a dune_pymodules <<< $dune_pymodules_single_string
 
 dune_packages=(
   "${dune_packages_with_ci[@]}"

--- a/scripts/github-ci/run-workflow-action.sh
+++ b/scripts/github-ci/run-workflow-action.sh
@@ -1,17 +1,33 @@
 #!/bin/bash
 
-if (( $# != 3 )); then
-    echo "Usage: $( basename $0 ) <production_v4 or develop> <workflow_file_name> <sync, trigger, or disable>" >&2
+usage() {
+    echo "Usage: $(basename "$0") <production_v4|develop> <workflow_file_name> <sync|trigger|disable> [--pymodules]" >&2
     exit 1
-fi
+}
 
-export DEVLINE=$1
+[[ $# -lt 3 || $# -gt 4 ]] && usage
+
+DEVLINE=$1
 workflow_file=$2
 action=$3
+run_pymodules=false
+
+if [[ "${4:-}" == "--pymodules" ]]; then
+    run_pymodules=true
+elif [[ -n "${4:-}" ]]; then
+    echo "Unknown flag '$4' (expected --pymodules)" >&2
+    exit 2
+fi
 
 # Store list of packages from repo.sh as dune_packages_with_ci
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source $SCRIPT_DIR/repo.sh || exit $?
+
+if [[ "$run_pymodules" == "true" ]]; then
+    packages_to_run=( "${dune_packages_with_ci[@]}" "${dune_pymodules[@]}" )
+else
+    packages_to_run=( "${dune_packages_with_ci[@]}" )
+fi
 
 if [[ $DEVLINE == "develop" && "$workflow_file" == *v4* ]]; then
     echo "ERROR: $workflow_file is not a develop-line workflow." >&2
@@ -36,18 +52,19 @@ if ! echo "$existing_workflow_templates" | grep -xq "${workflow_file}"; then
     exit 6
 fi
 
-read -p "This action will $action the workflow $workflow_file in all ${#dune_packages_with_ci[@]} packages in the $DEVLINE line. Proceed? (y/N): " response
-if [[ "$response" != "y" && "$response" != "Y" ]]; then
-    echo "Action canceled."
-    exit 7
+extra_info=""
+if [[ "$run_pymodules" == "true" ]]; then
+    extra_info=", including ${#dune_pymodules[@]} Python packages"
 fi
+read -r -p "This action will $action the workflow $workflow_file in ${#packages_to_run[@]} packages$extra_info. Proceed? (y/N): " response
+[[ "$response" != "y" && "$response" != "Y" ]] && { echo "Action canceled."; exit 7; }
 
 if [[ $action == "sync" ]]; then
     source $SCRIPT_DIR/sync-ci-workflow-to-template.sh
-    git_checkout_and_update_ci dune_packages_with_ci $workflow_file
+    git_checkout_and_update_ci packages_to_run $workflow_file
 elif [[ $action == "trigger" || $action == "disable" ]]; then
     source $SCRIPT_DIR/trigger-or-disable-ci-all.sh
-    trigger_or_disable_ci_all dune_packages_with_ci $workflow_file $action
+    trigger_or_disable_ci_all packages_to_run $workflow_file $action
 else
     echo "WARNING: No action taken. If this is unexpected, check your syntax or contact software coordination."
 fi

--- a/scripts/github-ci/run-workflow-action.sh
+++ b/scripts/github-ci/run-workflow-action.sh
@@ -24,40 +24,36 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source $SCRIPT_DIR/repo.sh || exit $?
 
 if [[ "$run_pymodules" == "true" ]]; then
-    packages_to_run=( "${dune_packages_with_ci[@]}" "${dune_pymodules[@]}" )
+    packages_to_run=( "${dune_pymodules[@]}" )
 else
     packages_to_run=( "${dune_packages_with_ci[@]}" )
 fi
 
 if [[ $DEVLINE == "develop" && "$workflow_file" == *v4* ]]; then
     echo "ERROR: $workflow_file is not a develop-line workflow." >&2
-    exit 2
+    exit 3
 elif [[ $DEVLINE == "production_v4" && "$workflow_file" != *v4* ]]; then
     echo "ERROR: $workflow_file is not a production_v4 workflow." >&2
-    exit 3
+    exit 4
 fi
 if [[ $action != "sync" && $action != "trigger" && $action != "disable" ]]; then
     echo "ERROR: $action is not a valid action argument. Available options are sync, trigger, or disable" >&2
-    exit 4
+    exit 5
 fi
 
 tmp_dir=$(mktemp -d -t cvmfs_dunedaq_release_XXXXXXXXXX)
 pushd $tmp_dir
 
-git clone https://github.com/DUNE-DAQ/.github.git || exit 5
+git clone https://github.com/DUNE-DAQ/.github.git || exit 6
 existing_workflow_templates=$(ls .github/workflow-templates/*.yml | xargs -n 1 basename)
 if ! echo "$existing_workflow_templates" | grep -xq "${workflow_file}"; then
     echo "ERROR: $workflow_file is not a valid workflow file name. The available options are:" >&2
     echo $existing_workflow_templates >&2
-    exit 6
+    exit 7
 fi
 
-extra_info=""
-if [[ "$run_pymodules" == "true" ]]; then
-    extra_info=", including ${#dune_pymodules[@]} Python packages"
-fi
-read -r -p "This action will $action the workflow $workflow_file in ${#packages_to_run[@]} packages$extra_info. Proceed? (y/N): " response
-[[ "$response" != "y" && "$response" != "Y" ]] && { echo "Action canceled."; exit 7; }
+read -r -p "This action will $action the workflow $workflow_file in ${#packages_to_run[@]} packages. Proceed? (y/N): " response
+[[ "$response" != "y" && "$response" != "Y" ]] && { echo "Action canceled."; exit 8; }
 
 if [[ $action == "sync" ]]; then
     source $SCRIPT_DIR/sync-ci-workflow-to-template.sh
@@ -69,5 +65,5 @@ else
     echo "WARNING: No action taken. If this is unexpected, check your syntax or contact software coordination."
 fi
 
-popd
+popd > /dev/null
 rm -rf $tmp_dir

--- a/scripts/github-ci/sync-ci-workflow-to-template.sh
+++ b/scripts/github-ci/sync-ci-workflow-to-template.sh
@@ -18,15 +18,25 @@ function git_checkout_and_update_ci {
   for repo in "${repo_list[@]}"; do
     irepo_arr=(${repo})
     repo_name=${irepo_arr[0]//_/-}
+    if [[ "$repo_name" == "elisa-client-api" ]]; then
+      repo_name="elisa_client_api"
+    fi
     echo "--------------------------------------------------------------"
     echo "********************* $repo_name *****************************"
-    git clone --quiet https://github.com/DUNE-DAQ/${repo_name}.git -b $branch || exit 3
-    pushd ${repo_name}
+    git clone --quiet https://github.com/DUNE-DAQ/${repo_name}.git -b "$branch" || exit 3
+    pushd "${repo_name}"
     mkdir -p .github/workflows
-    cp $src_workflow_file .github/workflows/$dest_workflow_file
-    git add .github/workflows
-    git commit -am "Syncing .github/workflows/$(basename $dest_workflow_file)"
-    git push --quiet || exit 4
+    if diff -q "$src_workflow_file" ".github/workflows/$dest_workflow_file" > /dev/null; then
+      echo "The workflow "$dest_workflow_file" in "$repo_name" is already up to date; continuing..."
+      popd
+      continue
+    fi
+    echo "Would overwrite $dest_workflow_file in $repo_name"
+    #cp "$src_workflow_file" ".github/workflows/$dest_workflow_file"
+    #git add .github/workflows
+    #git commit -am "Syncing .github/workflows/$(basename $dest_workflow_file)"
+    #git push --quiet || exit 4
     popd
   done
+  echo "Sync complete"
 }

--- a/scripts/github-ci/sync-ci-workflow-to-template.sh
+++ b/scripts/github-ci/sync-ci-workflow-to-template.sh
@@ -24,19 +24,18 @@ function git_checkout_and_update_ci {
     echo "--------------------------------------------------------------"
     echo "********************* $repo_name *****************************"
     git clone --quiet https://github.com/DUNE-DAQ/${repo_name}.git -b "$branch" || exit 3
-    pushd "${repo_name}"
+    pushd "${repo_name}" > /dev/null
     mkdir -p .github/workflows
     if diff -q "$src_workflow_file" ".github/workflows/$dest_workflow_file" > /dev/null; then
       echo "The workflow "$dest_workflow_file" in "$repo_name" is already up to date; continuing..."
-      popd
+      popd > /dev/null
       continue
     fi
-    echo "Would overwrite $dest_workflow_file in $repo_name"
-    #cp "$src_workflow_file" ".github/workflows/$dest_workflow_file"
-    #git add .github/workflows
-    #git commit -am "Syncing .github/workflows/$(basename $dest_workflow_file)"
-    #git push --quiet || exit 4
-    popd
+    cp "$src_workflow_file" ".github/workflows/$dest_workflow_file"
+    git add .github/workflows
+    git commit -am "Sync .github/workflows/$(basename $dest_workflow_file)"
+    git push --quiet || exit 4
+    popd > /dev/null
   done
   echo "Sync complete"
 }

--- a/scripts/github-ci/sync-ci-workflow-to-template.sh
+++ b/scripts/github-ci/sync-ci-workflow-to-template.sh
@@ -31,10 +31,12 @@ function git_checkout_and_update_ci {
       popd > /dev/null
       continue
     fi
+    echo "Syncing $dest_workflow_file..."
     cp "$src_workflow_file" ".github/workflows/$dest_workflow_file"
     git add .github/workflows
     git commit -am "Sync .github/workflows/$(basename $dest_workflow_file)"
     git push --quiet || exit 4
+    echo "Done"
     popd > /dev/null
   done
   echo "Sync complete"


### PR DESCRIPTION
The current version of `run-workflow-action.sh` only works on packages under the `coredaq` and `fddaq` umbrellas. In preparation for standardizing python packages, this PR adds pymodules functionality to that script. Now, any time `repo.sh` is sourced, you'll have access to `dune_pymodules`, an array of the available python packages output by `scripts/list_packages.py develop pymodules`. You can then pass `--pymodules` as an optional argument to `run-workflow-action.sh` to run the action over python packages instead of core/fddaq packages. Other changes:
- `sync-ci-workflow-to-template.sh` will now run `diff` on the source and destination workflow files. If there's no difference, it continues to the next package without running git commands. This will reduce the number of superfluous commits across packages whose workflows are already updated.
- Silenced the output of `pushd` and `popd` and added output of whether each repo's workflow is being synced
- Bespoke logic for `elisa_client_api`, yet again

I tested this by commenting the git commands in `sync-ci-workflow-to-template.sh` and running with various combinations of arguments. 

Note for the near future: once we decide on a standard list of python-specific workflows, we may want to consider a way to prevent python workflows from accidentally being copied to C++/hybrid packages, and vice versa. 