### PR TITLE
JCF: DUNE-DAQ/drunc#678: remove DUNEDAQ_DB_PATH from the daq_app_rte.…

### DIFF
--- a/.github/workflows/build-candidate-release-alma9.yml
+++ b/.github/workflows/build-candidate-release-alma9.yml
@@ -175,7 +175,7 @@ jobs:
           dbt-setup-release -b candidate ${{ github.event.inputs.det }}daq-${{ github.event.inputs.det-release }}-rc${{ github.event.inputs.build-number }}-a9
           declare -x > ${GITHUB_WORKSPACE}/${DET}daq-dbt-setup-release-env.sh
           declare -f >> ${GITHUB_WORKSPACE}/${DET}daq-dbt-setup-release-env.sh
-          egrep "declare -x (PATH|.*_SHARE|CET_PLUGIN_PATH|DUNEDAQ_SHARE_PATH|LD_LIBRARY_PATH|LIBRARY_PATH|PYTHONPATH|DUNEDAQ_DB_PATH)=" ${GITHUB_WORKSPACE}/${DET}daq-dbt-setup-release-env.sh > ${GITHUB_WORKSPACE}/${DET}daq_app_rte.sh
+          egrep "declare -x (PATH|.*_SHARE|CET_PLUGIN_PATH|DUNEDAQ_SHARE_PATH|LD_LIBRARY_PATH|LIBRARY_PATH|PYTHONPATH)=" ${GITHUB_WORKSPACE}/${DET}daq-dbt-setup-release-env.sh > ${GITHUB_WORKSPACE}/${DET}daq_app_rte.sh
 
 
     - name: upload ${{ github.event.inputs.det }}daq-dbt-setup-release-env.sh

--- a/.github/workflows/build-nightly-release-alma9.yml
+++ b/.github/workflows/build-nightly-release-alma9.yml
@@ -224,7 +224,7 @@ jobs:
           dbt-setup-release -n ${DETECTOR_TAG}
           declare -x > ${GITHUB_WORKSPACE}/${DET}daq-dbt-setup-release-env.sh
           declare -f >> ${GITHUB_WORKSPACE}/${DET}daq-dbt-setup-release-env.sh
-          egrep "declare -x (PATH|.*_SHARE|CET_PLUGIN_PATH|DUNEDAQ_SHARE_PATH|LD_LIBRARY_PATH|LIBRARY_PATH|PYTHONPATH|DUNEDAQ_DB_PATH)=" ${GITHUB_WORKSPACE}/${DET}daq-dbt-setup-release-env.sh > ${GITHUB_WORKSPACE}/${DET}daq_app_rte.sh
+          egrep "declare -x (PATH|.*_SHARE|CET_PLUGIN_PATH|DUNEDAQ_SHARE_PATH|LD_LIBRARY_PATH|LIBRARY_PATH|PYTHONPATH)=" ${GITHUB_WORKSPACE}/${DET}daq-dbt-setup-release-env.sh > ${GITHUB_WORKSPACE}/${DET}daq_app_rte.sh
 
     - name: upload fddaq-dbt-setup-release-env.sh
       uses: actions/upload-artifact@v5

--- a/.github/workflows/build-stable-release-alma9.yml
+++ b/.github/workflows/build-stable-release-alma9.yml
@@ -176,7 +176,7 @@ jobs:
           dbt-setup-release ${DET}daq-${{ github.event.inputs.det-release }}-a9
           declare -x > ${GITHUB_WORKSPACE}/${DET}daq-dbt-setup-release-env.sh
           declare -f >> ${GITHUB_WORKSPACE}/${DET}daq-dbt-setup-release-env.sh
-          egrep "declare -x (PATH|.*_SHARE|CET_PLUGIN_PATH|DUNEDAQ_SHARE_PATH|LD_LIBRARY_PATH|LIBRARY_PATH|PYTHONPATH|DUNEDAQ_DB_PATH)=" ${GITHUB_WORKSPACE}/${DET}daq-dbt-setup-release-env.sh > ${GITHUB_WORKSPACE}/${DET}daq_app_rte.sh
+          egrep "declare -x (PATH|.*_SHARE|CET_PLUGIN_PATH|DUNEDAQ_SHARE_PATH|LD_LIBRARY_PATH|LIBRARY_PATH|PYTHONPATH)=" ${GITHUB_WORKSPACE}/${DET}daq-dbt-setup-release-env.sh > ${GITHUB_WORKSPACE}/${DET}daq_app_rte.sh
 
 
     - name: upload ${{ github.event.inputs.det }}daq-dbt-setup-release-env.sh


### PR DESCRIPTION
…sh file produced in our builds

This is meant to address the concerns Marco raises in https://github.com/DUNE-DAQ/drunc/issues/678; it merely removes `DUNEDAQ_DB_PATH` from the `daq_app_rte.sh` script in our builds so it doesn't clobber the bespoke `DUNEDAQ_DB_PATH` set for EHN1 operations. 

Note that earlier today I created a test build using this feature branch, `DFD_DEV_251113_A9`, and have successfully run integration tests with it (https://github.com/DUNE-DAQ/daq-release/actions/runs/19340835603) as well as the daq-buildtools regression tests using a work area based on `DFD_DEV_251113_A9` (https://github.com/DUNE-DAQ/daq-release/actions/runs/19341989231). I would, however, like @mroda88 to check that `DFD_DEV_251113_A9` solves his problems before we merge this in. 