### PR TITLE
Add time since last commit to CI dashboard

### DIFF
--- a/.github/workflows/nightly-ci-dashboard.yml
+++ b/.github/workflows/nightly-ci-dashboard.yml
@@ -93,7 +93,9 @@ jobs:
         cp -r integration_test_summary/ daq-release-ci-dashboard/scripts/github-ci/integration_test_summary
         cd daq-release-ci-dashboard/scripts/github-ci/
         ./collect-ci-metrics.sh
-        ./combine_markdown_summaries.sh integration_test_summary/pytest_summary_table.md code_check_summary/pytest_summary/pytest_summary_table.md > combined_pytest_summary.md
+        ./combine_markdown_summaries.sh integration_test_summary/pytest_summary_table.md \
+                                        code_check_summary/pytest_summary_table.md \
+                                        > combined_pytest_summary.md
         cat combined_pytest_summary.md
         python generate_ci_site.py --json_input ci_summary.json \
                                    --unit_test_summary code_check_summary/unit_test_summary/unit_test_summary.log \

--- a/scripts/github-ci/collect-ci-metrics.sh
+++ b/scripts/github-ci/collect-ci-metrics.sh
@@ -6,8 +6,6 @@ export DEVLINE="develop"
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source $SCRIPT_DIR/repo.sh || exit $?
 
-#echo "${dune_packages_with_ci[@]}"
-
 ORG="DUNE-DAQ"
 REPOS=$(gh repo list "$ORG" --limit 100 --json name -q '.[].name')
 OUTFILE="ci_summary.json"
@@ -17,7 +15,7 @@ FIRST=true
 
 for REPO in "${dune_packages_with_ci[@]}"; do
   FULL_NAME="$ORG/$REPO"
-  echo "This repo: $FULL_NAME"
+  echo "Collecting metrics for $FULL_NAME..."
 
   OPEN_ISSUES=$(gh issue list -R "$FULL_NAME" --state open --limit 1000 --json number --jq 'length' || echo 0)
   ISSUES_URL=$(echo "https://github.com/DUNE-DAQ/$REPO/issues")
@@ -26,7 +24,10 @@ for REPO in "${dune_packages_with_ci[@]}"; do
 
   # Get most recent single-repo CI build status
   BUILD_DEVELOP_STATUS=$(gh run list -R "$FULL_NAME" --limit 1 --json status,conclusion,name,url --workflow dunedaq-develop-cpp-ci.yml -q '.[0]')
-  echo $?
+
+  now=$(date +%s)
+  last_commit_time=$(date -d "$(gh api repos/$ORG/$REPO/commits --jq '.[0].commit.author.date')" +%s)
+  TIME_SINCE_LAST_COMMIT=$(( now - last_commit_time ))
 
   # Prepare JSON fragment
   JSON_ENTRY=$(jq -n \
@@ -35,6 +36,7 @@ for REPO in "${dune_packages_with_ci[@]}"; do
     --arg issues_url "$ISSUES_URL" \
     --argjson prs "$OPEN_PRS" \
     --arg prs_url "$PRS_URL" \
+    --argjson time_since_last_commit $TIME_SINCE_LAST_COMMIT \
     --argjson build_develop "$BUILD_DEVELOP_STATUS" \
     '{
       repo: $repo,
@@ -42,11 +44,13 @@ for REPO in "${dune_packages_with_ci[@]}"; do
       issues_url: $issues_url,
       open_prs: $prs,
       prs_url: $prs_url,
+      time_since_last_commit: $time_since_last_commit,
       build_develop: $build_develop,
     }')
   retval=$?
 
   if [[ $retval == 0 ]]; then
+    echo "Success"
     if [[ "$FIRST" = true ]]; then
       FIRST=false
     else 

--- a/scripts/github-ci/generate_ci_site.py
+++ b/scripts/github-ci/generate_ci_site.py
@@ -135,6 +135,10 @@ def generate_site(json_input_path, unit_test_summary='', pytest_summary=''):
         "link": "https://github.com/DUNE-DAQ/daq-release/actions/workflows/nightly-code-check.yml",
         "alt": "Nightly unit tests and clang format check"},
     {
+        "image": "https://github.com/DUNE-DAQ/docs/actions/workflows/build-and-publish-doxygen.yml/badge.svg",
+        "link": "https://github.com/DUNE-DAQ/docs/actions/workflows/build-and-publish-doxygen.yml",
+        "alt": "Doxygen"},
+    {
         "image": "https://github.com/DUNE-DAQ/daq-release/actions/workflows/weekly-linting.yml/badge.svg",
         "link": "https://github.com/DUNE-DAQ/daq-release/actions/workflows/weekly-linting.yml",
         "alt": "Weekly linting"},

--- a/scripts/github-ci/generate_ci_site.py
+++ b/scripts/github-ci/generate_ci_site.py
@@ -9,6 +9,18 @@ def strip_ansi(line):
     """Strip color coding from unit test summary log."""
     return re.sub(r"\x1B\[[0-9;]*[a-zA-Z]", "", line)
 
+def commit_age(time_since_last_commit):
+    """Categorize the age of the latest commit."""
+    week = 7 * 24 * 60 * 60
+    month = 30 * 24 * 60 * 60
+
+    if time_since_last_commit < week:
+        return ("This week", "status-fresh")
+    elif time_since_last_commit < month:
+        return ("This month", "status-aging")
+    else:
+        return ("More than a month ago", "status-stale")
+
 def parse_unit_test_summary(log_path):
     """Parse unit test summary and store as a dictionary."""
     content_by_package = {}
@@ -103,6 +115,7 @@ def generate_site(json_input_path, unit_test_summary='', pytest_summary=''):
         repos = json.load(f)
 
     env = Environment(loader=FileSystemLoader("templates"))
+    env.filters["commit_age"] = commit_age
     index_template = env.get_template("index_template.html")
 
     total_issues = sum(repo["open_issues"] for repo in repos)

--- a/scripts/github-ci/site/static/style.css
+++ b/scripts/github-ci/site/static/style.css
@@ -84,3 +84,15 @@ a:hover {
 .status-error {
     color: darkorange;
 }
+
+.status-fresh {
+    color: green;
+}
+
+.status-aging {
+    color: #99cc00;
+}
+
+.status-stale {
+    color: darkorange;
+}

--- a/scripts/github-ci/templates/index_template.html
+++ b/scripts/github-ci/templates/index_template.html
@@ -91,15 +91,20 @@
     <thead>
         <tr>
             <th>Repository</th>
+            <th>Last Commit</th>
             <th>Open Issues</th>
             <th>Open PRs</th>
-            <th>Workflow Status</th>
+            <th>Develop Build Status</th>
         </tr>
     </thead>
     <tbody>
         {% for repo in repos %}
         <tr>
             <td><a href="https://github.com/DUNE-DAQ/{{ repo.repo }}">{{ repo.repo }}</a></td>
+            <td>
+                {% set label, cls = repo.time_since_last_commit | commit_age %}
+                <span class="{{cls}}">{{label}}</span>
+            </td>
             <td><a href="https://github.com/DUNE-DAQ/{{ repo.repo }}/issues">{{ repo.open_issues }}</a></td>
             <td><a href="https://github.com/DUNE-DAQ/{{ repo.repo }}/pulls">{{ repo.open_prs }}</a></td>
             <td>


### PR DESCRIPTION
Inspired by the [artdaq](https://art-daq.github.io/) nightly CI dashboard, this PR adds a column to the main summary table that includes the time since the last commit, categorized as "This week," "This month," and "More than a month ago."

I've tested that this works locally. In order to test in a real GitHub Actions environment, I need to push to `develop` and run from there since other branches don't have permission to publish to GitHub Pages. Since this is a holiday week, I'm going to merge and test this myself, and will revert if there are issues.