### PR TITLE
JCF: DUNE-DAQ/daq-deliverables#198: connectivity-service name has bee…

### DIFF
--- a/scripts/spack/mappings.py
+++ b/scripts/spack/mappings.py
@@ -16,5 +16,4 @@ cmake_to_spack = {
 
 pyvenv_url_names = {
     "elisa-client-api": {"repo_name": "elisa_client_api"},
-    "connectivityserver": {"egg_name": "connection-service"},
 }

--- a/scripts/version_surveys/pyproject.toml
+++ b/scripts/version_surveys/pyproject.toml
@@ -11,7 +11,7 @@ click = ">=8.1.7"
 click-didyoumean = ">=0.3.0"
 click-shell = ">=2.1"
 colorama = ">=0.4.4"
-connection-service = {git = "https://github.com/DUNE-DAQ/connectivityserver.git"}
+connectivityserver = {git = "https://github.com/DUNE-DAQ/connectivityserver.git"}
 daq-assettools = {git = "https://github.com/DUNE-DAQ/daq-assettools"}
 deepdiff = ">=6.3.1"
 drunc = {git = "https://github.com/DUNE-DAQ/drunc"}


### PR DESCRIPTION
…n changed to the name of its repo, connectivityserver