### PR TITLE
Refactor integration test XML parsing

### DIFF
--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -165,6 +165,9 @@ jobs:
       run: |
         cd $DAQ_RELEASE_PATH/scripts/github-ci/
         python integtest_xml_parser.py --input-directory ${{ needs.extended_integration_tests.outputs.integtest_log_dir }}
+        echo "-------json summary------------"
+        cat pytest_summary.json
+        echo "-------json summary end------------"
         cat pytest_summary_table.md >> $GITHUB_STEP_SUMMARY
     - name: Upload markdown summary as artifact
       uses: actions/upload-artifact@v6
@@ -172,6 +175,12 @@ jobs:
         if-no-files-found: error
         name: nightly_extended_integtest_summary
         path: ${{ needs.make_variables.outputs.daq_release_path }}/scripts/github-ci/pytest_summary_table.md
+    - name: Upload json summary as artifact
+      uses: actions/upload-artifact@v6
+      with:
+        if-no-files-found: error
+        name: nightly_extended_integtest_json
+        path: ${{ needs.make_variables.outputs.daq_release_path }}/scripts/github-ci/pytest_summary.json
 
   store_and_upload_logs:
     runs-on: daq

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -98,6 +98,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         path: ${{ needs.make_variables.outputs.daq_release_path }}
+        ref: amogan/refactor_xml_parsing
 
     - name: Create build area
       run: |

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -98,7 +98,6 @@ jobs:
       uses: actions/checkout@v6
       with:
         path: ${{ needs.make_variables.outputs.daq_release_path }}
-        ref: amogan/refactor_xml_parsing
 
     - name: Create build area
       run: |
@@ -166,9 +165,6 @@ jobs:
       run: |
         cd $DAQ_RELEASE_PATH/scripts/github-ci/
         python integtest_xml_parser.py --input-directory ${{ needs.extended_integration_tests.outputs.integtest_log_dir }}
-        echo "-------json summary------------"
-        cat pytest_summary.json
-        echo "-------json summary end------------"
         cat pytest_summary_table.md >> $GITHUB_STEP_SUMMARY
     - name: Upload markdown summary as artifact
       uses: actions/upload-artifact@v6

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -171,7 +171,7 @@ jobs:
       run: |
         cd daq-release-integtest/scripts/github-ci/
         python integtest_xml_parser.py \
-            --input-directory ${{ needs.make_variables.outputs.integtest_output_path }} \
+               --input-directory ${{ needs.make_variables.outputs.integtest_output_path }}
         echo "-------json summary------------"
         cat pytest_summary.json
         echo "-------json summary end------------"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -164,6 +164,7 @@ jobs:
       with:
         repository: DUNE-DAQ/daq-release
         path: daq-release-integtest
+        ref: amogan/refactor_xml_parsing
     - name: Generate summary tables
       env:
         RELEASE_TAG: ${{needs.make_variables.outputs.tag}}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -83,16 +83,16 @@ jobs:
 
             test_name: [
                         "listrev_test",
-                        #"3ru_1df_multirun_test",
-                        #"3ru_3df_multirun_test",
-                        #"example_system_test",
-                        #"fake_data_producer_test",
-                        #"long_window_readout_test",
+                        "3ru_1df_multirun_test",
+                        "3ru_3df_multirun_test",
+                        "example_system_test",
+                        "fake_data_producer_test",
+                        "long_window_readout_test",
                         "minimal_system_quick_test",
-                        #"readout_type_scan_test",
-                        #"small_footprint_quick_test",
-                        #"tpreplay_test",
-                        #"tpstream_writing_test"
+                        "readout_type_scan_test",
+                        "small_footprint_quick_test",
+                        "tpreplay_test",
+                        "tpstream_writing_test"
                        ]
     defaults:
       run:
@@ -164,7 +164,6 @@ jobs:
       with:
         repository: DUNE-DAQ/daq-release
         path: daq-release-integtest
-        ref: amogan/refactor_xml_parsing
     - name: Generate summary tables
       env:
         RELEASE_TAG: ${{needs.make_variables.outputs.tag}}
@@ -172,9 +171,6 @@ jobs:
         cd daq-release-integtest/scripts/github-ci/
         python integtest_xml_parser.py \
                --input-directory ${{ needs.make_variables.outputs.integtest_output_path }}
-        echo "-------json summary------------"
-        cat pytest_summary.json
-        echo "-------json summary end------------"
         cat pytest_summary_table.md >> $GITHUB_STEP_SUMMARY
     - name: Upload markdown summary as artifact
       uses: actions/upload-artifact@v6
@@ -218,8 +214,7 @@ jobs:
       integtest_xml_dir: ${{ needs.make_variables.outputs.integtest_output_path }}
       integtest_log_dir: ${{ needs.make_variables.outputs.persistent_log_dir }}
     secrets: 
-      #slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-      slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   cleanup_files:
     runs-on: daq

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -171,7 +171,6 @@ jobs:
         cd daq-release-integtest/scripts/github-ci/
         python integtest_xml_parser.py \
             --input-directory ${{ needs.make_variables.outputs.integtest_output_path }} \
-            --to-json
         echo "-------json summary------------"
         cat pytest_summary.json
         echo "-------json summary end------------"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -83,16 +83,16 @@ jobs:
 
             test_name: [
                         "listrev_test",
-                        "3ru_1df_multirun_test",
-                        "3ru_3df_multirun_test",
-                        "example_system_test",
-                        "fake_data_producer_test",
-                        "long_window_readout_test",
+                        #"3ru_1df_multirun_test",
+                        #"3ru_3df_multirun_test",
+                        #"example_system_test",
+                        #"fake_data_producer_test",
+                        #"long_window_readout_test",
                         "minimal_system_quick_test",
-                        "readout_type_scan_test",
-                        "small_footprint_quick_test",
-                        "tpreplay_test",
-                        "tpstream_writing_test"
+                        #"readout_type_scan_test",
+                        #"small_footprint_quick_test",
+                        #"tpreplay_test",
+                        #"tpstream_writing_test"
                        ]
     defaults:
       run:
@@ -169,7 +169,12 @@ jobs:
         RELEASE_TAG: ${{needs.make_variables.outputs.tag}}
       run: |
         cd daq-release-integtest/scripts/github-ci/
-        python integtest_xml_parser.py --input-directory ${{ needs.make_variables.outputs.integtest_output_path }}
+        python integtest_xml_parser.py \
+            --input-directory ${{ needs.make_variables.outputs.integtest_output_path }} \
+            --to-json
+        echo "-------json summary------------"
+        cat pytset_summary.json
+        echo "-------json summary end------------"
         cat pytest_summary_table.md >> $GITHUB_STEP_SUMMARY
     - name: Upload markdown summary as artifact
       uses: actions/upload-artifact@v6
@@ -177,6 +182,12 @@ jobs:
         if-no-files-found: error
         name: nightly_integtest_summary
         path: daq-release-integtest/scripts/github-ci/pytest_summary_table.md
+    - name: Upload json summary as artifact
+      uses: actions/upload-artifact@v6
+      with:
+        if-no-files-found: error
+        name: nightly_integtest_json
+        path: daq-release-integtest/scripts/github-ci/pytest_summary.json
 
   store_and_upload_logs:
     runs-on: daq

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -218,7 +218,8 @@ jobs:
       integtest_xml_dir: ${{ needs.make_variables.outputs.integtest_output_path }}
       integtest_log_dir: ${{ needs.make_variables.outputs.persistent_log_dir }}
     secrets: 
-      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+      #slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+      slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
 
   cleanup_files:
     runs-on: daq

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -173,7 +173,7 @@ jobs:
             --input-directory ${{ needs.make_variables.outputs.integtest_output_path }} \
             --to-json
         echo "-------json summary------------"
-        cat pytset_summary.json
+        cat pytest_summary.json
         echo "-------json summary end------------"
         cat pytest_summary_table.md >> $GITHUB_STEP_SUMMARY
     - name: Upload markdown summary as artifact

--- a/.github/workflows/nightly-ci-dashboard.yml
+++ b/.github/workflows/nightly-ci-dashboard.yml
@@ -119,7 +119,7 @@ jobs:
         cat combined_pytest_summary.md
         python generate_ci_site.py --json_input ci_summary.json \
                                    --unit_test_summary code_check_summary/unit_test_summary/unit_test_summary.log \
-                                   --pytest_summary pytest_summary.json
+                                   --pytest_summary combined_pytest_summary.md
 
   deploy_to_github_pages:
     name: Deploy to GitHub Pages

--- a/.github/workflows/nightly-ci-dashboard.yml
+++ b/.github/workflows/nightly-ci-dashboard.yml
@@ -119,7 +119,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: daq-release-ci-dashboard
-        ref: amogan/refactor_xml_parsing
     - name: Copy artifacts and generate dashboard
       env:
         CI_DASHBOARD_DIR: daq-release-ci-dashboard/scripts/github-ci/ci-dashboard

--- a/.github/workflows/nightly-ci-dashboard.yml
+++ b/.github/workflows/nightly-ci-dashboard.yml
@@ -115,13 +115,14 @@ jobs:
         ./collect-ci-metrics.sh
         echo "Collected the following metrics:"
         cat ci_summary.json
-        ./combine_markdown_summaries.sh integration_test_summary/pytest_summary_table.md \
-                                        extended_integration_test_summary/pytest_summary_table.md \
-                                        > combined_pytest_summary.md
-        cat combined_pytest_summary.md
+        #./combine_markdown_summaries.sh integration_test_summary/pytest_summary_table.md \
+        #                                extended_integration_test_summary/pytest_summary_table.md \
+        #                                > combined_pytest_summary.md
+        #cat combined_pytest_summary.md
         python generate_ci_site.py --json_input ci_summary.json \
                                    --unit_test_summary code_check_summary/unit_test_summary/unit_test_summary.log \
-                                   --pytest_summary combined_pytest_summary.md
+                                   --core_pytest_summary integration_test_summary/pytest_summary.json \
+                                   --extended_pytest_summary extended_integration_test_summary/pytest_summary.json \
 
   deploy_to_github_pages:
     name: Deploy to GitHub Pages

--- a/.github/workflows/nightly-ci-dashboard.yml
+++ b/.github/workflows/nightly-ci-dashboard.yml
@@ -119,7 +119,7 @@ jobs:
         cat combined_pytest_summary.md
         python generate_ci_site.py --json_input ci_summary.json \
                                    --unit_test_summary code_check_summary/unit_test_summary/unit_test_summary.log \
-                                   --pytest_summary combined_pytest_summary.md
+                                   --pytest_summary pytest_summary.json
 
   deploy_to_github_pages:
     name: Deploy to GitHub Pages

--- a/.github/workflows/nightly-ci-dashboard.yml
+++ b/.github/workflows/nightly-ci-dashboard.yml
@@ -105,11 +105,11 @@ jobs:
       env:
         CI_DASHBOARD_DIR: daq-release-ci-dashboard/scripts/github-ci/ci-dashboard
       run: |
-        cd ${{ env.CI_DASHBOARD_DIR }}
         cp -r lcov_report ${{ env.CI_DASHBOARD_DIR }}/site/code_coverage
         cp -r code_check_summary/ ${{ env.CI_DASHBOARD_DIR }}/code_check_summary
         cp -r integration_test_summary/ ${{ env.CI_DASHBOARD_DIR }}/integration_test_summary
         cp -r extended_integration_test_summary/ ${{ env.CI_DASHBOARD_DIR }}/extended_integration_test_summary
+        cd ${{ env.CI_DASHBOARD_DIR }}
         ls integration_test_summary
         ls extended_integration_test_summary
         ./collect-ci-metrics.sh

--- a/.github/workflows/nightly-ci-dashboard.yml
+++ b/.github/workflows/nightly-ci-dashboard.yml
@@ -101,6 +101,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: daq-release-ci-dashboard
+        ref: amogan/refactor_xml_parsing
     - name: Copy artifacts and generate dashboard
       env:
         CI_DASHBOARD_DIR: daq-release-ci-dashboard/scripts/github-ci/ci-dashboard

--- a/.github/workflows/nightly-ci-dashboard.yml
+++ b/.github/workflows/nightly-ci-dashboard.yml
@@ -72,7 +72,7 @@ jobs:
         path: ${{ steps.set_paths.outputs.code_check_summary_path }}
         run-id: ${{ steps.run_ids.outputs.code_check_id }}
 
-    - name: Download integration test summary
+    - name: Download integration test markdown
       id: download_integration_test
       uses: actions/download-artifact@v7
       with:
@@ -81,11 +81,29 @@ jobs:
         path: ${{ steps.set_paths.outputs.integration_test_summary_path }}
         run-id: ${{ steps.run_ids.outputs.integration_test_id }}
 
-    - name: Download extended integration test summary
+    - name: Download integration test json
+      id: download_integration_test_json
+      uses: actions/download-artifact@v7
+      with:
+        name: nightly_integtest_json
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        path: ${{ steps.set_paths.outputs.integration_test_summary_path }}
+        run-id: ${{ steps.run_ids.outputs.integration_test_id }}
+
+    - name: Download extended integration test markdown
       id: download_extended_integration_test
       uses: actions/download-artifact@v7
       with:
         name: nightly_extended_integtest_summary
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        path: ${{ steps.set_paths.outputs.extended_integration_test_summary_path }}
+        run-id: ${{ steps.run_ids.outputs.extended_integration_test_id }}
+
+    - name: Download extended integration test json
+      id: download_extended_integration_test_json
+      uses: actions/download-artifact@v7
+      with:
+        name: nightly_extended_integtest_json
         github-token: ${{ secrets.GITHUB_TOKEN }}
         path: ${{ steps.set_paths.outputs.extended_integration_test_summary_path }}
         run-id: ${{ steps.run_ids.outputs.extended_integration_test_id }}
@@ -111,11 +129,11 @@ jobs:
         cp -r integration_test_summary/ ${{ env.CI_DASHBOARD_DIR }}/integration_test_summary
         cp -r extended_integration_test_summary/ ${{ env.CI_DASHBOARD_DIR }}/extended_integration_test_summary
         cd ${{ env.CI_DASHBOARD_DIR }}
-        ls integration_test_summary
-        ls extended_integration_test_summary
         ./collect-ci-metrics.sh
         echo "Collected the following metrics:"
         cat ci_summary.json
+        ls integration_test_summary
+        ls extended_integration_test_summary
         #./combine_markdown_summaries.sh integration_test_summary/pytest_summary_table.md \
         #                                extended_integration_test_summary/pytest_summary_table.md \
         #                                > combined_pytest_summary.md

--- a/.github/workflows/nightly-ci-dashboard.yml
+++ b/.github/workflows/nightly-ci-dashboard.yml
@@ -105,11 +105,13 @@ jobs:
       env:
         CI_DASHBOARD_DIR: daq-release-ci-dashboard/scripts/github-ci/ci-dashboard
       run: |
+        cd ${{ env.CI_DASHBOARD_DIR }}
         cp -r lcov_report ${{ env.CI_DASHBOARD_DIR }}/site/code_coverage
         cp -r code_check_summary/ ${{ env.CI_DASHBOARD_DIR }}/code_check_summary
         cp -r integration_test_summary/ ${{ env.CI_DASHBOARD_DIR }}/integration_test_summary
         cp -r extended_integration_test_summary/ ${{ env.CI_DASHBOARD_DIR }}/extended_integration_test_summary
-        cd ${{ env.CI_DASHBOARD_DIR }}
+        ls integration_test_summary
+        ls extended_integration_test_summary
         ./collect-ci-metrics.sh
         echo "Collected the following metrics:"
         cat ci_summary.json

--- a/.github/workflows/nightly-ci-dashboard.yml
+++ b/.github/workflows/nightly-ci-dashboard.yml
@@ -132,12 +132,6 @@ jobs:
         ./collect-ci-metrics.sh
         echo "Collected the following metrics:"
         cat ci_summary.json
-        ls integration_test_summary
-        ls extended_integration_test_summary
-        #./combine_markdown_summaries.sh integration_test_summary/pytest_summary_table.md \
-        #                                extended_integration_test_summary/pytest_summary_table.md \
-        #                                > combined_pytest_summary.md
-        #cat combined_pytest_summary.md
         python generate_ci_site.py --json_input ci_summary.json \
                                    --unit_test_summary code_check_summary/unit_test_summary/unit_test_summary.log \
                                    --core_pytest_summary integration_test_summary/pytest_summary.json \

--- a/parsers/junit_xml.py
+++ b/parsers/junit_xml.py
@@ -1,0 +1,220 @@
+import os
+import sys
+import re
+import argparse
+import html
+import json
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from textwrap import dedent
+from dataclasses import dataclass, field, asdict
+from collections import defaultdict
+
+@dataclass
+class TestCaseResult:
+    case_name: str
+    status: str
+    failure_message: str = ''
+
+    def summarize_failure(self) -> str:
+        if not self.failure_message:
+            return
+
+        failure_summary = ''
+        failed_line_pattern = r"\n>\s+(.*?)\n"
+
+        failure_summary += f"\n\t\t  *{self.case_name}* failed"
+        failed_line_match = re.findall(failed_line_pattern, self.failure_message)
+        if failed_line_match:
+            failure_summary += f" while checking \n\t\t`{failed_line_match[0]}`\n"
+        return failure_summary
+
+@dataclass
+class PytestResult:
+    repo_name: str
+    test_name: str
+    testcase_results: list[TestCaseResult] = field(default_factory=list)
+
+    @property
+    def passed(self) -> int:
+        return sum(tc.status == "passed" for tc in self.testcase_results)
+
+    @property
+    def failed(self) -> int:
+        return sum(tc.status == "failed" for tc in self.testcase_results)
+
+    @property
+    def skipped(self) -> int:
+        return sum(tc.status == "skipped" for tc in self.testcase_results)
+
+    @property
+    def errors(self) -> int:
+        return sum(tc.status == "error" for tc in self.testcase_results)
+
+
+@dataclass
+class IntegrationTestSummary:
+    pytest_results: list[PytestResult] = field(default_factory=list)
+
+    @property
+    def totals(self) -> dict[str, int]:
+        passed = sum(pr.passed for pr in self.pytest_results)
+        failed = sum(pr.failed for pr in self.pytest_results)
+        skipped = sum(pr.skipped for pr in self.pytest_results)
+        errors = sum(pr.errors for pr in self.pytest_results)
+        return {
+            "passed": passed,
+            "failed": failed,
+            "skipped": skipped,
+            "errors": errors,
+            "total_run": passed + failed
+        }
+
+    def to_dict(self) -> dict:
+        grouped: dict[str, list[dict]] = {}
+        for pr in self.pytest_results:
+            if pr.repo_name not in grouped:
+                grouped[pr.repo_name] = []
+            grouped[pr.repo_name].append(asdict(pr))
+
+        return {
+            "totals": {
+                "passed": self.totals['passed'],
+                "failed": self.totals['failed'],
+                "skipped": self.totals['skipped'],
+                "errors": self.totals['errors'],
+                "total_run": self.totals['total_run'],
+            },
+            "pytest_results": grouped
+        }
+
+    def to_json(self, path: str="pytest_summary.json"):
+        json_path = Path(path)
+        json_path.write_text(json.dumps(self.to_dict(), indent=2))
+
+    def to_markdown(self, output_filename: str="pytest_summary_table.md"):
+        def which_emoji(test_status: str) -> str:
+            emoji_map = {
+                'passed': ':white_check_mark:',
+                'failed': ':x:',
+                'skipped': ':fast_forward:',
+                'error': ':warning:'
+            }
+            return emoji_map.get(test_status, ':question:')
+
+        def format_markdown_row(testname: str, result: str) -> str:
+            emoji = which_emoji(result)
+            return f"| {testname} | {emoji} {result} |\n"
+
+        with open(output_filename, 'w') as f:
+            summary_string = dedent(f"""\
+                {self.totals['total_run']} total tests run. 
+                {self.totals['passed']} passed {which_emoji('passed')}, 
+                {self.totals['failed']} failed {which_emoji('failed')}, 
+                {self.totals['skipped']} were skipped {which_emoji('skipped')}, and
+                {self.totals['errors']} had errors {which_emoji('error')} which prevented the test from completing.\n""")
+            f.write(summary_string)
+
+            for idx, pytest_result in enumerate(self.pytest_results):
+                f.write(f"# {pytest_result.repo_name} {pytest_result.test_name} Results\n")
+                f.write("| Test Case | Status |\n")
+                f.write("|-----------|--------|\n")
+                for ic, case in enumerate(pytest_result.testcase_results):
+                    f.writelines(format_markdown_row(case.case_name, case.status))
+
+        if not Path(output_filename).is_file():
+            raise FileNotFoundError(f"There was a problem writing the output markdown file: {output_filename}")
+
+        print(f"Markdown summary generated at {output_filename}")
+
+class JUnitXMLParser:
+    def __init__(self, input_directory: str='', input_file: str=''):
+        self.input_directory = Path(input_directory) if Path(input_directory).is_dir() else None
+        self.input_file = Path(input_file) if Path(input_file).is_file() else None
+        self.summary = IntegrationTestSummary()
+
+        if not self.input_directory and not self.input_file:
+            raise FileNotFoundError("No valid input file or directory specified.")
+
+    def get_xml_files(self, pattern="*.xml"):
+        xml_files = self.input_directory.rglob(pattern)
+        if not xml_files:
+            raise FileNotFoundError(f"Error: No xml files found in {self.input_directory}.")
+        return xml_files
+
+    # Junit xml file names should be structured as <package_name>_<pytest_name>_results.xml
+    def get_package_name(self, file):
+        return file.stem.split('_')[0]
+
+    def get_pytest_name(self, file):
+        return file.stem.replace('_results', '').split('_', 1)[1]
+
+    def parse_xml_file(self, file_path):
+        tree = ET.parse(file_path)
+        root = tree.getroot()
+
+        package_name = self.get_package_name(file_path)
+        pytest_name  = self.get_pytest_name(file_path)
+
+        pytest_result = PytestResult(
+            repo_name=package_name,
+            test_name=pytest_name
+        )
+
+        for testcase in root.findall(".//testcase"):
+            test_name = testcase.get("name").split("[")[0]
+            result = "passed"
+            failure_message = ""
+
+            if (failure_element := testcase.find("failure")) is not None:
+                result = "failed"
+                failure_message = html.unescape(failure_element.text.strip()) if failure_element.text else "No message provided"
+            elif testcase.find("error") is not None:
+                result = "error"
+            elif testcase.find("skipped") is not None:
+                result = "skipped"
+            
+            testcase_result = TestCaseResult(
+                case_name=test_name,
+                status=result,
+                failure_message=failure_message
+            )
+
+            pytest_result.testcase_results.append(testcase_result)
+
+        self.summary.pytest_results.append(pytest_result)
+
+def main():
+    parser = argparse.ArgumentParser(description="Parse a JUnit XML file and extract test case results.")
+    parser.add_argument("--input-directory", "-d", type=str, default='',
+                        help="Path to the directory containing junit xml files.")
+    parser.add_argument("--input-file", "-i", type=str, default='',
+                        help="Path to a single JUnit XML file. Cannot be used in conjunction with --input-directory.")
+
+    args = parser.parse_args()
+
+    if len(sys.argv) == 1:
+        parser.print_usage()
+        exit(1)
+
+    integtest_parser = JUnitXMLParser(
+        input_directory=args.input_directory,
+        input_file=args.input_file,
+    )
+
+    if integtest_parser.input_directory:
+        xml_files = integtest_parser.get_xml_files()
+        for file in xml_files:
+            integtest_parser.parse_xml_file(file)
+
+    elif integtest_parser.input_file:
+        integtest_parser.parse_xml_file(integtest_parser.input_file)
+
+    integtest_parser.generate_markdown_table()
+    #integtest_parser.prepend_totals()
+    #summary = integtest_parser.parse_integration_test_summary('pytest_summary_table.md')
+    print('SUMMARY:', integtest_parser.summary)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/github-ci/ci-dashboard/combine_markdown_summaries.sh
+++ b/scripts/github-ci/ci-dashboard/combine_markdown_summaries.sh
@@ -22,7 +22,6 @@ extract_counts() {
   errored=$((errored + $(grep -oP '\s+\K[0-9]+(?= had errors)' "$file")))
 }
 
-# Loop over all input files
 for file in "$@"; do
   extract_counts "$file"
 
@@ -30,7 +29,6 @@ for file in "$@"; do
   awk '/^# /{flag=1} flag' "$file" >> /tmp/all_tables.tmp
 done
 
-# Output the combined summary
 echo "There were $total_tests total tests run."
 echo "           $passed passed :white_check_mark:,"
 echo "           $failed failed :x:,"
@@ -38,8 +36,6 @@ echo "           $skipped were skipped :fast_forward:, and"
 echo "           $errored had errors :warning: which prevented the test from completing."
 echo
 
-# Output the combined tables
 cat /tmp/all_tables.tmp
 
-# Clean up
 rm /tmp/all_tables.tmp

--- a/scripts/github-ci/ci-dashboard/data/integration_tests.py
+++ b/scripts/github-ci/ci-dashboard/data/integration_tests.py
@@ -1,76 +1,11 @@
-import re
 import json
+import sys
 from pathlib import Path
-from dataclasses import dataclass, field
 
-@dataclass
-class TestCaseResult:
-    name: str
-    status: str
+sys.path.append(str(Path(__file__).resolve().parents[4]))
+from parsers.junit_xml import JUnitXMLParser
 
-@dataclass
-class IntegrationTestSummary:
-    passed: int = 0
-    failed: int = 0
-    skipped: int = 0
-    errors: int = 0
-    total: int = 0
-    repo_results: dict[str, list[TestCaseResult]] = field(default_factory=dict)
-
-    def to_dict(self):
-        return {
-            "passed": self.passed,
-            "failed": self.failed,
-            "skipped": self.skipped,
-            "errors": self.errors,
-            "total": self.total,
-            "repo_results": self.repo_results
-        }
-
-def parse_integration_test_summary(pytest_summary):
-    summary = IntegrationTestSummary()
-
-    with open(pytest_summary, "r") as f:
-        num_header_lines = 5
-        lines = [line.strip() for line in f if line.strip()]
-        header_lines = lines[:num_header_lines]
-        results_lines = lines[num_header_lines:]
-
-    numbers = [int(re.search(r'\d+', line).group()) for line in header_lines]
-    total, passed, failed, skipped, errors = numbers
-    summary.total = total
-    summary.passed = passed
-    summary.failed = failed
-    summary.skipped = skipped
-    summary.errors = errors
-    # Parse test results line by line
-    i = 0
-    while i < len(results_lines):
-        line = results_lines[i]
-        if line.startswith("#"):
-            # Each section represents a new package
-            section_title = re.sub(r"^#+ ", "", line)
-            #summary["results"][section_title] = []
-            summary.repo_results[section_title] = []
-            i += 3  # Skip table header and separator
-
-            # Read test rows until next heading or end of list
-            while i < len(results_lines) and not results_lines[i].startswith("#"):
-                row = results_lines[i]
-                if "|" in row:
-                    columns = [c.strip() for c in row.strip("|").split("|")]
-                    if len(columns) == 2:
-                        test_name, status_col = columns
-                        status = "passed" if "passed" in status_col else "failed" if "failed" in status_col else "skipped" if "skipped" in status_col else "error"
-                        #summary["results"][section_title].append({
-                        #summary.repo_results[section_title].append({
-                        #    "name": test_name,
-                        #    "status": status
-                        #})
-                        test_result = TestCaseResult(name=test_name, status=status)
-                        summary.repo_results[section_title].append(test_result)
-                i += 1
-        else:
-            i += 1
-
-    return summary
+def load_integration_test_data(json_file: str):
+    with open(json_file) as f:
+        integration_test_data = json.load(f)
+    return integration_test_data

--- a/scripts/github-ci/ci-dashboard/data/integration_tests.py
+++ b/scripts/github-ci/ci-dashboard/data/integration_tests.py
@@ -5,7 +5,8 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[4]))
 from parsers.junit_xml import JUnitXMLParser
 
-def load_integration_test_data(json_file: str):
-    with open(json_file) as f:
-        integration_test_data = json.load(f)
-    return integration_test_data
+def load_integration_test_data(core_json_file: str, extended_json_file: str):
+    core_summary = IntegrationTestSummary.from_json_file(core_json_file)
+    extended_summary = IntegrationTestSummary.from_json_file(extended_json_file)
+    combined_summary = IntegrationTestSummary.combined(core_summary, extended_summary)
+    return combined_summary

--- a/scripts/github-ci/ci-dashboard/data/integration_tests.py
+++ b/scripts/github-ci/ci-dashboard/data/integration_tests.py
@@ -2,11 +2,11 @@ import json
 import sys
 from pathlib import Path
 
-sys.path.append(str(Path(__file__).resolve().parents[4]))
-from parsers.junit_xml import JUnitXMLParser
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from integration_test_summary import IntegrationTestSummary
 
 def load_integration_test_data(core_json_file: str, extended_json_file: str):
     core_summary = IntegrationTestSummary.from_json_file(core_json_file)
     extended_summary = IntegrationTestSummary.from_json_file(extended_json_file)
     combined_summary = IntegrationTestSummary.combined(core_summary, extended_summary)
-    return combined_summary
+    return combined_summary.to_dict()

--- a/scripts/github-ci/ci-dashboard/generate_ci_site.py
+++ b/scripts/github-ci/ci-dashboard/generate_ci_site.py
@@ -5,7 +5,7 @@ from jinja2 import Environment, FileSystemLoader
 from pathlib import Path
 from datetime import datetime
 
-from data.integration_tests import parse_integration_test_summary
+from data.integration_tests import load_integration_test_data
 from data.unit_tests import parse_unit_test_summary
 from renderer.renderer import Renderer
 from pages.page import Page, IndexPage, UnitTestPage, IntegrationTestPage
@@ -55,9 +55,8 @@ def generate_site(json_input_path, unit_test_summary='', pytest_summary=''):
     ]
 
     unit_test_data = parse_unit_test_summary(unit_test_summary)
-    integration_test_data = parse_integration_test_summary(pytest_summary)
+    integration_test_data = load_integration_test_data(pytest_summary)
     
-    # Content of the index page
     index_context = {
         "repos": repos,
         "last_updated": last_updated,
@@ -66,13 +65,13 @@ def generate_site(json_input_path, unit_test_summary='', pytest_summary=''):
         "passing_percentage": passing_percentage,
         "workflow_badges": workflow_badges,
         "unit_test_summary": unit_test_data,
-        "integration_test_summary": integration_test_data,
+        "integration_test_summary": integration_test_data["totals"],
     }
 
     pages = [
         IndexPage(index_context),
         UnitTestPage(unit_test_data.to_dict()),
-        IntegrationTestPage(integration_test_data.to_dict()),
+        IntegrationTestPage(integration_test_data),
     ]
 
     renderer = Renderer()
@@ -85,7 +84,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Generate CI HTML site from a JSON summary file.")
     parser.add_argument("--json_input", required=True, help="Path to the JSON file containing CI summary data. See collect-ci-metrics.sh.")
     parser.add_argument("--unit_test_summary", required=False, help="Path to the unit test summary output by dbt-build --unittest.")
-    parser.add_argument("--pytest_summary", required=False, help="Path to the pytest markdown summary output by integration test workflow.")
+    parser.add_argument("--pytest_summary", required=False, help="Path to the json summary output by integration test workflow.")
     args = parser.parse_args()
 
     generate_site(args.json_input, args.unit_test_summary, args.pytest_summary)

--- a/scripts/github-ci/ci-dashboard/generate_ci_site.py
+++ b/scripts/github-ci/ci-dashboard/generate_ci_site.py
@@ -10,7 +10,7 @@ from data.unit_tests import parse_unit_test_summary
 from renderer.renderer import Renderer
 from pages.page import Page, IndexPage, UnitTestPage, IntegrationTestPage
 
-def generate_site(json_input_path, unit_test_summary='', pytest_summary=''):
+def generate_site(json_input_path, unit_test_summary='', core_summary='', extended_summary=''):
     """Render html files from templates to generate the site."""
     with open(json_input_path, 'r') as f:
         repos = json.load(f)
@@ -55,7 +55,7 @@ def generate_site(json_input_path, unit_test_summary='', pytest_summary=''):
     ]
 
     unit_test_data = parse_unit_test_summary(unit_test_summary)
-    integration_test_data = load_integration_test_data(pytest_summary)
+    integration_test_data = load_integration_test_data(core_summary, extended_summary)
     
     index_context = {
         "repos": repos,
@@ -65,7 +65,7 @@ def generate_site(json_input_path, unit_test_summary='', pytest_summary=''):
         "passing_percentage": passing_percentage,
         "workflow_badges": workflow_badges,
         "unit_test_summary": unit_test_data,
-        "integration_test_summary": integration_test_data["totals"],
+        "integration_test_summary": integration_test_data['totals'],
     }
 
     pages = [
@@ -84,7 +84,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Generate CI HTML site from a JSON summary file.")
     parser.add_argument("--json_input", required=True, help="Path to the JSON file containing CI summary data. See collect-ci-metrics.sh.")
     parser.add_argument("--unit_test_summary", required=False, help="Path to the unit test summary output by dbt-build --unittest.")
-    parser.add_argument("--pytest_summary", required=False, help="Path to the json summary output by integration test workflow.")
+    parser.add_argument("--core_pytest_summary", required=False, help="Path to the json summary output by core integration test workflow.")
+    parser.add_argument("--extended_pytest_summary", required=False, help="Path to the json summary output by extended integration test workflow.")
     args = parser.parse_args()
 
-    generate_site(args.json_input, args.unit_test_summary, args.pytest_summary)
+    generate_site(args.json_input, args.unit_test_summary, args.core_pytest_summary, args.extended_pytest_summary)

--- a/scripts/github-ci/ci-dashboard/renderer/renderer.py
+++ b/scripts/github-ci/ci-dashboard/renderer/renderer.py
@@ -25,7 +25,6 @@ class Renderer:
             "Integration Test Summary": "integtest_summary.html",
             "Code Coverage Report": "code_coverage/index.html",
         }
-        #self.env = Environment(loader=FileSystemLoader(str(self.templates_path)))
         self.env = Environment(loader=FileSystemLoader(self.templates_path))
         self.env.filters["commit_age"] = commit_age
         self.env.globals["links"] = self.links

--- a/scripts/github-ci/ci-dashboard/templates/index_template.html
+++ b/scripts/github-ci/ci-dashboard/templates/index_template.html
@@ -24,25 +24,23 @@
     <div class="summary-block">
       <h3>Integration Tests</h3>
       <p>
-        {{ integration_test_summary.total }} total tests run.<br>
+        {{ integration_test_summary.total_run }} total tests run.<br>
         <span class="status-success">
           Passed: {{ integration_test_summary.passed }} 
-          ({{ (100 * integration_test_summary.passed / integration_test_summary.total) | round(1) }}%)
+          ({{ (100 * integration_test_summary.passed / integration_test_summary.total_run) | round(1) }}%)
           <br>
         </span>
         <span class="status-failure">
           Failed: {{ integration_test_summary.failed }} 
-          ({{ (100 * integration_test_summary.failed / integration_test_summary.total) | round(1) }}%)
+          ({{ (100 * integration_test_summary.failed / integration_test_summary.total_run) | round(1) }}%)
           <br>
         </span>
         <span class="status-skipped">
           Skipped: {{ integration_test_summary.skipped }} 
-          ({{ (100 * integration_test_summary.skipped / integration_test_summary.total) | round(1) }}%)
           <br>
         </span>
         <span class="status-error">
           Errored: {{ integration_test_summary.errors }} 
-          ({{ (100 * integration_test_summary.errors / integration_test_summary.total) | round(1) }}%)
           <br>
         </span>
       </p>

--- a/scripts/github-ci/ci-dashboard/templates/integration_test_template.html
+++ b/scripts/github-ci/ci-dashboard/templates/integration_test_template.html
@@ -1,29 +1,47 @@
-<!-- templates/integration_test_template.html -->
 {% extends "base_template.html" %}
 
 {% block title %}Integration Test Summary{% endblock %}
 
 {% block content %}
 <h1>Integration Test Report</h1>
-{% for package, tests in repo_results.items() %}
-  <h2>{{ package }}</h2>
+
+<p>
+  <strong>{{ totals.total_run }}</strong> total tests —
+  {{ totals.passed }} passed,
+  {{ totals.failed }} failed,
+  {{ totals.skipped }} skipped,
+  {{ totals.errors }} errors.
+</p>
+
+{% for repo, pytest_list in pytest_results.items() %}
+  <h2>{{ repo }} Results</h2>
+
+  {% for pytest_result in pytest_list %}
+    <h3>{{ pytest_result.test_name }} Results</h3>
     <table>
-      <thead><tr><th>Test</th><th>Status</th></tr></thead>
+      <thead>
+        <tr>
+          <th>Test Case</th>
+          <th>Status</th>
+        </tr>
+      </thead>
       <tbody>
-        {% for test in tests %}
+        {% for case in pytest_result.testcase_results %}
           <tr>
-            <td>{{ test.name }}</td>
+            <td>{{ case.case_name }}</td>
             <td>
-              {% if test.status == 'passed' %}	&#x2705
-              {% elif test.status == 'failed' %}&#x274C
-              {% elif test.status == 'skipped' %}⏩
-              {% elif test.status == 'errors' %}	&#x2757
+              {% if case.status == 'passed' %}&#x2705
+              {% elif case.status == 'failed' %}&#x274C
+              {% elif case.status == 'skipped' %}⏩
+              {% elif case.status == 'error' %}&#x2757
               {% else %}&#x2753 Unknown
-              {% endif %} {{ test.status }}
+              {% endif %}
+              {{ case.status }}
             </td>
           </tr>
         {% endfor %}
       </tbody>
     </table>
+  {% endfor %}
 {% endfor %}
 {% endblock %}

--- a/scripts/github-ci/integration_test_summary.py
+++ b/scripts/github-ci/integration_test_summary.py
@@ -1,20 +1,19 @@
-import os
-import sys
+from __future__ import annotations
 import re
-import argparse
-import html
 import json
-import xml.etree.ElementTree as ET
 from pathlib import Path
 from textwrap import dedent
 from dataclasses import dataclass, field, asdict
-from collections import defaultdict
 
 @dataclass
 class TestCaseResult:
     case_name: str
     status: str
     failure_message: str = ''
+
+    @classmethod
+    def from_dict(cls, d: dict) -> TestCaseResult:
+        return cls(**d)
 
     def summarize_failure(self) -> str:
         if not self.failure_message:
@@ -51,6 +50,14 @@ class PytestResult:
     def errors(self) -> int:
         return sum(tc.status == "error" for tc in self.testcase_results)
 
+    @classmethod
+    def from_dict(cls, d: dict) -> PytestResult:
+        cases = [TestCaseResult.from_dict(case) for case in d["testcase_results"]]
+        return cls(
+            repo_name=d["repo_name"],
+            test_name=d["test_name"],
+            testcase_results=cases,
+        )
 
 @dataclass
 class IntegrationTestSummary:
@@ -69,6 +76,21 @@ class IntegrationTestSummary:
             "errors": errors,
             "total_run": passed + failed
         }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> IntegrationTestSummary:
+        pytest_results = [
+            PytestResult.from_dict(test)
+            for repo_tests in data["pytest_results"].values()
+            for test in repo_tests
+        ]
+        return cls(pytest_results=pytest_results)
+
+    @classmethod
+    def from_json_file(cls, path: str | Path) -> IntegrationTestSummary:
+        path = Path(path)
+        data = json.loads(path.read_text())
+        return cls.from_dict(data)
 
     def to_dict(self) -> dict:
         grouped: dict[str, list[dict]] = {}
@@ -91,6 +113,7 @@ class IntegrationTestSummary:
     def to_json(self, path: str="pytest_summary.json"):
         json_path = Path(path)
         json_path.write_text(json.dumps(self.to_dict(), indent=2))
+        print(f"json summary generated at {path}")
 
     def to_markdown(self, output_filename: str="pytest_summary_table.md"):
         def which_emoji(test_status: str) -> str:
@@ -127,94 +150,13 @@ class IntegrationTestSummary:
 
         print(f"Markdown summary generated at {output_filename}")
 
-class JUnitXMLParser:
-    def __init__(self, input_directory: str='', input_file: str=''):
-        self.input_directory = Path(input_directory) if Path(input_directory).is_dir() else None
-        self.input_file = Path(input_file) if Path(input_file).is_file() else None
-        self.summary = IntegrationTestSummary()
+    def combine(self, additional_summary: IntegrationTestSummary) -> None:
+        self.pytest_results.extend(additional_summary.pytest_results)
 
-        if not self.input_directory and not self.input_file:
-            raise FileNotFoundError("No valid input file or directory specified.")
+    @classmethod
+    def combined(cls, *summaries: IntegrationTestSummary) -> IntegrationTestSummary:
+        merged = cls()
+        for s in summaries:
+            merged.combine(s)
+        return merged
 
-    def get_xml_files(self, pattern="*.xml"):
-        xml_files = self.input_directory.rglob(pattern)
-        if not xml_files:
-            raise FileNotFoundError(f"Error: No xml files found in {self.input_directory}.")
-        return xml_files
-
-    # Junit xml file names should be structured as <package_name>_<pytest_name>_results.xml
-    def get_package_name(self, file):
-        return file.stem.split('_')[0]
-
-    def get_pytest_name(self, file):
-        return file.stem.replace('_results', '').split('_', 1)[1]
-
-    def parse_xml_file(self, file_path):
-        tree = ET.parse(file_path)
-        root = tree.getroot()
-
-        package_name = self.get_package_name(file_path)
-        pytest_name  = self.get_pytest_name(file_path)
-
-        pytest_result = PytestResult(
-            repo_name=package_name,
-            test_name=pytest_name
-        )
-
-        for testcase in root.findall(".//testcase"):
-            test_name = testcase.get("name").split("[")[0]
-            result = "passed"
-            failure_message = ""
-
-            if (failure_element := testcase.find("failure")) is not None:
-                result = "failed"
-                failure_message = html.unescape(failure_element.text.strip()) if failure_element.text else "No message provided"
-            elif testcase.find("error") is not None:
-                result = "error"
-            elif testcase.find("skipped") is not None:
-                result = "skipped"
-            
-            testcase_result = TestCaseResult(
-                case_name=test_name,
-                status=result,
-                failure_message=failure_message
-            )
-
-            pytest_result.testcase_results.append(testcase_result)
-
-        self.summary.pytest_results.append(pytest_result)
-
-def main():
-    parser = argparse.ArgumentParser(description="Parse a JUnit XML file and extract test case results.")
-    parser.add_argument("--input-directory", "-d", type=str, default='',
-                        help="Path to the directory containing junit xml files.")
-    parser.add_argument("--input-file", "-i", type=str, default='',
-                        help="Path to a single JUnit XML file. Cannot be used in conjunction with --input-directory.")
-
-    args = parser.parse_args()
-
-    if len(sys.argv) == 1:
-        parser.print_usage()
-        exit(1)
-
-    integtest_parser = JUnitXMLParser(
-        input_directory=args.input_directory,
-        input_file=args.input_file,
-    )
-
-    if integtest_parser.input_directory:
-        xml_files = integtest_parser.get_xml_files()
-        for file in xml_files:
-            integtest_parser.parse_xml_file(file)
-
-    elif integtest_parser.input_file:
-        integtest_parser.parse_xml_file(integtest_parser.input_file)
-
-    integtest_parser.generate_markdown_table()
-    #integtest_parser.prepend_totals()
-    #summary = integtest_parser.parse_integration_test_summary('pytest_summary_table.md')
-    print('SUMMARY:', integtest_parser.summary)
-
-
-if __name__ == "__main__":
-    main()

--- a/scripts/github-ci/integtest_xml_parser.py
+++ b/scripts/github-ci/integtest_xml_parser.py
@@ -1,15 +1,68 @@
-import os
+from __future__ import annotations
 import sys
 import re
 import argparse
 import html
 import xml.etree.ElementTree as ET
 from pathlib import Path
-from textwrap import dedent
-from dataclasses import dataclass, field
+from integration_test_summary import IntegrationTestSummary
 
-sys.path.append(str(Path(__file__).resolve().parents[2]))
-from parsers.junit_xml import JUnitXMLParser
+class JUnitXMLParser:
+    def __init__(self, input_directory: str='', input_file: str=''):
+        self.input_directory = Path(input_directory) if Path(input_directory).is_dir() else None
+        self.input_file = Path(input_file) if Path(input_file).is_file() else None
+        self.summary = IntegrationTestSummary()
+
+        if not self.input_directory and not self.input_file:
+            raise FileNotFoundError("No valid input file or directory specified.")
+
+    def get_xml_files(self, pattern="*.xml"):
+        xml_files = self.input_directory.rglob(pattern)
+        if not xml_files:
+            raise FileNotFoundError(f"Error: No xml files found in {self.input_directory}.")
+        return xml_files
+
+    # Junit xml file names should be structured as <package_name>_<pytest_name>_results.xml
+    def get_package_name(self, file):
+        return file.stem.split('_')[0]
+
+    def get_pytest_name(self, file):
+        return file.stem.replace('_results', '').split('_', 1)[1]
+
+    def parse_xml_file(self, file_path):
+        tree = ET.parse(file_path)
+        root = tree.getroot()
+
+        package_name = self.get_package_name(file_path)
+        pytest_name  = self.get_pytest_name(file_path)
+
+        pytest_result = PytestResult(
+            repo_name=package_name,
+            test_name=pytest_name
+        )
+
+        for testcase in root.findall(".//testcase"):
+            test_name = testcase.get("name").split("[")[0]
+            result = "passed"
+            failure_message = ""
+
+            if (failure_element := testcase.find("failure")) is not None:
+                result = "failed"
+                failure_message = html.unescape(failure_element.text.strip()) if failure_element.text else "No message provided"
+            elif testcase.find("error") is not None:
+                result = "error"
+            elif testcase.find("skipped") is not None:
+                result = "skipped"
+            
+            testcase_result = TestCaseResult(
+                case_name=test_name,
+                status=result,
+                failure_message=failure_message
+            )
+
+            pytest_result.testcase_results.append(testcase_result)
+
+        self.summary.pytest_results.append(pytest_result)
 
 def main():
     parser = argparse.ArgumentParser(description="Parse a JUnit XML file and extract test case results.")
@@ -17,8 +70,6 @@ def main():
                         help="Path to the directory containing junit xml files.")
     parser.add_argument("--input-file", "-i", type=str, default='',
                         help="Path to a single JUnit XML file. Cannot be used in conjunction with --input-directory.")
-    parser.add_argument("--to-json", "-j", action='store_true',
-                        help="Write summary data to a json file.")
 
     args = parser.parse_args()
 
@@ -39,10 +90,12 @@ def main():
     elif integtest_parser.input_file:
         integtest_parser.parse_xml_file(integtest_parser.input_file)
 
-    integtest_parser.summary.to_markdown()
+    integtest_parser.to_markdown()
+    integtest_parser.to_json()
+    #integtest_parser.prepend_totals()
+    #summary = integtest_parser.parse_integration_test_summary('pytest_summary_table.md')
+    print('SUMMARY:', integtest_parser.summary)
 
-    if args.to_json:
-        integtest_parser.summary.to_json()
 
 if __name__ == "__main__":
     main()

--- a/scripts/github-ci/integtest_xml_parser.py
+++ b/scripts/github-ci/integtest_xml_parser.py
@@ -5,212 +5,11 @@ import argparse
 import html
 import xml.etree.ElementTree as ET
 from pathlib import Path
+from textwrap import dedent
 from dataclasses import dataclass, field
 
-@dataclass
-class TestCaseResult:
-    name: str
-    status: str
-    failure_message: str = ''
-
-@dataclass
-class IntegrationTestSummary:
-    passed: int = 0
-    failed: int = 0
-    skipped: int = 0
-    errors: int = 0
-    total: int = 0
-    repo_results: dict[str, list[TestCaseResult]] = field(default_factory=dict)
-
-    def to_dict(self):
-        return {
-            "passed": self.passed,
-            "failed": self.failed,
-            "skipped": self.skipped,
-            "errors": self.errors,
-            "total": self.total,
-            "repo_results": self.repo_results
-        }
-
-class JUnitXMLParser:
-    def __init__(self, input_directory: str='', input_file: str=''):
-        self.input_directory = Path(input_directory) if Path(input_directory).is_dir() else None
-        self.input_file = Path(input_file) if Path(input_file).is_file() else None
-        self.test_results = []
-        self.summary = IntegrationTestSummary()
-
-        if not self.input_directory and not self.input_file:
-            raise FileNotFoundError("No valid input file or directory specified.")
-
-    def get_xml_files(self, pattern="*.xml"):
-        xml_files = self.input_directory.rglob(pattern)
-        if not xml_files:
-            raise FileNotFoundError(f"Error: No xml files found in {self.input_directory}.")
-        return xml_files
-
-    # Junit xml file names should be structured as <package_name>_<pytest_name>_results.xml
-    def get_package_name(self, file):
-        return file.stem.split('_')[0]
-
-    def get_pytest_name(self, file):
-        return file.stem.replace('_results', '').split('_', 1)[1]
-
-    def parse_xml_file(self, file_path):
-        tree = ET.parse(file_path)
-        root = tree.getroot()
-
-        package_name = self.get_package_name(file_path)
-        pytest_name  = self.get_pytest_name(file_path)
-
-        for testcase in root.findall(".//testcase"):
-            test_name = testcase.get("name").split("[")[0]
-            result = "passed"
-            failure_message = None
-
-            if (failure_element := testcase.find("failure")) is not None:
-                result = "failed"
-                failure_message = html.unescape(failure_element.text.strip()) if failure_element.text else "No message provided"
-            elif testcase.find("error") is not None:
-                result = "error"
-            elif testcase.find("skipped") is not None:
-                result = "skipped"
-
-            self.test_results.append({
-                "package_name": package_name,
-                "pytest_name": pytest_name,
-                "test_name": test_name,
-                "result": result,
-                "failure_message": failure_message
-            })
-
-    def summarize_failures(self):
-        failure_summary = ''
-        failed_line_pattern = r"\n>\s+(.*?)\n"
-
-        for result in self.test_results:
-            if not result.get('failure_message'):
-                continue
-            failure_summary += f"\n\t\t  *{result['test_name']}* failed"
-            failed_line_match = re.findall(failed_line_pattern, result['failure_message'])
-            if failed_line_match:
-                failure_summary += f" while checking \n\t\t`{failed_line_match[0]}`\n"
-        return failure_summary
-
-    def which_emoji(self, test_status):
-        emoji_map = {
-            'passed': ':white_check_mark:',
-            'failed': ':x:',
-            'skipped': ':fast_forward:',
-            'error': ':warning:'
-        }
-        return emoji_map.get(test_status, ':question:')
-
-    def format_markdown_row(self, testname, result):
-        emoji = self.which_emoji(result)
-        return f"| {testname} | {emoji} {result} |\n"
-
-    def generate_markdown_table(self, output_filename: str="pytest_summary_table.md"):
-        with open(output_filename, 'w') as f:
-            for idx, result in enumerate(self.test_results):
-                if not result: continue
-                f.write(f"# {result['package_name']} {result['pytest_name']} Results\n")
-                f.write("| Test Case | Status |\n")
-                f.write("|-----------|--------|\n")
-                f.writelines(self.format_markdown_row(result['pytest_name'], result['result']))
-
-        self.prepend_totals(output_filename)
-
-        if not Path(output_filename).is_file():
-            raise FileNotFoundError(f"There was a problem writing the output markdown file: {output_filename}")
-
-        print(f"Markdown summary generated at {output_filename}")
-
-    def prepend_totals(self, markdown_filename="pytest_summary_table.md"):
-        num_passed = 0
-        num_failed = 0
-        num_skipped = 0
-        num_errors = 0
-        total_tests = 0
-        if not Path(markdown_filename).is_file():
-            raise FileNotFoundError(f"No markdown file named {markdown_filename} found.\n \
-                                      Make sure to generate the markdown file using 'this.generate_markdown_table()'.")
-        with open(markdown_filename, 'r') as ifile:
-            original_lines = ifile.readlines()
-            for line in original_lines:
-                print(line)
-                if 'passed' in line:
-                    num_passed += 1
-                    total_tests += 1
-                elif 'failed' in line:
-                    num_failed += 1
-                    total_tests += 1
-                elif 'skipped' in line:
-                    num_skipped += 1
-                    total_tests += 1
-                elif 'error' in line:
-                    num_errors += 1
-                    total_tests += 1
-
-        print('Passed:', num_passed)
-        print('Skipped:', num_skipped)
-        print('Failed:', num_failed)
-        print('Errors:', num_errors)
-
-        summary = f"""There were {total_tests} total tests run. 
-           {num_passed} passed {self.which_emoji('passed')}, 
-           {num_failed} failed {self.which_emoji('failed')}, 
-           {num_skipped} were skipped {self.which_emoji('skipped')}, and
-           {num_errors} had errors {self.which_emoji('error')} which prevented the test from completing.\n"""
-        new_lines = [summary] + original_lines
-        with open(markdown_filename, 'w') as ofile:
-            ofile.writelines(new_lines)
-
-    def parse_integration_test_summary(self, pytest_summary):
-        summary = IntegrationTestSummary()
-
-        with open(pytest_summary, "r") as f:
-            num_header_lines = 5
-            lines = [line.strip() for line in f if line.strip()]
-            header_lines = lines[:num_header_lines]
-            results_lines = lines[num_header_lines:]
-
-        numbers = [int(re.search(r'\d+', line).group()) for line in header_lines]
-        total, passed, failed, skipped, errors = numbers
-        summary.total = total
-        summary.passed = passed
-        summary.failed = failed
-        summary.skipped = skipped
-        summary.errors = errors
-        # Parse test results line by line
-        i = 0
-        while i < len(results_lines):
-            line = results_lines[i]
-            if line.startswith("#"):
-                # Each section represents a new package
-                section_title = re.sub(r"^#+ ", "", line)
-                summary.repo_results[section_title] = []
-                i += 3  # Skip table header and separator
-
-                # Read test rows until next heading or end of list
-                while i < len(results_lines) and not results_lines[i].startswith("#"):
-                    row = results_lines[i]
-                    if "|" in row:
-                        columns = [c.strip() for c in row.strip("|").split("|")]
-                        if len(columns) == 2:
-                            test_name, status_col = columns
-                            status = "passed" if "passed" in status_col else "failed" if "failed" in status_col else "skipped" if "skipped" in status_col else "error"
-                            #summary["results"][section_title].append({
-                            #summary.repo_results[section_title].append({
-                            #    "name": test_name,
-                            #    "status": status
-                            #})
-                            test_result = TestCaseResult(name=test_name, status=status)
-                            summary.repo_results[section_title].append(test_result)
-                    i += 1
-            else:
-                i += 1
-
-        return summary
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from parsers.junit_xml import JUnitXMLParser
 
 def main():
     parser = argparse.ArgumentParser(description="Parse a JUnit XML file and extract test case results.")
@@ -218,6 +17,8 @@ def main():
                         help="Path to the directory containing junit xml files.")
     parser.add_argument("--input-file", "-i", type=str, default='',
                         help="Path to a single JUnit XML file. Cannot be used in conjunction with --input-directory.")
+    parser.add_argument("--to-json", "-j", action='store_true',
+                        help="Write summary data to a json file.")
 
     args = parser.parse_args()
 
@@ -238,11 +39,10 @@ def main():
     elif integtest_parser.input_file:
         integtest_parser.parse_xml_file(integtest_parser.input_file)
 
-    integtest_parser.generate_markdown_table()
-    #integtest_parser.prepend_totals()
-    summary = integtest_parser.parse_integration_test_summary('pytest_summary_table.md')
-    print('SUMMARY:', summary)
+    integtest_parser.summary.to_markdown()
 
+    if args.to_json:
+        integtest_parser.summary.to_json()
 
 if __name__ == "__main__":
     main()

--- a/scripts/github-ci/integtest_xml_parser.py
+++ b/scripts/github-ci/integtest_xml_parser.py
@@ -5,7 +5,7 @@ import argparse
 import html
 import xml.etree.ElementTree as ET
 from pathlib import Path
-from integration_test_summary import IntegrationTestSummary
+from integration_test_summary import IntegrationTestSummary, PytestResult, TestCaseResult
 
 class JUnitXMLParser:
     def __init__(self, input_directory: str='', input_file: str=''):
@@ -90,8 +90,8 @@ def main():
     elif integtest_parser.input_file:
         integtest_parser.parse_xml_file(integtest_parser.input_file)
 
-    integtest_parser.to_markdown()
-    integtest_parser.to_json()
+    integtest_parser.summary.to_markdown()
+    integtest_parser.summary.to_json()
     #integtest_parser.prepend_totals()
     #summary = integtest_parser.parse_integration_test_summary('pytest_summary_table.md')
     print('SUMMARY:', integtest_parser.summary)

--- a/scripts/github-ci/integtest_xml_parser.py
+++ b/scripts/github-ci/integtest_xml_parser.py
@@ -3,40 +3,65 @@ import sys
 import re
 import argparse
 import html
-from pathlib import Path
 import xml.etree.ElementTree as ET
+from pathlib import Path
+from dataclasses import dataclass, field
+
+@dataclass
+class TestCaseResult:
+    name: str
+    status: str
+    failure_message: str = ''
+
+@dataclass
+class IntegrationTestSummary:
+    passed: int = 0
+    failed: int = 0
+    skipped: int = 0
+    errors: int = 0
+    total: int = 0
+    repo_results: dict[str, list[TestCaseResult]] = field(default_factory=dict)
+
+    def to_dict(self):
+        return {
+            "passed": self.passed,
+            "failed": self.failed,
+            "skipped": self.skipped,
+            "errors": self.errors,
+            "total": self.total,
+            "repo_results": self.repo_results
+        }
 
 class JUnitXMLParser:
-    def __init__(self, input_directory=None, input_file=None, output_filename="pytest_summary_table.md"):
-        self.input_directory = input_directory
-        self.input_file = input_file
-        self.output_filename = output_filename
+    def __init__(self, input_directory: str='', input_file: str=''):
+        self.input_directory = Path(input_directory) if Path(input_directory).is_dir() else None
+        self.input_file = Path(input_file) if Path(input_file).is_file() else None
         self.test_results = []
+        self.summary = IntegrationTestSummary()
 
-    def get_xml_files(self, directory, pattern):
-        if not os.path.isdir(directory):
-            raise FileNotFoundError(f"Error: {directory} is not a valid directory.")
+        if not self.input_directory and not self.input_file:
+            raise FileNotFoundError("No valid input file or directory specified.")
 
-        path = Path(directory)
-        xml_files = path.rglob(pattern)
+    def get_xml_files(self, pattern="*.xml"):
+        xml_files = self.input_directory.rglob(pattern)
         if not xml_files:
-            raise FileNotFoundError(f"Error: No xml files found in {directory}.")
+            raise FileNotFoundError(f"Error: No xml files found in {self.input_directory}.")
         return xml_files
 
-    def get_package_and_pytest_name_from_file(self, file_path):
-        file_name = os.path.basename(file_path)
-        # Junit xml files should be structured as <package_name>_<pytest_name>_results.xml
-        package_and_pytest_name = file_name.replace('_results.xml', '')
-        package_name, pytest_name = package_and_pytest_name.split("_", 1)
-        return package_name, pytest_name
+    # Junit xml file names should be structured as <package_name>_<pytest_name>_results.xml
+    def get_package_name(self, file):
+        return file.stem.split('_')[0]
 
-    def parse_junit_xml(self, file_path):
+    def get_pytest_name(self, file):
+        return file.stem.replace('_results', '').split('_', 1)[1]
+
+    def parse_xml_file(self, file_path):
         tree = ET.parse(file_path)
         root = tree.getroot()
 
-        package_name, pytest_name = self.get_package_and_pytest_name_from_file(file_path)
+        package_name = self.get_package_name(file_path)
+        pytest_name  = self.get_pytest_name(file_path)
 
-        results = []
         for testcase in root.findall(".//testcase"):
             test_name = testcase.get("name").split("[")[0]
             result = "passed"
@@ -50,14 +75,26 @@ class JUnitXMLParser:
             elif testcase.find("skipped") is not None:
                 result = "skipped"
 
-            results.append({
+            self.test_results.append({
                 "package_name": package_name,
                 "pytest_name": pytest_name,
                 "test_name": test_name,
                 "result": result,
                 "failure_message": failure_message
             })
-        return results
+
+    def summarize_failures(self):
+        failure_summary = ''
+        failed_line_pattern = r"\n>\s+(.*?)\n"
+
+        for result in self.test_results:
+            if not result.get('failure_message'):
+                continue
+            failure_summary += f"\n\t\t  *{result['test_name']}* failed"
+            failed_line_match = re.findall(failed_line_pattern, result['failure_message'])
+            if failed_line_match:
+                failure_summary += f" while checking \n\t\t`{failed_line_match[0]}`\n"
+        return failure_summary
 
     def which_emoji(self, test_status):
         emoji_map = {
@@ -68,31 +105,36 @@ class JUnitXMLParser:
         }
         return emoji_map.get(test_status, ':question:')
 
-    def format_markdown_row(self, test):
-        emoji = self.which_emoji(test['result'])
-        return f"| {test['test_name']} | {emoji} {test['result']} |\n"
+    def format_markdown_row(self, testname, result):
+        emoji = self.which_emoji(result)
+        return f"| {testname} | {emoji} {result} |\n"
 
-    def generate_markdown_table(self):
-        with open(self.output_filename, 'w') as f:
+    def generate_markdown_table(self, output_filename: str="pytest_summary_table.md"):
+        with open(output_filename, 'w') as f:
             for idx, result in enumerate(self.test_results):
                 if not result: continue
-                f.write(f"# {result[0]['package_name']} {result[0]['pytest_name']} Results\n")
+                f.write(f"# {result['package_name']} {result['pytest_name']} Results\n")
                 f.write("| Test Case | Status |\n")
                 f.write("|-----------|--------|\n")
-                f.writelines(self.format_markdown_row(test) for test in result)
+                f.writelines(self.format_markdown_row(result['pytest_name'], result['result']))
 
-        if not os.path.exists(self.output_filename):
-            raise FileNotFoundError(f"There was a problem writing the output markdown file: {self.output_filename}")
+        self.prepend_totals(output_filename)
 
-        print(f"Markdown summary generated at {self.output_filename}")
+        if not Path(output_filename).is_file():
+            raise FileNotFoundError(f"There was a problem writing the output markdown file: {output_filename}")
 
-    def prepend_test_summary(self):
+        print(f"Markdown summary generated at {output_filename}")
+
+    def prepend_totals(self, markdown_filename="pytest_summary_table.md"):
         num_passed = 0
         num_failed = 0
         num_skipped = 0
         num_errors = 0
         total_tests = 0
-        with open(self.output_filename, 'r') as ifile:
+        if not Path(markdown_filename).is_file():
+            raise FileNotFoundError(f"No markdown file named {markdown_filename} found.\n \
+                                      Make sure to generate the markdown file using 'this.generate_markdown_table()'.")
+        with open(markdown_filename, 'r') as ifile:
             original_lines = ifile.readlines()
             for line in original_lines:
                 print(line)
@@ -120,42 +162,62 @@ class JUnitXMLParser:
            {num_skipped} were skipped {self.which_emoji('skipped')}, and
            {num_errors} had errors {self.which_emoji('error')} which prevented the test from completing.\n"""
         new_lines = [summary] + original_lines
-        with open(self.output_filename, 'w') as ofile:
+        with open(markdown_filename, 'w') as ofile:
             ofile.writelines(new_lines)
 
-    def parse(self):
-        if self.input_directory and self.input_file:
-            print(f"Error: You must specify either an input directory or a specific file, not both.")
-            exit(1)
+    def parse_integration_test_summary(self, pytest_summary):
+        summary = IntegrationTestSummary()
 
-        if self.input_directory:
-            if not os.path.isdir(self.input_directory):
-                raise FileNotFoundError(f"Error: {self.input_directory} is not a valid directory.")
+        with open(pytest_summary, "r") as f:
+            num_header_lines = 5
+            lines = [line.strip() for line in f if line.strip()]
+            header_lines = lines[:num_header_lines]
+            results_lines = lines[num_header_lines:]
 
-            xml_files = self.get_xml_files(self.input_directory, "*.xml")
-            for file in xml_files:
-                self.test_results.append(self.parse_junit_xml(file))
+        numbers = [int(re.search(r'\d+', line).group()) for line in header_lines]
+        total, passed, failed, skipped, errors = numbers
+        summary.total = total
+        summary.passed = passed
+        summary.failed = failed
+        summary.skipped = skipped
+        summary.errors = errors
+        # Parse test results line by line
+        i = 0
+        while i < len(results_lines):
+            line = results_lines[i]
+            if line.startswith("#"):
+                # Each section represents a new package
+                section_title = re.sub(r"^#+ ", "", line)
+                summary.repo_results[section_title] = []
+                i += 3  # Skip table header and separator
 
-        elif self.input_file:
-            if not os.path.isfile(self.input_file):
-                raise FileNotFoundError(f"Error: Input file {self.input_file} is invalid.")
-            self.test_results.append(self.parse_junit_xml(self.input_file))
+                # Read test rows until next heading or end of list
+                while i < len(results_lines) and not results_lines[i].startswith("#"):
+                    row = results_lines[i]
+                    if "|" in row:
+                        columns = [c.strip() for c in row.strip("|").split("|")]
+                        if len(columns) == 2:
+                            test_name, status_col = columns
+                            status = "passed" if "passed" in status_col else "failed" if "failed" in status_col else "skipped" if "skipped" in status_col else "error"
+                            #summary["results"][section_title].append({
+                            #summary.repo_results[section_title].append({
+                            #    "name": test_name,
+                            #    "status": status
+                            #})
+                            test_result = TestCaseResult(name=test_name, status=status)
+                            summary.repo_results[section_title].append(test_result)
+                    i += 1
+            else:
+                i += 1
 
-        else:
-            raise RuntimeError(f"Error: No input file or directory specified. Exiting...")
-
-        self.generate_markdown_table()
-        self.prepend_test_summary()
+        return summary
 
 def main():
     parser = argparse.ArgumentParser(description="Parse a JUnit XML file and extract test case results.")
-    parser.add_argument("--input-directory", "-d",
+    parser.add_argument("--input-directory", "-d", type=str, default='',
                         help="Path to the directory containing junit xml files.")
-    parser.add_argument("--input-file", "-i",
+    parser.add_argument("--input-file", "-i", type=str, default='',
                         help="Path to a single JUnit XML file. Cannot be used in conjunction with --input-directory.")
-    parser.add_argument("--output-markdown-file", "-o", 
-                        default="pytest_summary_table.md",
-                        help="Name of the output file containing the markdown summary table. Default: ./pytest_summary_table.md")
 
     args = parser.parse_args()
 
@@ -163,16 +225,23 @@ def main():
         parser.print_usage()
         exit(1)
 
-    if args.input_directory and args.input_file:
-        print(f"Error: You must specify either an input directory or a specific file, not both.")
-        exit(1)
-
-    parser = JUnitXMLParser(
+    integtest_parser = JUnitXMLParser(
         input_directory=args.input_directory,
         input_file=args.input_file,
-        output_filename=args.output_markdown_file
     )
-    parser.parse()
+
+    if integtest_parser.input_directory:
+        xml_files = integtest_parser.get_xml_files()
+        for file in xml_files:
+            integtest_parser.parse_xml_file(file)
+
+    elif integtest_parser.input_file:
+        integtest_parser.parse_xml_file(integtest_parser.input_file)
+
+    integtest_parser.generate_markdown_table()
+    #integtest_parser.prepend_totals()
+    summary = integtest_parser.parse_integration_test_summary('pytest_summary_table.md')
+    print('SUMMARY:', summary)
 
 
 if __name__ == "__main__":

--- a/scripts/github-ci/integtest_xml_parser.py
+++ b/scripts/github-ci/integtest_xml_parser.py
@@ -23,13 +23,13 @@ class JUnitXMLParser:
         return xml_files
 
     # Junit xml file names should be structured as <package_name>_<pytest_name>_results.xml
-    def get_package_name(self, file):
+    def get_package_name(self, file) -> str:
         return file.stem.split('_')[0]
 
-    def get_pytest_name(self, file):
+    def get_pytest_name(self, file) -> str:
         return file.stem.replace('_results', '').split('_', 1)[1]
 
-    def parse_xml_file(self, file_path):
+    def parse_xml_file(self, file_path: str) -> None:
         tree = ET.parse(file_path)
         root = tree.getroot()
 
@@ -92,10 +92,6 @@ def main():
 
     integtest_parser.summary.to_markdown()
     integtest_parser.summary.to_json()
-    #integtest_parser.prepend_totals()
-    #summary = integtest_parser.parse_integration_test_summary('pytest_summary_table.md')
-    print('SUMMARY:', integtest_parser.summary)
-
 
 if __name__ == "__main__":
     main()

--- a/scripts/github-ci/slack_payload_generator.py
+++ b/scripts/github-ci/slack_payload_generator.py
@@ -4,8 +4,7 @@ import argparse
 import sys
 import re
 from pathlib import Path
-sys.path.append(str(Path(__file__).resolve().parents[2]))
-from parsers.junit_xml import JUnitXMLParser
+from integtest_xml_parser import JUnitXMLParser
 
 class SlackPayload:
     """Class to generate a Slack JSON payload for workflow notifications."""

--- a/scripts/github-ci/slack_payload_generator.py
+++ b/scripts/github-ci/slack_payload_generator.py
@@ -4,7 +4,8 @@ import argparse
 import sys
 import re
 from pathlib import Path
-from integtest_xml_parser import JUnitXMLParser
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from parsers.junit_xml import JUnitXMLParser
 
 class SlackPayload:
     """Class to generate a Slack JSON payload for workflow notifications."""
@@ -28,7 +29,7 @@ class SlackPayload:
         self.blocks = []
         self.junit_xml_dir = junit_xml_dir
         self.xml_parser = JUnitXMLParser(self.junit_xml_dir) if self.junit_xml_dir else None
-        self.xml_files = self.xml_parser.get_xml_files(self.junit_xml_dir, "*_results.xml") if self.xml_parser else []
+        self.xml_files = self.xml_parser.get_xml_files() if self.xml_parser else []
 
     def get_workflow_status(self):
         """Determine the overall workflow status based on job conclusions."""
@@ -222,7 +223,6 @@ def main():
     if args.junit_xml_dir and os.path.isdir(args.junit_xml_dir):
         xml_files = list(Path(args.junit_xml_dir).rglob("*_results.xml"))
 
-    print('args.pytest_log_dir:', args.pytest_log_dir)
     slack_payload = SlackPayload(workflow_summary, args.release_name, args.junit_xml_dir, args.pytest_log_dir)
     json_payload = slack_payload.to_json()
     write_payload_to_file(json_payload)


### PR DESCRIPTION
In the process of trying to centralize some Slack message payload generation logic, I noticed significant duplication of junit XML parsing logic (my fault). This PR centralizes all parsing of junit XML files output by integration tests into the `JUnitXMLParser` class. Furthermore, this parser class makes use of the `IntegrationTestSummary`, `PytestResult`, and `TestCaseResult` classes, which better reflect the hierarchical structure of pytest output. For example, the `listrev_test.py` result is summarized in a `PytestResult`, while individual tests such as `test_nanorc_success` are summarized in a `TestCaseResult`. The `IntegrationTestSummary` then contains a list of `PytestResults` (which themselves contain a list of `TestCaseResults`) and computes the totals automatically. These classes were previously contained in the CI dashboard module which parses integration test results, but are now contained in `scripts/github-ci/integration_test_summary.py`. Basically, this provides better separation of concerns and reduces unnecessary coupling. 

Realizing this structure involves several changes to other modules account for this:
- In addition to markdown, integration test summaries are uploaded as json for more flexible parsing downstream
- The CI dashboard integration test parser now uses that json input
- The integration test page renderer now accounts for the updated structure

Successful workflows using this branch:
- [Core integration tests](https://github.com/DUNE-DAQ/daq-release/actions/runs/21295134980) with json summary uploaded
- [Extended integration tests](https://github.com/DUNE-DAQ/daq-release/actions/runs/21295572104) with json summary uploaded
- [CI dashboard publication](https://github.com/DUNE-DAQ/daq-release/actions/runs/21297854865) with the updated parser, summaries, and renderer

Note that `slack_payload_generator.py` is still using its own, redundant parsing logic. This PR is already quite invasive, so I'll file a separate PR for overhauling the Slack message logic, which similarly could use some refactoring. 

 