### PR TITLE
Overhaul checkout-daq-package.py

### DIFF
--- a/scripts/checkout-daq-package.py
+++ b/scripts/checkout-daq-package.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import os
+import os, sys
 import yaml
 import argparse
 import subprocess
@@ -187,8 +187,7 @@ class DAQCheckoutPackage:
         else:
             print(f"{self.checkout_path}: No [project] section found in pyproject.toml")
             return None
-
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser(
         prog='checkout-daq-package.py',
         description="Tool for checking out DAQ package(s).",
@@ -229,4 +228,9 @@ if __name__ == "__main__":
     print("Successfully checked out", success_count ,"packages to", checkout_area.path)
     if checkout_area.packages_with_errors:
         print("The following packages had one or more errors:", checkout_area.packages_with_errors)
+        return 1
+    return 0
 
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/checkout-daq-package.py
+++ b/scripts/checkout-daq-package.py
@@ -6,104 +6,187 @@ import argparse
 import subprocess
 import re
 import textwrap
+from pathlib import Path
 
 from spack.dr_tools import parse_yaml_file
-from spack.mappings import pyvenv_url_names
+from run_command import run_command
 
-def check_output(cmd, is_success_required=True):
-    irun = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE)
-    stdout, stderr = irun.communicate()
-    rc = irun.returncode
-    if rc != 0:
-        if is_success_required:
-            print(f'\nERROR: command "{cmd}" failed with exit code {rc}')
-            print(f'STDOUT:\n{stdout.decode()}')
-            print(f'STDERR:\n{stderr.decode()}')
 
-            exit(10)
+class DAQCheckoutArea:
+
+    def __init__(self, 
+                 release_manifest, path, package="", all_packages=False, 
+                 branch="", load_pymodules=False, check_tag=False, 
+                 overwrite=False, continue_on_error=False):
+        if package and all_packages:
+            raise ValueError("Cannot specify both '-a' (all packages) and '-p' (single package).")
+        if not package and not all_packages:
+            raise ValueError("Please specify '-a' or '-p <pkg>' option.")
+
+        self.release_manifest = release_manifest
+        self.path = path
+        self.package = package
+        self.all_packages = all_packages
+        self.load_pymodules = load_pymodules
+        self.config = {
+            "branch": branch,
+            "check_tag": check_tag,
+            "overwrite": overwrite,
+            "continue_on_error": continue_on_error
+        }
+        self.packages_with_errors = []
+
+        self.package_list = self.load_packages()
+        if package:
+            pkg_entry = next((pkg for pkg in self.package_list if pkg.get("name") == args.package), None)
+            if not pkg_entry:
+                raise ValueError(textwrap.dedent(f"""
+                    Package {self.package} not found in {self.release_manifest}
+                    Note that you must pass '-m' or '--pymodules' to load python packages."""))
+            self.package_list = [pkg_entry]
+    
+    def load_packages(self):
+        yaml_dict = parse_yaml_file(self.release_manifest)
+        pkgs = yaml_dict.get("coredaq", []) + yaml_dict.get("fddaq", []) + yaml_dict.get("nddaq", [])
+        if self.load_pymodules:
+            pymodules = yaml_dict.get("pymodules", [])
+            if not pymodules:
+                raise ValueError(f'WARNING: You\'ve requested --pymodules, but {self.release_manifest} does not have any pymodules.')
+            dunedaq_pymodules = [entry for entry in pymodules if entry["source"] == "github_DUNE-DAQ"]
+            pkgs = dunedaq_pymodules
+        if not pkgs:
+            raise ValueError(f"No packages loaded from {self.release_manifest}.")
+        return pkgs
+
+    def confirm_overwrite(self):
+        if not self.config["overwrite"]:
+            return
+        target = ", ".join(pkg["name"] for pkg in self.package_list)
+        proceed = input(f"This action will overwrite {target} in {self.path}. Continue? [y/N] ")
+        if proceed.lower() not in ("y", "yes"):
+            raise RuntimeError("Aborted")
+
+    def checkout_packages(self):
+        for package_dict in self.package_list:
+            checkout_package = DAQCheckoutPackage(package_dict, self)
+            checkout_package.checkout()
+            if self.config["check_tag"]:
+                checkout_package.verify_tags()
+            if not checkout_package.success:
+                print(f"There was a problem with {checkout_package.name}")
+                self.packages_with_errors.append(checkout_package.name)
+
+class DAQCheckoutPackage:
+
+    def __init__(self, package_dict, checkout_area):
+        self.name = package_dict.get("name")
+        # AJM Nov. 17, 2025: for now, keep next two lines for backwards compatibility
+        if self.name == "elisa-client-api":
+            self.name = "elisa_client_api"
+        self.commit = package_dict.get("commit")
+        self.version = package_dict.get("version")
+        self.source = package_dict.get("source")
+        # Only python packages have a "source" field
+        self.is_pymodule = bool(package_dict.get("source"))
+        self.checkout_area = Path(f"{checkout_area.path}")
+        self.checkout_path = Path(f"{checkout_area.path}/{self.name}")
+        self.branch = checkout_area.config["branch"]
+        self.check_tag = checkout_area.config["check_tag"]
+        self.overwrite = checkout_area.config["overwrite"]
+        self.continue_on_error = checkout_area.config["continue_on_error"]
+        self.checkout_token = self.get_checkout_token()
+        self.success = True
+
+    def get_checkout_token(self):
+        if self.name == 'daq-cmake' and self.branch:
+            return self.version
+        if self.branch and (self.commit or re.search(r"\d+\.\d+\.\d+", self.version)):
+            raise ValueError(f"{self.name} uses a fixed tag or commit in the manifest. Can't override with a branch.")
+        if self.version == 'develop' and self.check_tag:
+            raise ValueError(f"Error: You requested to check tags ('-c'), but the manifest specifies the develop branch of {self.name}.")
+        if self.branch:
+            return self.branch
+        if re.search(r"\d+\.\d+\.\d+", self.version):
+            # Python package versions don't start with "v" in the release manifest; 
+            # add it here for consistency in checkout tokens
+            return f"v{self.version}" if self.source else self.version
+        if self.commit:
+            return self.commit
+        return "develop"
+
+    def checkout(self):
+        if self.overwrite and self.checkout_path.is_dir():
+            run_command(["rm", "-rf", f"{self.checkout_path}"], cwd=self.checkout_area)
+
+        run_command(["git", "clone", f"https://github.com/DUNE-DAQ/{self.name}.git"], cwd=self.checkout_area)
+        print(f"\nINFO: Attempting checkout of {self.name:<20} {self.checkout_token:<20} under {self.checkout_path}")
+        checkout_results = run_command(["git", "checkout", f"{self.checkout_token}"], cwd=self.checkout_path, continue_on_error=self.continue_on_error)
+        if checkout_results["exit_code"] != 0:
+            self.success = False
+
+    def verify_tags(self):
+        cmakelists_tag = self.get_cmakelists_version()
+        pyproj_tag = self.get_pyproj_version()
+
+        if self.is_pymodule:
+            self.version = f"v{self.version}"
+
+        # Verify tag on GitHub
+        run_command(["git", "fetch", "--tags"], cwd=self.checkout_path)
+        run_command(["git", "show-ref", "--tags", "--verify", "--quiet", f"refs/tags/{self.version}"], 
+                           cwd=self.checkout_path, context=f"Tag {self.version} does not exist for package {self.name}",
+                           continue_on_error=self.continue_on_error)
+
+        # Verify tag in CMakeLists and/or pyproject.toml
+        if cmakelists_tag is not None and f"v{cmakelists_tag}" != self.version:
+            self.success = False
+            if not self.continue_on_error:
+                raise RuntimeError(f"Tag mismatch in {self.name}: you requested {self.version}, but the CMakeLists has {cmakelists_tag}")
+
+        if pyproj_tag is not None and f"v{pyproj_tag}" != self.version:
+            self.success = False
+            if not self.continue_on_error:
+                raise RuntimeError(f"Tag mismatch in {self.name}: you requested {self.version}, but the pyproject.toml has {pyproj_tag}")
+
+    def get_cmakelists_version(self):
+        cmakelists_file = Path(self.checkout_path) / "CMakeLists.txt"
+        if not cmakelists_file.exists():
+            return None
+
+        version_regex = re.compile(r'project\s*\(\S*\w+\s+VERSION\s+(\d+\.\d+\.\d+)')
+
+        with cmakelists_file.open() as f:
+            content = f.read()
+        
+        match = version_regex.search(content)
+        if not match:
+            print(f"WARNING: {self.checkout_path}: No CMakeLists version extracted")
+            return None
+        return match.group(1)
+
+    def get_pyproj_version(self):
+        pyproject_file = self.checkout_path / "pyproject.toml"
+        if not pyproject_file.exists():
+            return None
+
+        version_regex = re.compile(r'^\s*version\s*=\s*["\']([^"\']+)["\']', re.MULTILINE)
+
+        with pyproject_file.open() as f:
+            content = f.read()
+
+        # Match [project] section until the next [section] or end of file
+        project_section = re.search(r'^\[project\]\s*(.*?)(?=^\[|\Z)', content, re.DOTALL | re.MULTILINE)
+        if project_section:
+            section_text = project_section.group(1)
+            match = version_regex.search(section_text)
+            if match:
+                return match.group(1)
+            else:
+                print(f"{self.checkout_path}: No version found in [project] section")
+                return None
         else:
-            print('Non-zero exit status from checkout attempt; this is acceptable')
-    else:
-        print("Checkout successful")
-
-def checkout_commit(repo, commit, outdir, is_success_required=True):
-    if repo in pyvenv_url_names:
-        repo = pyvenv_url_names[repo].get('repo_name', repo)
-    cmd = textwrap.dedent(f"""
-        mkdir -p {outdir} && cd {outdir} &&
-        git clone https://github.com/DUNE-DAQ/{repo}.git; 
-        cd {repo}; 
-        git checkout {commit}
-    """)
-    print(f"\nInfo: attempting checkout of {repo:<20} {commit:<20} under {outdir}")
-    check_output(cmd, is_success_required)
-    return
-
-def checkout_tag(repo, version, outdir, is_pymodule=False):
-    if repo in pyvenv_url_names:
-        repo = pyvenv_url_names[repo].get('repo_name', repo)
-    cmd = textwrap.dedent(f"""
-        mkdir -p {outdir} && cd {outdir} &&
-        git clone https://github.com/DUNE-DAQ/{repo}.git &&
-        cd {repo} &&
-        git fetch --tags &&
-        if ! git show-ref --tags --verify --quiet "refs/tags/{version}"; then
-            echo "The tag {version} does not exist for package {repo}. Exiting..." && exit 1
-        fi
-        git checkout {version} &&
-        if [[ "{is_pymodule}" == "False" ]]; then
-            cmake_version=`grep "^project" CMakeLists.txt |grep ")$"|grep -oP "(([[:digit:]]+\.)([[:digit:]]+\.)([[:digit:]]+))"` &&
-            tag=v"$cmake_version" &&
-            echo $tag &&
-            echo $version &&
-            if [[ $tag != "{version}" ]]; then
-                echo "Tag mismatches version in CMakeLists.txt ( $tag vs {version} )" && exit 1;
-            fi
-        # TODO AJM 2025/07/08: Once python package structure is standardized, add an else block for checking python package tags
-        fi
-    """)
-    check_output(cmd)
-    print(f"Info: verified version in CMake, checked out {repo:<20} {version:<20} under {outdir}.")
-    return
-
-def load_packages(manifest_path, load_pymodules=False):
-    yaml_dict = parse_yaml_file(manifest_path)
-    pkgs = yaml_dict.get("coredaq", []) + yaml_dict.get("fddaq", []) + yaml_dict.get("nddaq", [])
-    if load_pymodules:
-        pymodules = yaml_dict.get("pymodules", [])
-        if not pymodules:
-            print(f'WARNING: You\'ve requested --pymodules, but {manifest_path} does not have any pymodules.')
-        dunedaq_pymodules = [entry for entry in pymodules if entry["source"] == "github_DUNE-DAQ"]
-        pkgs += dunedaq_pymodules
-    if not pkgs:
-        print("Error: No packages found in manifest.")
-        exit(20)
-    return pkgs
-
-def get_checkout_token(name, branch, commit, version, source, check_tag=False):
-    if name == 'daq-cmake' and branch:
-        return version
-    if branch and (commit or re.search(r"\d+\.\d+\.\d+", version)):
-        print(textwrap.dedent(f"""\n
-            Error: {name} uses a fixed tag or commit in the manifest. Can't override with a branch.
-        """))
-        exit(30)
-    if version == 'develop' and check_tag:
-        print(textwrap.dedent(f"""\n
-            Error: You requested to check tags ('-c'), but the manifest specifies the develop branch of {name}.
-        """))
-        exit(31)
-    if branch:
-        return branch
-    if re.search(r"\d+\.\d+\.\d+", version):
-        # Python package versions don't start with "v" in the release manifest; 
-        # add it here for consistency in checkout tokens
-        return f"v{version}" if source else version
-    if commit:
-        return commit
-    return "develop"
-
+            print(f"{self.checkout_path}: No [project] section found in pyproject.toml")
+            return None
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
@@ -125,44 +208,25 @@ if __name__ == "__main__":
                         help="path to the output directory;")
     parser.add_argument('-m', '--pymodules', action='store_true',
                         help="whether to checkout DAQ python modules;")
+    parser.add_argument('--overwrite', action='store_true',
+                        help="whether to overwrite the output directory if it already exists;")
+    parser.add_argument('--continue-on-error', action='store_true',
+                        help="whether to continue after a failed checkout or tag/commit verification;")
 
     args = parser.parse_args()
 
-    pkgs = load_packages(args.input_manifest, args.pymodules)
-    is_success_required = False if args.branch else True
+    checkout_area = DAQCheckoutArea(
+        args.input_manifest, args.output_path, args.package, 
+        args.all_packages, args.branch, args.pymodules, 
+        args.check_tag, args.overwrite, args.continue_on_error
+    )
 
-    if args.all_packages:
-        for pkg in pkgs:
-            name = pkg.get("name")
-            if name == "elisa-client-api":
-                name = "elisa_client_api"
-            commit = pkg.get("commit")
-            version = pkg.get("version")
-            source = pkg.get("source")
-            is_pymodule = bool(source)
-            token = get_checkout_token(name, args.branch, commit, version, source, args.check_tag)
-            if args.check_tag:
-                checkout_tag(name, token, args.output_path, is_pymodule)
-            else:
-                checkout_commit(name, token, args.output_path, is_success_required)
-    elif args.package is not None:
-        pkg_entry = next((pkg for pkg in pkgs if pkg.get("name") == args.package), None)
-        if not pkg_entry:
-            print(f"Error: {args.package} not found in {args.input_manifest}")
-            print(f"       Note that you must pass -m or --pymodules to load python packages.")
-            exit(21)
-        name = pkg_entry.get("name")
-        if name == "elisa-client-api":
-            name = "elisa_client_api"
-        commit = pkg_entry.get("commit")
-        version = pkg_entry.get("version")
-        source = pkg_entry.get("source")
-        is_pymodule = bool(source)
-        token = get_checkout_token(name, args.branch, commit, version, source, args.check_tag)
-        if args.check_tag:
-            checkout_tag(args.package, token, args.output_path, is_pymodule)
-        else:
-            checkout_commit(args.package, token, args.output_path, is_success_required)
-    else:
-        print('Error: please specify "-a" or "-p <pkg>" option.')
-        exit(22)
+    checkout_area.load_packages()
+    checkout_area.confirm_overwrite()
+    checkout_area.checkout_packages()
+
+    success_count = len(checkout_area.package_list) - len(checkout_area.packages_with_errors)
+    print("Successfully checked out", success_count ,"packages to", checkout_area.path)
+    if checkout_area.packages_with_errors:
+        print("The following packages had one or more errors:", checkout_area.packages_with_errors)
+

--- a/scripts/run_command.py
+++ b/scripts/run_command.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+
+from pathlib import Path
+
+def run_command(
+    cmd,
+    cwd=None,
+    check=True,
+    context=None,
+    continue_on_error=False
+):
+    """
+    Run a shell command and return a dictionary with its results.
+
+    Parameters:
+        cmd: list or str - the command to run (list preferred)
+        cwd: str - directory to run the command in
+        check: bool - raise RuntimeError if the command fails
+        context: str - optional extra message for errors
+        continue_on_error: bool - if True, don't raise, just return dict
+
+    Returns:
+        dict with keys: success, stdout, stderr, exit_code, command, context
+    """
+
+    result_dict = {
+        "success": False,
+        "stdout": "",
+        "stderr": "",
+        "exit_code": None,
+        "command": " ".join(cmd),
+        "context": context,
+    }
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=check,
+            cwd=cwd
+        )
+        result_dict.update({
+            "success": True,
+            "stdout": result.stdout.strip(),
+            "stderr": result.stderr.strip(),
+            "exit_code": result.returncode
+        })
+        if result_dict["stdout"]:
+            print(result_dict["stdout"])
+    except subprocess.CalledProcessError as e:
+        result_dict.update({
+            "stdout": e.stdout.strip() if e.stdout else "",
+            "stderr": e.stderr.strip() if e.stderr else "",
+            "exit_code": e.returncode
+        })
+
+        message = (
+            f"Command failed: {result_dict['command']}\n"
+            f"Exit code: {result_dict['exit_code']}\n"
+            f"Stdout:\n{result_dict['stdout']}\n"
+            f"Stderr:\n{result_dict['stderr']}"
+        )
+        if context:
+            message = f"{context}\n\n{message}"
+
+        if continue_on_error:
+            print(message)
+            print("Continuing despite error...")
+        else:
+            raise RuntimeError(message) from e
+
+    return result_dict
+
+if __name__ == "__main__":
+    pass
+    


### PR DESCRIPTION
When trying to add options for `--overwrite` and `--continue-on-error` to `checkout-daq-package.py`, I found it cumbersome to deal with the repetitive logic and lack of centralized parameter handling, particularly things like `version`, `commit`, `branch`, etc. This PR factors the same functionality into two classes, `DAQCheckoutArea` and `DAQCheckoutPackage`. `DAQCheckoutArea` has a `path` which is set to the user input `-o <outdir>`. Each package is configured as a `DAQCheckoutPackage` which is checked out and optionally validated within the `DAQCheckoutArea`. This makes the script easier to modify, which was helpful in adding the aforementioned `--overwrite` and `--continue-on-error`. If `--overwrite` is provided, it requests user input to confirm the removal of existing directories. If `--continue-on-error` is provided, any packages with errors (such as mismatched tags) will be listed at the bottom of the output.  

Other key changes and improvements:
- Add `run_command.py`, a wrapper script for running shell commands from Python, removing the need for messy, multi-line bash commands handled by `subprocess`. I think this could be used in other `daq-release` scripts as well, but that's outside the scope of this PR.
- Consolidated checkout logic, i.e., no more separate functions for `checkout_commit` and `checkout_tag`. 
- Add functionality for verifying python tags in `pyproject.toml` for "pure" Python packages (not "hybrid" Python/C++ packages)
- Cleaner logic for handling single package checkout vs. all package checkout (no more repetitive if/else block)
- Handle errors with `raise` instead of `exit`

Finally, a notable change is that specifying `-m`/`--pymodules` will now only checkout python packages, rather than checking them out in addition to `fddaq` packages. This makes the behavior more consistent with checking out `coredaq` and `fddaq` packages. 

Examples (relative to `daq-release/scripts`):
- Checkout `dpdklibs` and overwrite its path if it already exists:
```
./checkout-daq-package.py -i ../configs/fddaq/fddaq-v5.5.0/release.yaml -p dpdklibs -o /tmp/$USER --overwrite
```
- Checkout all packages, verify tags, overwrite existing directories, and continue on error:
```
./checkout-daq-package.py -i ../configs/fddaq/fddaq-v5.5.0/release.yaml -a -c -o /tmp/$USER -c --overwrite --continue-on-error
```