### PR TITLE
Script for syncing issue forms across repos

### DIFF
--- a/scripts/github-ci/repo.sh
+++ b/scripts/github-ci/repo.sh
@@ -14,10 +14,14 @@ fi
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 packages_with_ci_single_string=$( $SCRIPT_DIR/../list_packages.py $DEVLINE coredaq )" "$( $SCRIPT_DIR/../list_packages.py $DEVLINE fddaq )  #" "$( $SCRIPT_DIR/../list_packages.py $DEVLINE nddaq )
+coredaq_packages_single_string=$( $SCRIPT_DIR/../list_packages.py $DEVLINE coredaq )
+fddaq_packages_single_string=$( $SCRIPT_DIR/../list_packages.py $DEVLINE fddaq )
 dune_pymodules_single_string=$( $SCRIPT_DIR/../list_packages.py $DEVLINE pymodules )
 
 read -r -a dune_packages_with_ci <<< $packages_with_ci_single_string
 read -r -a dune_pymodules <<< $dune_pymodules_single_string
+read -r -a coredaq_packages <<< $coredaq_packages_single_string
+read -r -a fddaq_packages <<< $fddaq_packages_single_string
 
 dune_packages=(
   "${dune_packages_with_ci[@]}"

--- a/scripts/github-ci/sync-issue-form.sh
+++ b/scripts/github-ci/sync-issue-form.sh
@@ -30,6 +30,15 @@ case "$arg" in
   all)
     repo_list=( "${coredaq_packages[@]}" "${fddaq_packages[@]}" "${python_packages[@]}" )
     ;;
+  coredaq)
+    repo_list=( "${coredaq_packages[@]}" )
+    ;;
+  fddaq)
+    repo_list=( "${fddaq_packages[@]}" )
+    ;;
+  pymodules)
+    repo_list=( "${dune_pymodules[@]}" )
+    ;;
   *)
     echo "INFO: interpreting $arg as the name of a single repo name since it doesn't match an umbrella name."
     repo_list=( "$arg" )
@@ -39,7 +48,7 @@ esac
 tmp_dir=$(mktemp -d -t cvmfs_dunedaq_release_XXXXXXXXXX)
 pushd $tmp_dir
 
-git clone https://github.com/DUNE-DAQ/.github.git dunedaq_github || exit 6
+git clone https://github.com/DUNE-DAQ/.github.git dunedaq_github || exit 2
 
 ORG="DUNE-DAQ"
 for REPO in "${repo_list[@]}"; do

--- a/scripts/github-ci/sync-issue-form.sh
+++ b/scripts/github-ci/sync-issue-form.sh
@@ -40,7 +40,6 @@ src_issue_dir=$(readlink -f dunedaq_github/issue-templates)
 
 ORG="DUNE-DAQ"
 for REPO in "${repo_list[@]}"; do
-    echo "REPO: $REPO..."
     if [[ "$REPO" == "elisa-client-api" ]]; then
       REPO="elisa_client_api"
     fi
@@ -54,22 +53,25 @@ for REPO in "${repo_list[@]}"; do
       echo "$REPO has its own issue forms, so will sync from $src_issue_dir"
     fi
     dest_issue_dir=".github/ISSUE_TEMPLATE"
-    mkdir -p .github/ISSUE_TEMPLATE
+    mkdir -p "$dest_issue_dir"
     if diff -rq "$src_issue_dir" "$dest_issue_dir" > /dev/null; then
       echo "The issue forms in "$repo_name" are already up to date; continuing..."
       popd > /dev/null
       continue
     fi
     echo "Copying contents of $src_issue_dir into $(pwd)/${dest_issue_dir}"
-    cp "$src_issue_dir"/* "$dest_issue_dir"
+    echo "LS:"
+    ls "$src_issue_dir"/*
+    cp "$src_issue_dir"/*.yml "$dest_issue_dir"
     git status
     git add "$dest_issue_dir"
     git status
-    git commit -am "Sync issue form templates"
-    git push --quiet || exit 4
+    #git commit -am "Sync issue form templates"
+    #git push --quiet || exit 4
     echo "Done with $REPO"
     popd > /dev/null
 done
 
 popd > /dev/null
+rm -rf $tmp_dir
 echo "Done"

--- a/scripts/github-ci/sync-issue-form.sh
+++ b/scripts/github-ci/sync-issue-form.sh
@@ -3,11 +3,15 @@
 set -euo pipefail
 
 usage() {
-    echo "Usage: $0 <repo_list>"
-    echo
-    echo "Arguments:"
-    echo "  repo_list    : Repository or repositories in which to sync the issue form. Use 'all' to sync issue forms in all repos, or a single repo name (e.g., 'trigger')."
-    exit 1
+  local prog=$(basename $0)
+  cat <<EOF
+Usage: $prog <repo_list>
+
+Arguments:
+  repo_list: Repository or repositories in which to sync the issue form. 
+             Use 'all' to sync issue forms in all repos, or a single repo name (e.g., 'trigger').
+EOF
+  exit 1
 }
 
 if [[ $# -eq 0 || $# -gt 1 ]]; then
@@ -35,8 +39,7 @@ esac
 tmp_dir=$(mktemp -d -t cvmfs_dunedaq_release_XXXXXXXXXX)
 pushd $tmp_dir
 
-git clone https://github.com/DUNE-DAQ/.github.git -b amogan/new_templates dunedaq_github || exit 6
-src_issue_dir=$(readlink -f dunedaq_github/issue-templates)
+git clone https://github.com/DUNE-DAQ/.github.git dunedaq_github || exit 6
 
 ORG="DUNE-DAQ"
 for REPO in "${repo_list[@]}"; do
@@ -47,27 +50,24 @@ for REPO in "${repo_list[@]}"; do
     echo "********************* $REPO *****************************"
     git clone --quiet https://github.com/${ORG}/${REPO}.git || exit 3
     pushd "${REPO}" > /dev/null
+
+    src_issue_dir=$(readlink -f ../dunedaq_github/issue-templates)
     if [[ -d "${src_issue_dir}/${REPO}" ]]; then
-      readlink -f ../dunedaq_github/issue-templates/$REPO
       src_issue_dir="$(readlink -f ../dunedaq_github/issue-templates/$REPO)"
-      echo "$REPO has its own issue forms, so will sync from $src_issue_dir"
+      echo "Syncing custom issue forms for $REPO..."
     fi
+
     dest_issue_dir=".github/ISSUE_TEMPLATE"
     mkdir -p "$dest_issue_dir"
     if diff -rq "$src_issue_dir" "$dest_issue_dir" > /dev/null; then
-      echo "The issue forms in "$repo_name" are already up to date; continuing..."
+      echo "The issue forms in "$REPO" are already up to date; continuing..."
       popd > /dev/null
       continue
     fi
-    echo "Copying contents of $src_issue_dir into $(pwd)/${dest_issue_dir}"
-    echo "LS:"
-    ls "$src_issue_dir"/*
     cp "$src_issue_dir"/*.yml "$dest_issue_dir"
-    git status
     git add "$dest_issue_dir"
-    git status
-    #git commit -am "Sync issue form templates"
-    #git push --quiet || exit 4
+    git commit -am "Sync issue form templates"
+    git push --quiet || exit 4
     echo "Done with $REPO"
     popd > /dev/null
 done

--- a/scripts/github-ci/sync-issue-form.sh
+++ b/scripts/github-ci/sync-issue-form.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 <repo_list>"
+    echo
+    echo "Arguments:"
+    echo "  repo_list    : Repository or repositories in which to sync the issue form. Use 'all' to sync issue forms in all repos, or a single repo name (e.g., 'trigger')."
+    exit 1
+}
+
+if [[ $# -eq 0 || $# -gt 1 ]]; then
+    usage
+fi
+
+# Need to set DEVLINE before sourcing repo.sh, even though it's not used here
+export DEVLINE="develop"
+
+# Get list of repos in coredaq, fddaq, and pymodules
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source $SCRIPT_DIR/repo.sh
+
+arg="$1"
+case "$arg" in
+  all)
+    repo_list=( "${coredaq_packages[@]}" "${fddaq_packages[@]}" "${python_packages[@]}" )
+    ;;
+  *)
+    echo "INFO: interpreting $arg as the name of a single repo name since it doesn't match an umbrella name."
+    repo_list=( "$arg" )
+    ;;
+esac
+
+tmp_dir=$(mktemp -d -t cvmfs_dunedaq_release_XXXXXXXXXX)
+pushd $tmp_dir
+
+git clone https://github.com/DUNE-DAQ/.github.git -b amogan/new_templates dunedaq_github || exit 6
+src_issue_dir=$(readlink -f dunedaq_github/issue-templates)
+# Allow for individual repos to have their own set of forms to sync, separate from the generic ones
+special_cases=($(ls -d $src_issue_dir/*/ | tr "/" " "))
+echo "ls of source dir: $(ls $src_issue_dir)"
+echo "Found special cases: ${special_cases[@]}"
+
+ORG="andrewmogan"
+for REPO in "${repo_list[@]}"; do
+    echo "REPO: $REPO..."
+    if [[ "$REPO" == "elisa-client-api" ]]; then
+      REPO="elisa_client_api"
+    fi
+    echo "--------------------------------------------------------------"
+    echo "********************* $REPO *****************************"
+    git clone --quiet https://github.com/${ORG}/${REPO}.git || exit 3
+    pushd "${REPO}" > /dev/null
+    if [[ -d ${src_issue_dir}/${REPO} ]];
+      src_issue_dir=$(readlink -f dunedaq_github/issue-templates/$REPO)
+      echo "$REPO has its own issue forms, so will sync from"
+    fi
+    dest_issue_dir=".github/ISSUE_TEMPLATE"
+    mkdir -p .github/ISSUE_TEMPLATE
+    if diff -rq "$src_issue_dir" "$dest_issue_dir" > /dev/null; then
+      echo "The issue forms in "$repo_name" are already up to date; continuing..."
+      popd > /dev/null
+      continue
+    fi
+    echo "Copying contents of $src_issue_dir into $(pwd)/${dest_issue_dir}"
+    cp "$src_issue_dir"/* "$dest_issue_dir"
+    git status
+    git add "$dest_issue_dir"
+    git status
+    #git commit -am "Sync issue form templates"
+    #git push --quiet || exit 4
+    echo "Done with $REPO"
+    popd > /dev/null
+done
+
+popd > /dev/null
+echo "Done"

--- a/scripts/github-ci/sync-issue-form.sh
+++ b/scripts/github-ci/sync-issue-form.sh
@@ -37,12 +37,8 @@ pushd $tmp_dir
 
 git clone https://github.com/DUNE-DAQ/.github.git -b amogan/new_templates dunedaq_github || exit 6
 src_issue_dir=$(readlink -f dunedaq_github/issue-templates)
-# Allow for individual repos to have their own set of forms to sync, separate from the generic ones
-special_cases=($(ls -d $src_issue_dir/*/ | tr "/" " "))
-echo "ls of source dir: $(ls $src_issue_dir)"
-echo "Found special cases: ${special_cases[@]}"
 
-ORG="andrewmogan"
+ORG="DUNE-DAQ"
 for REPO in "${repo_list[@]}"; do
     echo "REPO: $REPO..."
     if [[ "$REPO" == "elisa-client-api" ]]; then
@@ -52,9 +48,10 @@ for REPO in "${repo_list[@]}"; do
     echo "********************* $REPO *****************************"
     git clone --quiet https://github.com/${ORG}/${REPO}.git || exit 3
     pushd "${REPO}" > /dev/null
-    if [[ -d ${src_issue_dir}/${REPO} ]];
-      src_issue_dir=$(readlink -f dunedaq_github/issue-templates/$REPO)
-      echo "$REPO has its own issue forms, so will sync from"
+    if [[ -d "${src_issue_dir}/${REPO}" ]]; then
+      readlink -f ../dunedaq_github/issue-templates/$REPO
+      src_issue_dir="$(readlink -f ../dunedaq_github/issue-templates/$REPO)"
+      echo "$REPO has its own issue forms, so will sync from $src_issue_dir"
     fi
     dest_issue_dir=".github/ISSUE_TEMPLATE"
     mkdir -p .github/ISSUE_TEMPLATE
@@ -68,8 +65,8 @@ for REPO in "${repo_list[@]}"; do
     git status
     git add "$dest_issue_dir"
     git status
-    #git commit -am "Sync issue form templates"
-    #git push --quiet || exit 4
+    git commit -am "Sync issue form templates"
+    git push --quiet || exit 4
     echo "Done with $REPO"
     popd > /dev/null
 done


### PR DESCRIPTION
This PR adds the script `scripts/github-ci/sync-issue-form.sh` which will copy issue form templates from the org-level `.github` into each individual repo. Note that this depends on the merging of [DUNE-DAQ/.github Issue #7](https://github.com/DUNE-DAQ/.github/pull/7), and should not be merged until that PR is resolved.

This also modifies `repo.sh` to now set separate `coredaq_packages` and `fddaq_packages` arrays. 

If the maintainers of a repo want to make custom forms, we can add them in a subdirectory in the org-level `.github/issue-templates`. In the meantime, you can test the functionality using the feature branch `amogan/new_templates`, which is based on Wes' `wketchum/new_templates` but with added subdirectories for `dfmodules` and `confmodel` to simulate custom forms for specific repos. I forked both `dfmodules` and `confmodel` so I could test without accidentally pushing to `develop`. If doing something similar, note that you'll want to add a `-b amogan/new_templates` to
```
git clone https://github.com/DUNE-DAQ/.github.git dunedaq_github || exit 2
```
and change the line
```
ORG="DUNE-DAQ"
```
to suit your case. 

Another case to keep in mind is `hdf5libs`, where Kurt's already added issue forms for testing. I assume we'll want to remove those in favor of the upstream forms we eventually settle on, but we should check just in case.