### PR TITLE
Refactor extended integration tests

### DIFF
--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -1,8 +1,8 @@
 name: Extended integration test workflow
 
 on:
-  #schedule:
-  #  - cron: "0 7 * * *"
+  schedule:
+    - cron: "0 7 * * *"
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -194,11 +194,6 @@ jobs:
         old_dirs=$(find /home/nfs/dunedaq/github-actions -mindepth 1 -maxdepth 1 -type d -mtime +7)
         echo "Removing the following directories that are more than 7 days old: $old_dirs"
         rm -rf $old_dirs
-    - name: Debug prints
-      run: |
-        echo "Integtest_log_dir: ${{ needs.extended_integration_tests.outputs.integtest_log_dir }}"
-        echo "ls integtest_log_dir: $(ls ${{ needs.extended_integration_tests.outputs.integtest_log_dir }})"
-
 
   send_slack_message:
     if: (success() || failure()) && ((github.event_name != 'workflow_dispatch') || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes'))
@@ -206,7 +201,6 @@ jobs:
     uses: ./.github/workflows/slack-notification.yml
     with:
       release_tag: ${{ needs.make_variables.outputs.tag }}
-      #integtest_xml_dir: ${{ needs.make_variables.outputs.integtest_output_path }}
       integtest_xml_dir: ${{ needs.extended_integration_tests.outputs.integtest_log_dir }}
       integtest_log_dir: ${{ needs.make_variables.outputs.persistent_log_dir }}
     secrets: 

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -121,7 +121,7 @@ jobs:
         cd ../$DAQ_RELEASE_PATH/scripts
         #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -p dfmodules -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -p dfmodules -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         ./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
 
@@ -171,7 +171,7 @@ jobs:
       with:
         if-no-files-found: error
         name: nightly_extended_integtest_summary
-        path: $DAQ_RELEASE_PATH/scripts/github-ci/pytest_summary_table.md
+        path: ${{ needs.make_variables.outputs.daq_release_path }}/scripts/github-ci/pytest_summary_table.md
 
   store_and_upload_logs:
     runs-on: daq

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -185,7 +185,7 @@ jobs:
         PERSISTENT_LOG_DIR: ${{needs.make_variables.outputs.persistent_log_dir}}
       uses: actions/upload-artifact@v6
       with:
-        name: pytest-logs-${{ env.TIMESTAMP }}
+        name: pytest-logs-extended-${{ env.TIMESTAMP }}
         path: ${{ env.PERSISTENT_LOG_DIR }}
     - name: Delete old log directories
       run: |

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -218,10 +218,11 @@ jobs:
           #echo "NOT removing ${{ needs.make_variables.outputs.integtest_output_path }} for now"
       - name: Remove daq-release
         run: |
-          rm -rf ${{ github.workspace }}/$DAQ_RELEASE_PATH
-          pwd
+          #rm -rf $DAQ_RELEASE_PATH
+          ls -lrt $DAQ_RELEASE_PATH
+          echo "PWD REMOVE: $(pwd)"
           ls -lrt ${{ needs.make_variables.outputs.tag }}
-          rm -rf ${{ needs.make_variables.outputs.tag }}
+          #rm -rf ${{ needs.make_variables.outputs.tag }}
 
   # Integration tests can sometimes collide with stale processes, leading to timeout
   cleanup_stale_gunicorn_processes:

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -6,13 +6,6 @@ on:
 
   workflow_dispatch:
     inputs:
-      subset:
-        type: choice
-        description: 'which subset of tests to run (core or extended)'
-        default: 'core'
-        options:
-          - core
-          - extended
       send-slack-message:
         description: 'whether to send a message to #daq-release-notifications on completion'
         default: 'no'
@@ -68,7 +61,7 @@ jobs:
           fi
 
           timestamp=$(date +"%Y-%m-%d-%H%M%Z")
-          persistent_log_dir=/home/nfs/dunedaq/github-actions/pytest-logs-${timestamp}
+          persistent_log_dir=/home/nfs/dunedaq/github-actions/pytest-logs-extended-${timestamp}
           integtest_output_path=${{ github.workspace }}/integration_tests_${release_tag}
 
           echo "release_tag=${release_tag}"  >>  "$GITHUB_OUTPUT"
@@ -79,34 +72,21 @@ jobs:
           echo "integtest_output_path=${integtest_output_path}" >> "$GITHUB_OUTPUT"
           cat "$GITHUB_OUTPUT"
 
-  integration_tests:
-    name: integration_tests
+  extended_integration_tests:
+    name: extended_integration_tests
     runs-on: daq
     timeout-minutes: 30
     needs: make_variables
-    if: ${{ github.event.inputs.subset == 'core' }} 
-    strategy:
-        fail-fast: false
-        matrix:
-
-            test_name: [
-                        "listrev_test",
-                        "3ru_1df_multirun_test",
-                        "3ru_3df_multirun_test",
-                        "example_system_test",
-                        "fake_data_producer_test",
-                        "long_window_readout_test",
-                        "minimal_system_quick_test",
-                        "readout_type_scan_test",
-                        "small_footprint_quick_test",
-                        "tpreplay_test",
-                        "tpstream_writing_test"
-                       ]
     defaults:
       run:
         shell: bash
 
     steps:
+    - name: checkout daq-release
+      uses: actions/checkout@v6
+      with:
+        path: daq-release-extended-tests
+
     - name: setup release and run tests
       env:
         RELEASE_TAG: ${{needs.make_variables.outputs.tag}}
@@ -116,7 +96,6 @@ jobs:
         INTEGTEST_OUTPUT_PATH: ${{needs.make_variables.outputs.integtest_output_path}}
       id: setup_and_run_test
       run: |
-        DET=fd
         mkdir -p $INTEGTEST_OUTPUT_PATH
         cd $INTEGTEST_OUTPUT_PATH
         echo "Am in $(pwd)"
@@ -126,32 +105,31 @@ jobs:
         if [[ "$IS_CANDIDATE_RELEASE" == "true" ]]; then
           echo "dbt-setup-release -b candidate $RELEASE_TAG"
           [[ -e /cvmfs/dunedaq-development.opensciencegrid.org/candidates/$RELEASE_TAG/daq_app_rte.sh ]]
-          dbt-setup-release -b candidate $RELEASE_TAG
+          dbt-create -b candidate $RELEASE_TAG
         elif [[ "$IS_STABLE_RELEASE" == "true" ]]; then
           echo "dbt-setup-release $RELEASE_TAG"
           [[ -e /cvmfs/dunedaq.opensciencegrid.org/spack/releases/$RELEASE_TAG/daq_app_rte.sh ]]
-          dbt-setup-release $RELEASE_TAG
+          dbt-create $RELEASE_TAG
         else
           echo "dbt-setup-release -n $RELEASE_TAG"
           [[ -e /cvmfs/dunedaq-development.opensciencegrid.org/nightly/$RELEASE_TAG/daq_app_rte.sh ]]
-          dbt-setup-release -n $RELEASE_TAG
-        fi
-        TEST_PATH=""
-        TEST_SOURCE=""
-        if [[ "${{ matrix.test_name }}" == "listrev_test" ]]; then
-          TEST_PATH=$LISTREV_SHARE/integtest
-          TEST_SOURCE=listrev
-        else
-          TEST_PATH=$DAQSYSTEMTEST_SHARE/integtest
-          TEST_SOURCE=daqsystemtest
+          dbt-create -n $RELEASE_TAG
         fi
 
-        pytest_retval=0
-        pytest --tb=short --junit-xml=${TEST_SOURCE}_${{ matrix.test_name }}_results.xml \
-                $TEST_PATH/${{ matrix.test_name }}.py || { pytest_retval=$?; true; }
+        ./daq-release-extended-tests/scripts/checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o $RELEASE_TAG/sourcecode
+        ./daq-release-extended-tests/scripts/checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o $RELEASE_TAG/sourcecode
+        # daqsystemtest and listrev tests are already run as part of the core tests
+        rm -rf $RELEASE_TAG/sourcecode/daqsystemtest
+        rm -rf $RELEASE_TAG/sourcecode/listrev
+
+        cd $RELEASE_TAG
+        source env.sh
+
+        dbt-workarea-env
+        dbt-build --integtest
 
         mkdir -p $PERSISTENT_LOG_DIR
-        cp -rL $(readlink -f /tmp/pytest-of-dunedaq/pytest-current/) $PERSISTENT_LOG_DIR/${{ matrix.test_name }}
+        cp -rL $(readlink -f /tmp/pytest-of-dunedaq/pytest-current/) $PERSISTENT_LOG_DIR/
 
         chmod -R 755 $PERSISTENT_LOG_DIR
         if [[ $(du -sk $PERSISTENT_LOG_DIR | awk '{print $1}') -gt 10000000 ]]; then
@@ -162,28 +140,16 @@ jobs:
 
         test $pytest_retval == 0 || false
 
-  extended_integration_tests:
-    name: extended_integration_tests
-    runs-on: daq
-    timeout-minutes: 30
-    needs: make_variables
-    if: ${{ github.event.inputs.subset == 'extended' }} 
-
   parse_and_upload_results:
     runs-on: daq
     if: always()
-    needs: [make_variables, integration_tests]
+    needs: [make_variables, extended_integration_tests]
     steps:
-    - name: Checkout daq-release
-      uses: actions/checkout@v4
-      with:
-        repository: DUNE-DAQ/daq-release
-        path: daq-release-integtest
     - name: Generate summary tables
       env:
         RELEASE_TAG: ${{needs.make_variables.outputs.tag}}
       run: |
-        cd daq-release-integtest/scripts/github-ci/
+        cd daq-release-extended-tests/scripts/github-ci/
         python integtest_xml_parser.py --input-directory ${{ needs.make_variables.outputs.integtest_output_path }}
         cat pytest_summary_table.md >> $GITHUB_STEP_SUMMARY
     - name: Upload markdown summary as artifact
@@ -196,7 +162,7 @@ jobs:
   store_and_upload_logs:
     runs-on: daq
     timeout-minutes: 5
-    needs: [make_variables, integration_tests]
+    needs: [make_variables, extended_integration_tests]
     if: success() || failure()
     steps:
     - name: Upload logs as artifact
@@ -243,7 +209,7 @@ jobs:
   cleanup_stale_gunicorn_processes:
     runs-on: daq
     if: always()
-    needs: integration_tests
+    needs: extended_integration_tests
     steps:
       - name: Run cleanup script
         run: |

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -217,11 +217,14 @@ jobs:
           rm -rf ${{ needs.make_variables.outputs.integtest_output_path }}
       - name: Remove daq-release
         run: |
-          #rm -rf $DAQ_RELEASE_PATH
-          echo "DAQ_RELEASE_PATH: $DAQ_RELEASE_PATH"
-          ls -lrt $DAQ_RELEASE_PATH
-          echo "PWD REMOVE: $(pwd)"
-          rm -rf ${{ needs.make_variables.outputs.tag }}
+          if [[ -d "$DAQ_RELEASE_PATH" ]]; then
+            echo "Removing $DAQ_RELEASE_PATH"
+            rm -rf $DAQ_RELEASE_PATH
+          fi
+          if [[ -d "$RELEASE_TAG" ]]; then
+            echo "Removing $RELEASE_TAG"
+            rm -rf $RELEASE_TAG
+          fi
 
   # Integration tests can sometimes collide with stale processes, leading to timeout
   cleanup_stale_gunicorn_processes:

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -77,6 +77,10 @@ jobs:
     runs-on: daq
     timeout-minutes: 30
     needs: make_variables
+    outputs:
+      integtest_log_dir: ${{ steps.integtests.outputs.integtest_log_dir }}
+    env:
+      DBT_AREA_ROOT: ${{ needs.make_variables.outputs.tag }}
     defaults:
       run:
         shell: bash
@@ -87,58 +91,47 @@ jobs:
       with:
         path: daq-release-extended-tests
 
-    - name: setup release and run tests
-      env:
-        RELEASE_TAG: ${{needs.make_variables.outputs.tag}}
-        IS_CANDIDATE_RELEASE: ${{needs.make_variables.outputs.is_candidate_release}}
-        IS_STABLE_RELEASE: ${{needs.make_variables.outputs.is_stable_release}}
-        PERSISTENT_LOG_DIR: ${{needs.make_variables.outputs.persistent_log_dir}}
-        INTEGTEST_OUTPUT_PATH: ${{needs.make_variables.outputs.integtest_output_path}}
-      id: setup_and_run_test
+    - name: Create build area
       run: |
-        mkdir -p $INTEGTEST_OUTPUT_PATH
-        cd $INTEGTEST_OUTPUT_PATH
-        echo "Am in $(pwd)"
-        echo "INTEGTEST_OUTPUT_PATH: $INTEGTEST_OUTPUT_PATH"
         source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
         setup_dbt latest_v5
         if [[ "$IS_CANDIDATE_RELEASE" == "true" ]]; then
-          echo "dbt-setup-release -b candidate $RELEASE_TAG"
-          [[ -e /cvmfs/dunedaq-development.opensciencegrid.org/candidates/$RELEASE_TAG/daq_app_rte.sh ]]
-          dbt-create -b candidate $RELEASE_TAG
+          echo "dbt-setup-release -b candidate $release_tag"
+          [[ -e /cvmfs/dunedaq-development.opensciencegrid.org/candidates/$release_tag/daq_app_rte.sh ]]
+          dbt-create -b candidate $release_tag
         elif [[ "$IS_STABLE_RELEASE" == "true" ]]; then
-          echo "dbt-setup-release $RELEASE_TAG"
-          [[ -e /cvmfs/dunedaq.opensciencegrid.org/spack/releases/$RELEASE_TAG/daq_app_rte.sh ]]
-          dbt-create $RELEASE_TAG
+          echo "dbt-setup-release $release_tag"
+          [[ -e /cvmfs/dunedaq.opensciencegrid.org/spack/releases/$release_tag/daq_app_rte.sh ]]
+          dbt-create $release_tag
         else
-          echo "dbt-setup-release -n $RELEASE_TAG"
-          [[ -e /cvmfs/dunedaq-development.opensciencegrid.org/nightly/$RELEASE_TAG/daq_app_rte.sh ]]
-          dbt-create -n $RELEASE_TAG
+          echo "dbt-setup-release -n $release_tag"
+          [[ -e /cvmfs/dunedaq-development.opensciencegrid.org/nightly/$release_tag/daq_app_rte.sh ]]
+          dbt-create -n $release_tag
         fi
-
-        ./daq-release-extended-tests/scripts/checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o $RELEASE_TAG/sourcecode
-        ./daq-release-extended-tests/scripts/checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o $RELEASE_TAG/sourcecode
-        # daqsystemtest and listrev tests are already run as part of the core tests
-        rm -rf $RELEASE_TAG/sourcecode/daqsystemtest
-        rm -rf $RELEASE_TAG/sourcecode/listrev
-
-        cd $RELEASE_TAG
+        cd ${{ env.DBT_AREA_ROOT }}
         source env.sh
+        cd ../daq-release-extended-tests/scripts
+        #cd ${{ github.workspace }}/daq-release-code-checks/scripts
+        ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
 
+    - name: Run integration tests
+      id: integtests
+      run: |
+        cd $DBT_AREA_ROOT
+        # daqsystemtest and listrev tests are already run as part of the nightly integration tests
+        rm -rf sourcecode/daqsystemtest
+        rm -rf sourcecode/listrev
+        source env.sh
         dbt-workarea-env
-        dbt-build --integtest
-
-        mkdir -p $PERSISTENT_LOG_DIR
-        cp -rL $(readlink -f /tmp/pytest-of-dunedaq/pytest-current/) $PERSISTENT_LOG_DIR/
-
-        chmod -R 755 $PERSISTENT_LOG_DIR
-        if [[ $(du -sk $PERSISTENT_LOG_DIR | awk '{print $1}') -gt 10000000 ]]; then
-          echo "The log directory $PERSISTENT_LOG_DIR has exceeded 10 GB. Deleting and exiting..."
-          rm -rf $PERSISTENT_LOG_DIR
-          exit 2
-        fi
-
-        test $pytest_retval == 0 || false
+        dbt-build --integtest | tee integtest_full_output.log
+        # Log directory is the last non-empty line of output
+        integtest_log_dir=$(readlink -f $DBT_AREA_ROOT/log/integtest_tests_* | tail -n 1)
+        echo "integtest_log_dir=${integtest_log_dir}" >> "$GITHUB_OUTPUT"
+        echo "integtest_log_dir: $integtest_log_dir"
 
   parse_and_upload_results:
     runs-on: daq

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -82,6 +82,7 @@ jobs:
     env:
       DBT_AREA_ROOT: ${{ needs.make_variables.outputs.tag }}
       RELEASE_TAG: ${{ needs.make_variables.outputs.tag }}
+      PERSISTENT_LOG_DIR: ${{ needs.make_variables.outputs.persistent_log_dir }}
     defaults:
       run:
         shell: bash
@@ -113,10 +114,10 @@ jobs:
         source env.sh
         cd ../daq-release-extended-tests/scripts
         #cd ${{ github.workspace }}/daq-release-code-checks/scripts
-        ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -p dfmodules -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
 
     - name: Run integration tests
@@ -134,6 +135,19 @@ jobs:
         echo "integtest_log_dir=${integtest_log_dir}" >> "$GITHUB_OUTPUT"
         echo "integtest_log_dir: $integtest_log_dir"
 
+    - name:
+      id: move_logs
+      run: |
+        mkdir -p $PERSISTENT_LOG_DIR
+        cp -rL $(readlink -f /tmp/pytest-of-dunedaq/pytest-*/) $PERSISTENT_LOG_DIR/
+
+        chmod -R 755 $PERSISTENT_LOG_DIR
+        if [[ $(du -sk $PERSISTENT_LOG_DIR | awk '{print $1}') -gt 10000000 ]]; then
+          echo "The log directory $PERSISTENT_LOG_DIR has exceeded 10 GB. Deleting and exiting..."
+          rm -rf $PERSISTENT_LOG_DIR
+          exit 2
+        fi
+
   parse_and_upload_results:
     runs-on: daq
     if: always()
@@ -144,13 +158,13 @@ jobs:
         RELEASE_TAG: ${{needs.make_variables.outputs.tag}}
       run: |
         cd daq-release-extended-tests/scripts/github-ci/
-        python integtest_xml_parser.py --input-directory ${{ needs.make_variables.outputs.integtest_output_path }}
+        python integtest_xml_parser.py --input-directory ${{ needs.extended_integration_tests.outputs.integtest_log_dir }}
         cat pytest_summary_table.md >> $GITHUB_STEP_SUMMARY
     - name: Upload markdown summary as artifact
       uses: actions/upload-artifact@v6
       with:
         if-no-files-found: error
-        name: nightly_integtest_summary
+        name: nightly_extended_integtest_summary
         path: daq-release-integtest/scripts/github-ci/pytest_summary_table.md
 
   store_and_upload_logs:
@@ -197,7 +211,8 @@ jobs:
           #echo "NOT removing ${{ needs.make_variables.outputs.integtest_output_path }} for now"
       - name: Remove daq-release
         run: |
-          rm -rf ${{ github.workspace }}/daq-release-integtest/
+          rm -rf ${{ github.workspace }}/daq-release-extended-tests/
+          rm -rf ${{ needs.make_variables.outputs.tag }}
 
   # Integration tests can sometimes collide with stale processes, leading to timeout
   cleanup_stale_gunicorn_processes:

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -101,8 +101,6 @@ jobs:
 
     - name: Create build area
       run: |
-        echo "PWD: $(pwd)"
-        echo "ls: $(ls)"
         source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
         setup_dbt latest_v5
         if [[ "$IS_CANDIDATE_RELEASE" == "true" ]]; then
@@ -204,8 +202,7 @@ jobs:
       integtest_xml_dir: ${{ needs.extended_integration_tests.outputs.integtest_log_dir }}
       integtest_log_dir: ${{ needs.make_variables.outputs.persistent_log_dir }}
     secrets: 
-      #slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-      slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   cleanup_files:
     runs-on: daq

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -192,14 +192,20 @@ jobs:
         old_dirs=$(find /home/nfs/dunedaq/github-actions -mindepth 1 -maxdepth 1 -type d -mtime +7)
         echo "Removing the following directories that are more than 7 days old: $old_dirs"
         rm -rf $old_dirs
+    - name: Debug prints
+      run: |
+        echo "Integtest_log_dir: ${{ needs.extended_integration_tests.outputs.integtest_log_dir }}"
+        echo "ls integtest_log_dir: $(ls ${{ needs.extended_integration_tests.outputs.integtest_log_dir }})"
+
 
   send_slack_message:
     if: (success() || failure()) && ((github.event_name != 'workflow_dispatch') || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes'))
-    needs: [make_variables, store_and_upload_logs]
+    needs: [make_variables, extended_integration_tests, store_and_upload_logs]
     uses: ./.github/workflows/slack-notification.yml
     with:
       release_tag: ${{ needs.make_variables.outputs.tag }}
-      integtest_xml_dir: ${{ needs.make_variables.outputs.integtest_output_path }}
+      #integtest_xml_dir: ${{ needs.make_variables.outputs.integtest_output_path }}
+      integtest_xml_dir: ${{ needs.extended_integration_tests.outputs.integtest_log_dir }}
       integtest_log_dir: ${{ needs.make_variables.outputs.persistent_log_dir }}
     secrets: 
       #slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -95,6 +95,8 @@ jobs:
 
     - name: Create build area
       run: |
+        echo "PWD: $(pwd)"
+        echo "ls: $(ls)"
         source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
         setup_dbt latest_v5
         if [[ "$IS_CANDIDATE_RELEASE" == "true" ]]; then
@@ -113,7 +115,6 @@ jobs:
         cd ${{ env.DBT_AREA_ROOT }}
         source env.sh
         cd ../daq-release-extended-tests/scripts
-        #cd ${{ github.workspace }}/daq-release-code-checks/scripts
         #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         ./checkout-daq-package.py -p dfmodules -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
@@ -212,6 +213,8 @@ jobs:
       - name: Remove daq-release
         run: |
           rm -rf ${{ github.workspace }}/daq-release-extended-tests/
+          pwd
+          ls -lrt ${{ needs.make_variables.outputs.tag }}
           rm -rf ${{ needs.make_variables.outputs.tag }}
 
   # Integration tests can sometimes collide with stale processes, leading to timeout

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -75,7 +75,7 @@ jobs:
   extended_integration_tests:
     name: extended_integration_tests
     runs-on: daq
-    timeout-minutes: 30
+    timeout-minutes: 60
     needs: make_variables
     outputs:
       integtest_log_dir: ${{ steps.integtests.outputs.integtest_log_dir }}

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -108,15 +108,15 @@ jobs:
         if [[ "$IS_CANDIDATE_RELEASE" == "true" ]]; then
           echo "create -b candidate $RELEASE_TAG"
           [[ -e /cvmfs/dunedaq-development.opensciencegrid.org/candidates/$RELEASE_TAG/daq_app_rte.sh ]]
-          dbt-create -b candidate $RELEASE_TAG
+          dbt-create -b candidate $RELEASE_TAG $RELEASE_TAG
         elif [[ "$IS_STABLE_RELEASE" == "true" ]]; then
           echo "create $RELEASE_TAG"
           [[ -e /cvmfs/dunedaq.opensciencegrid.org/spack/releases/$RELEASE_TAG/daq_app_rte.sh ]]
-          dbt-create $RELEASE_TAG
+          dbt-create $RELEASE_TAG $RELEASE_TAG
         else
           echo "create -n $RELEASE_TAG"
           [[ -e /cvmfs/dunedaq-development.opensciencegrid.org/nightly/$RELEASE_TAG/daq_app_rte.sh ]]
-          dbt-create -n $RELEASE_TAG
+          dbt-create -n $RELEASE_TAG $RELEASE_TAG
         fi
         cd ${{ env.DBT_AREA_ROOT }}
         source env.sh

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -119,10 +119,10 @@ jobs:
         cd ${{ env.DBT_AREA_ROOT }}
         source env.sh
         cd ../$DAQ_RELEASE_PATH/scripts
-        #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         #./checkout-daq-package.py -p dfmodules -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
 
     - name: Run integration tests

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -81,6 +81,7 @@ jobs:
       integtest_log_dir: ${{ steps.integtests.outputs.integtest_log_dir }}
     env:
       DBT_AREA_ROOT: ${{ needs.make_variables.outputs.tag }}
+      RELEASE_TAG: ${{ needs.make_variables.outputs.tag }}
     defaults:
       run:
         shell: bash
@@ -96,17 +97,17 @@ jobs:
         source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
         setup_dbt latest_v5
         if [[ "$IS_CANDIDATE_RELEASE" == "true" ]]; then
-          echo "dbt-setup-release -b candidate $release_tag"
-          [[ -e /cvmfs/dunedaq-development.opensciencegrid.org/candidates/$release_tag/daq_app_rte.sh ]]
-          dbt-create -b candidate $release_tag
+          echo "create -b candidate $RELEASE_TAG"
+          [[ -e /cvmfs/dunedaq-development.opensciencegrid.org/candidates/$RELEASE_TAG/daq_app_rte.sh ]]
+          dbt-create -b candidate $RELEASE_TAG
         elif [[ "$IS_STABLE_RELEASE" == "true" ]]; then
-          echo "dbt-setup-release $release_tag"
-          [[ -e /cvmfs/dunedaq.opensciencegrid.org/spack/releases/$release_tag/daq_app_rte.sh ]]
-          dbt-create $release_tag
+          echo "create $RELEASE_TAG"
+          [[ -e /cvmfs/dunedaq.opensciencegrid.org/spack/releases/$RELEASE_TAG/daq_app_rte.sh ]]
+          dbt-create $RELEASE_TAG
         else
-          echo "dbt-setup-release -n $release_tag"
-          [[ -e /cvmfs/dunedaq-development.opensciencegrid.org/nightly/$release_tag/daq_app_rte.sh ]]
-          dbt-create -n $release_tag
+          echo "create -n $RELEASE_TAG"
+          [[ -e /cvmfs/dunedaq-development.opensciencegrid.org/nightly/$RELEASE_TAG/daq_app_rte.sh ]]
+          dbt-create -n $RELEASE_TAG
         fi
         cd ${{ env.DBT_AREA_ROOT }}
         source env.sh

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -32,6 +32,7 @@ jobs:
       timestamp: ${{ steps.create_variables.outputs.timestamp }}
       persistent_log_dir: ${{ steps.create_variables.outputs.persistent_log_dir }}
       integtest_output_path: ${{ steps.create_variables.outputs.integtest_output_path }}
+      daq_release_path: ${{ steps.create_variables.outputs.daq_release_path }}
     defaults:
       run:
         shell: bash
@@ -63,6 +64,7 @@ jobs:
           timestamp=$(date +"%Y-%m-%d-%H%M%Z")
           persistent_log_dir=/home/nfs/dunedaq/github-actions/pytest-logs-extended-${timestamp}
           integtest_output_path=${{ github.workspace }}/integration_tests_${release_tag}
+          daq_release_path="daq-release-extended-tests"
 
           echo "release_tag=${release_tag}"  >>  "$GITHUB_OUTPUT"
           echo "is_candidate=${is_candidate}"  >>  "$GITHUB_OUTPUT"
@@ -70,6 +72,7 @@ jobs:
           echo "timestamp=${timestamp}" >> "$GITHUB_OUTPUT"
           echo "persistent_log_dir=${persistent_log_dir}" >> "$GITHUB_OUTPUT"
           echo "integtest_output_path=${integtest_output_path}" >> "$GITHUB_OUTPUT"
+          echo "daq_release_path=${daq_release_path}" >> "$GITHUB_OUTPUT"
           cat "$GITHUB_OUTPUT"
 
   extended_integration_tests:
@@ -83,6 +86,7 @@ jobs:
       DBT_AREA_ROOT: ${{ needs.make_variables.outputs.tag }}
       RELEASE_TAG: ${{ needs.make_variables.outputs.tag }}
       PERSISTENT_LOG_DIR: ${{ needs.make_variables.outputs.persistent_log_dir }}
+      DAQ_RELEASE_PATH: ${{ needs.make_variables.outputs.daq_release_path }}
     defaults:
       run:
         shell: bash
@@ -91,7 +95,7 @@ jobs:
     - name: checkout daq-release
       uses: actions/checkout@v6
       with:
-        path: daq-release-extended-tests
+        path: ${{ needs.make_variables.outputs.daq_release_path }}
 
     - name: Create build area
       run: |
@@ -114,7 +118,7 @@ jobs:
         fi
         cd ${{ env.DBT_AREA_ROOT }}
         source env.sh
-        cd ../daq-release-extended-tests/scripts
+        cd ../$DAQ_RELEASE_PATH/scripts
         #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         ./checkout-daq-package.py -p dfmodules -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
@@ -156,9 +160,10 @@ jobs:
     steps:
     - name: Generate summary tables
       env:
-        RELEASE_TAG: ${{needs.make_variables.outputs.tag}}
+        RELEASE_TAG: ${{ needs.make_variables.outputs.tag }}
+        DAQ_RELEASE_PATH: ${{ needs.make_variables.outputs.daq_release_path }}
       run: |
-        cd daq-release-extended-tests/scripts/github-ci/
+        cd $DAQ_RELEASE_PATH/scripts/github-ci/
         python integtest_xml_parser.py --input-directory ${{ needs.extended_integration_tests.outputs.integtest_log_dir }}
         cat pytest_summary_table.md >> $GITHUB_STEP_SUMMARY
     - name: Upload markdown summary as artifact
@@ -166,7 +171,7 @@ jobs:
       with:
         if-no-files-found: error
         name: nightly_extended_integtest_summary
-        path: daq-release-integtest/scripts/github-ci/pytest_summary_table.md
+        path: $DAQ_RELEASE_PATH/scripts/github-ci/pytest_summary_table.md
 
   store_and_upload_logs:
     runs-on: daq
@@ -206,13 +211,14 @@ jobs:
     steps:
       - name: Remove xml files
         env:
-          RELEASE_TAG: ${{needs.make_variables.outputs.tag}}
+          RELEASE_TAG: ${{ needs.make_variables.outputs.tag }}
+          DAQ_RELEASE_PATH: ${{ needs.make_variables.outputs.daq_release_path }}
         run: |
           rm -rf ${{ needs.make_variables.outputs.integtest_output_path }}
           #echo "NOT removing ${{ needs.make_variables.outputs.integtest_output_path }} for now"
       - name: Remove daq-release
         run: |
-          rm -rf ${{ github.workspace }}/daq-release-extended-tests/
+          rm -rf ${{ github.workspace }}/$DAQ_RELEASE_PATH
           pwd
           ls -lrt ${{ needs.make_variables.outputs.tag }}
           rm -rf ${{ needs.make_variables.outputs.tag }}

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -87,6 +87,8 @@ jobs:
       RELEASE_TAG: ${{ needs.make_variables.outputs.tag }}
       PERSISTENT_LOG_DIR: ${{ needs.make_variables.outputs.persistent_log_dir }}
       DAQ_RELEASE_PATH: ${{ needs.make_variables.outputs.daq_release_path }}
+      IS_CANDIDATE_RELEASE: ${{ needs.make_variables.outputs.is_candidate_release }}
+      IS_STABLE_RELEASE: ${{ needs.make_variables.outputs.is_stable_release }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -119,10 +119,10 @@ jobs:
         cd ${{ env.DBT_AREA_ROOT }}
         source env.sh
         cd ../$DAQ_RELEASE_PATH/scripts
-        ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         #./checkout-daq-package.py -p dfmodules -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
 
     - name: Run integration tests
@@ -202,7 +202,8 @@ jobs:
       integtest_xml_dir: ${{ needs.make_variables.outputs.integtest_output_path }}
       integtest_log_dir: ${{ needs.make_variables.outputs.persistent_log_dir }}
     secrets: 
-      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+      #slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+      slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
 
   cleanup_files:
     runs-on: daq

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -208,21 +208,20 @@ jobs:
     runs-on: daq
     if: always()
     needs: [make_variables, parse_and_upload_results, send_slack_message]
+    env:
+      RELEASE_TAG: ${{ needs.make_variables.outputs.tag }}
+      DAQ_RELEASE_PATH: ${{ needs.make_variables.outputs.daq_release_path }}
     steps:
       - name: Remove xml files
-        env:
-          RELEASE_TAG: ${{ needs.make_variables.outputs.tag }}
-          DAQ_RELEASE_PATH: ${{ needs.make_variables.outputs.daq_release_path }}
         run: |
           rm -rf ${{ needs.make_variables.outputs.integtest_output_path }}
-          #echo "NOT removing ${{ needs.make_variables.outputs.integtest_output_path }} for now"
       - name: Remove daq-release
         run: |
           #rm -rf $DAQ_RELEASE_PATH
+          echo "DAQ_RELEASE_PATH: $DAQ_RELEASE_PATH"
           ls -lrt $DAQ_RELEASE_PATH
           echo "PWD REMOVE: $(pwd)"
-          ls -lrt ${{ needs.make_variables.outputs.tag }}
-          #rm -rf ${{ needs.make_variables.outputs.tag }}
+          rm -rf ${{ needs.make_variables.outputs.tag }}
 
   # Integration tests can sometimes collide with stale processes, leading to timeout
   cleanup_stale_gunicorn_processes:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -2,7 +2,7 @@ name: Integration test workflow
 
 on:
   schedule:
-    - cron: "0 7 * * *"
+    - cron: "0 6 * * *"
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/nightly-ci-dashboard.yml
+++ b/.github/workflows/nightly-ci-dashboard.yml
@@ -17,6 +17,7 @@ jobs:
       lcov_html_report_path: ${{ steps.set_paths.outputs.lcov_html_report_path }}
       code_check_summary_path: ${{ steps.set_paths.outputs.code_check_summary_path }}
       integration_test_summary_path: ${{ steps.set_paths.outputs.integration_test_summary_path }}
+      extended_integration_test_summary_path: ${{ steps.set_paths.outputs.extended_integration_test_summary_path }}
     defaults:
       run: 
         shell: bash
@@ -29,6 +30,7 @@ jobs:
         echo "lcov_html_report_path=lcov_report" >> "$GITHUB_OUTPUT"
         echo "code_check_summary_path=code_check_summary" >> "$GITHUB_OUTPUT"
         echo "integration_test_summary_path=integration_test_summary" >> "$GITHUB_OUTPUT"
+        echo "extended_integration_test_summary_path=extended_integration_test_summary" >> "$GITHUB_OUTPUT"
     - name: Get workflow run IDs
       id: run_ids
       run: |
@@ -42,11 +44,16 @@ jobs:
                                    --json databaseId --jq '.[0].databaseId')
         integration_test_id=$(gh run list --repo DUNE-DAQ/daq-release \
                                           --workflow integration_tests.yml \
-                                          --limit 1 --status success \
+                                          --limit 1 \
+                                          --json databaseId --jq '.[0].databaseId')
+        extended_integration_test_id=$(gh run list --repo DUNE-DAQ/daq-release \
+                                          --workflow extended_integration_tests.yml \
+                                          --limit 1 \
                                           --json databaseId --jq '.[0].databaseId')
         echo "code_check_id=$code_check_id" | tee -a "$GITHUB_OUTPUT"
         echo "lcov_id=$lcov_id" | tee -a "$GITHUB_OUTPUT"
         echo "integration_test_id=$integration_test_id" | tee -a "$GITHUB_OUTPUT"
+        echo "extended_integration_test_id=$extended_integration_test_id" | tee -a "$GITHUB_OUTPUT"
 
     - name: Download lcov html report
       id: download_lcov
@@ -73,6 +80,15 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         path: ${{ steps.set_paths.outputs.integration_test_summary_path }}
         run-id: ${{ steps.run_ids.outputs.integration_test_id }}
+
+    - name: Download extended integration test summary
+      id: download_extended_integration_test
+      uses: actions/download-artifact@v7
+      with:
+        name: nightly_extended_integtest_summary
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        path: ${{ steps.set_paths.outputs.extended_integration_test_summary_path }}
+        run-id: ${{ steps.run_ids.outputs.extended_integration_test_id }}
   
   build_ci_dashboard:
     runs-on: daq
@@ -81,7 +97,7 @@ jobs:
       run:
         shell: bash
     steps:
-    - name: Checkout daq-release feature branch
+    - name: Checkout daq-release
       uses: actions/checkout@v4
       with:
         path: daq-release-ci-dashboard
@@ -95,6 +111,7 @@ jobs:
         cp -r lcov_report ${{ env.CI_DASHBOARD_DIR }}/site/code_coverage
         cp -r code_check_summary/ ${{ env.CI_DASHBOARD_DIR }}/code_check_summary
         cp -r integration_test_summary/ ${{ env.CI_DASHBOARD_DIR }}/integration_test_summary
+        cp -r extended_integration_test_summary/ ${{ env.CI_DASHBOARD_DIR }}/extended_integration_test_summary
         cd ${{ env.CI_DASHBOARD_DIR }}
         echo "Debug: pwd - $(pwd)"
         echo "Debug: ls - $(ls)"
@@ -102,7 +119,7 @@ jobs:
         echo "Collected the following metrics:"
         cat ci_summary.json
         ./combine_markdown_summaries.sh integration_test_summary/pytest_summary_table.md \
-                                        code_check_summary/pytest_summary/pytest_summary_table.md \
+                                        extended_integration_test_summary/pytest_summary/pytest_summary_table.md \
                                         > combined_pytest_summary.md
         cat combined_pytest_summary.md
         python generate_ci_site.py --json_input ci_summary.json \

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -32,12 +32,10 @@ jobs:
       upload_logs: 'yes'
 
   run_checks:
-    name: Run linting and integration tests
+    name: Run integration tests and clang formatting
     runs-on: daq
     needs: [make_variables, run_unittests]
     timeout-minutes: 60
-    outputs:
-      integtest_log_dir: ${{ steps.integtests.outputs.integtest_log_dir }}
     env:
       DBT_AREA_ROOT: ${{ needs.make_variables.outputs.tag }}
     defaults:
@@ -76,49 +74,19 @@ jobs:
         name: clang_formatting_summary
         path: ${{ env.DBT_AREA_ROOT }}/sourcecode/clang_format_summary_table.md
 
-    - name: Run integration tests
-      id: integtests
-      run: |
-        cd $DBT_AREA_ROOT
-        # daqsystemtest and listrev tests are already run as part of the nightly integration tests
-        rm -rf sourcecode/daqsystemtest
-        rm -rf sourcecode/listrev
-        source env.sh
-        dbt-workarea-env
-        dbt-build --integtest | tee integtest_full_output.log
-        # Log directory is the last non-empty line of output
-        integtest_log_dir=$(readlink -f $DBT_AREA_ROOT/log/integtest_tests_* | tail -n 1)
-        echo "integtest_log_dir=${integtest_log_dir}" >> "$GITHUB_OUTPUT"
-        echo "integtest_log_dir: $integtest_log_dir"
-
-  parse_integtest_results:
-    runs-on: daq
-    needs: [make_variables, run_unittests, run_checks]
-    steps:
-    - name: Generate summary tables
-      run: |
-        cd daq-release-code-checks/scripts/github-ci/
-        python integtest_xml_parser.py --input-directory ${{ needs.run_checks.outputs.integtest_log_dir }}
-        cat pytest_summary_table.md >> $GITHUB_STEP_SUMMARY
-
-    - name: Upload pytest summary
-      uses: actions/upload-artifact@v6
-      with:
-        if-no-files-found: error
-        name: pytest_summary
-        path: daq-release-code-checks/scripts/github-ci/pytest_summary_table.md
-
   send_slack_message:
     if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')
-    needs: parse_integtest_results
+    needs: [make_variables, run_checks]
     uses: ./.github/workflows/slack-notification.yml
     secrets: 
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+    with:
+      release_tag: ${{ needs.make_variables.outputs.tag }}
 
   cleanup_test_area:
     runs-on: daq
     if: always()
-    needs: [make_variables, parse_integtest_results]
+    needs: [make_variables, send_slack_message]
     steps:
       - name: Remove test directory and daq-release
         run: |


### PR DESCRIPTION
This PR refactors the extended integration tests (i.e., those outside `daqsystemtest` and `listrev`) into their own workflow. Unlike the core integration tests, the extended tests run in a local build area using `dbt-build --integtest`. This workflow runs after the core integration tests, which have been moved to run one hour sooner than before. I've also updated the nightly CI dashboard workflow to account for the new location of integration test artifacts. 