### PR TITLE
Johnfreeman/issue517 autofill dunedaq db path

### DIFF
--- a/scripts/spack/make-release-repo.py
+++ b/scripts/spack/make-release-repo.py
@@ -158,14 +158,18 @@ class DAQRelease:
             yaml.dump(self.rdict, outfile, Dumper=MyDumper, default_flow_style=False, sort_keys=False)
         return
 
-    def get_cmake_dependencies(self, package_name, branch_name):
+    def get_file_from_package(self, package_name, branch_name, file_name):
         if self.overwrite_branch != '':
             if check_branch_exists(package_name, self.overwrite_branch):
                 branch_name = self.overwrite_branch
-        file_name = "CMakeLists.txt"
-        cmakelists_path = f'https://raw.githubusercontent.com/DUNE-DAQ/{package_name}/{branch_name}/{file_name}'
-        command = f'curl -o {file_name} --fail {cmakelists_path}'
+        file_url = f'https://raw.githubusercontent.com/DUNE-DAQ/{package_name}/{branch_name}/{file_name}'
+        command = f'curl -o {file_name} --fail {file_url}'
         check_output(command, 5)
+
+    def get_cmake_dependencies(self, package_name, branch_name):
+
+        file_name = "CMakeLists.txt"
+        self.get_file_from_package(package_name, branch_name, file_name)
 
         cmake_dependencies_list = []
         with open(file_name, 'r') as infile:
@@ -187,6 +191,18 @@ class DAQRelease:
                 cmake_dependencies_list.append('numactl')
         cmake_dependencies_list = [dep.lower() for dep in cmake_dependencies_list]
         return cmake_dependencies_list
+
+    def get_is_db_path_needed(self, package_name, branch_name):
+        file_name = "CMakeLists.txt"
+        self.get_file_from_package(package_name, branch_name, file_name)
+
+        pattern = re.compile(r"\bdaq_add_dal_library\s*\(")
+        with open(file_name, 'r') as infile:
+            for line in [l.lstrip() for l in infile]:
+                if pattern.search(line) and not line.startswith("#"):
+                    return True
+
+        return False
 
     def generate_depends_on_list(self, cmake_package_list):
         depends_on_list = ""
@@ -228,6 +244,12 @@ class DAQRelease:
                 cmake_package_list = self.get_cmake_dependencies(ipkg["name"], ipkg["commit"])
                 depends_on_list = self.generate_depends_on_list(cmake_package_list)
                 lines = lines.replace("XDEPENDSX", depends_on_list)
+
+                if self.get_is_db_path_needed(ipkg["name"], ipkg["commit"]):
+                    lines = lines.replace("XDBPATHX", "env.prepend_path(\"DUNEDAQ_DB_PATH\", self.prefix + \"/share\")")
+                else:
+                    lines = lines.replace("XDBPATHX", "")
+
             ipkg_dir = os.path.join(repo_dir, ipkg["name"])
             os.makedirs(ipkg_dir)
             ipkgpy = os.path.join(ipkg_dir, "package.py")

--- a/scripts/spack/make-release-repo.py
+++ b/scripts/spack/make-release-repo.py
@@ -9,11 +9,14 @@ import tempfile
 import re
 import copy
 import tempfile
+import pathlib
 
 from time import sleep
 
 from dr_tools import parse_yaml_file
 from mappings import cmake_to_spack, pyvenv_url_names
+
+contains_oks_file = {}
 
 class MyDumper(yaml.Dumper):
 
@@ -48,6 +51,17 @@ def check_output(cmd, max_tries = 1):
                 sleep(sleep_time)
     return out
 
+def get_contains_oks_file(repo_path_name):
+
+    assert os.path.exists(repo_path_name), f"The {get_contains_oks_file.__name__} function is unable to find expected path {repo_path_name}"
+
+    repo_path = pathlib.PosixPath(repo_path_name)
+
+    for glob_extension in ["*.schema.xml", "*.data.xml"]:
+        if len(list(repo_path.rglob(glob_extension))) > 0:
+            return True
+
+    return False
 
 def get_commit_hash(repo, tag_or_branch, fall_back_tag="develop"):
     tmp_dir = tempfile.mkdtemp()
@@ -91,6 +105,7 @@ def get_commit_hash(repo, tag_or_branch, fall_back_tag="develop"):
         return (used_ref, commit_hash)
 
     finally:
+        contains_oks_file[repo] = get_contains_oks_file(f"{tmp_dir}/{repo}")
         shutil.rmtree(tmp_dir)
 
 def check_branch_exists(repo, branch):
@@ -192,18 +207,6 @@ class DAQRelease:
         cmake_dependencies_list = [dep.lower() for dep in cmake_dependencies_list]
         return cmake_dependencies_list
 
-    def get_is_db_path_needed(self, package_name, branch_name):
-        file_name = "CMakeLists.txt"
-        self.get_file_from_package(package_name, branch_name, file_name)
-
-        pattern = re.compile(r"\bdaq_add_dal_library\s*\(")
-        with open(file_name, 'r') as infile:
-            for line in [l.lstrip() for l in infile]:
-                if pattern.search(line) and not line.startswith("#"):
-                    return True
-
-        return False
-
     def generate_depends_on_list(self, cmake_package_list):
         depends_on_list = ""
         for idep in cmake_package_list:
@@ -245,7 +248,7 @@ class DAQRelease:
                 depends_on_list = self.generate_depends_on_list(cmake_package_list)
                 lines = lines.replace("XDEPENDSX", depends_on_list)
 
-                if self.get_is_db_path_needed(ipkg["name"], ipkg["commit"]):
+                if contains_oks_file[ ipkg["name"] ]:
                     lines = lines.replace("XDBPATHX", "env.prepend_path(\"DUNEDAQ_DB_PATH\", self.prefix + \"/share\")")
                 else:
                     lines = lines.replace("XDBPATHX", "")

--- a/spack-repos/coredaq-repo-template/packages/appfwk/package.py
+++ b/spack-repos/coredaq-repo-template/packages/appfwk/package.py
@@ -32,6 +32,6 @@ class Appfwk(CMakePackage):
     def setup_run_environment(self, env):
         env.set(self.__module__.split(".")[-1].upper().replace("-", "_") + "_SHARE", self.prefix + "/share" )
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
-        env.prepend_path("DUNEDAQ_DB_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/appmodel/package.py
+++ b/spack-repos/coredaq-repo-template/packages/appmodel/package.py
@@ -30,6 +30,6 @@ class Appmodel(CMakePackage):
     def setup_run_environment(self, env):
         env.set(self.__module__.split(".")[-1].upper().replace("-", "_") + "_SHARE", self.prefix + "/share" )
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
-        env.prepend_path("DUNEDAQ_DB_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/cmdlib/package.py
+++ b/spack-repos/coredaq-repo-template/packages/cmdlib/package.py
@@ -33,3 +33,4 @@ class Cmdlib(CMakePackage):
         env.prepend_path('DUNEDAQ_SHARE_PATH', self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/conffwk/package.py
+++ b/spack-repos/coredaq-repo-template/packages/conffwk/package.py
@@ -30,6 +30,6 @@ class Conffwk(CMakePackage):
     def setup_run_environment(self, env):
         env.set(self.__module__.split(".")[-1].upper().replace("-", "_") + "_SHARE", self.prefix + "/share" )
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
-        env.prepend_path("DUNEDAQ_DB_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/confmodel/package.py
+++ b/spack-repos/coredaq-repo-template/packages/confmodel/package.py
@@ -30,6 +30,6 @@ class Confmodel(CMakePackage):
     def setup_run_environment(self, env):
         env.set(self.__module__.split(".")[-1].upper().replace("-", "_") + "_SHARE", self.prefix + "/share" )
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
-        env.prepend_path("DUNEDAQ_DB_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/daq-cmake/package.py
+++ b/spack-repos/coredaq-repo-template/packages/daq-cmake/package.py
@@ -31,3 +31,4 @@ class DaqCmake(CMakePackage):
     def setup_run_environment(self, env):
         env.set(self.__module__.split(".")[-1].upper().replace("-", "_") + "_SHARE", self.prefix + "/share" )
         env.prepend_path('PYTHONPATH', self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/daqconf/package.py
+++ b/spack-repos/coredaq-repo-template/packages/daqconf/package.py
@@ -30,4 +30,4 @@ class Daqconf(CMakePackage):
         env.set(self.__module__.split(".")[-1].upper().replace("-", "_") + "_SHARE", self.prefix + "/share" )
         env.prepend_path('DUNEDAQ_SHARE_PATH', self.prefix + "/share")
         env.prepend_path('PYTHONPATH', self.prefix.lib + "64/python")
-
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/daqdataformats/package.py
+++ b/spack-repos/coredaq-repo-template/packages/daqdataformats/package.py
@@ -32,5 +32,4 @@ class Daqdataformats(CMakePackage):
         env.prepend_path('DUNEDAQ_SHARE_PATH', self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
-
-
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/dataformats/package.py
+++ b/spack-repos/coredaq-repo-template/packages/dataformats/package.py
@@ -33,3 +33,4 @@ class Dataformats(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/datahandlinglibs/package.py
+++ b/spack-repos/coredaq-repo-template/packages/datahandlinglibs/package.py
@@ -35,7 +35,8 @@ class Datahandlinglibs(CMakePackage):
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
         env.prepend_path('LIBRARY_PATH', self.spec['numactl'].prefix.lib)
         env.prune_duplicate_paths('LIBRARY_PATH')
-
+        XDBPATHX
+        
     def setup_build_environment(self, env):
         env.prepend_path('LIBRARY_PATH', self.spec['numactl'].prefix.lib)
         env.prune_duplicate_paths('LIBRARY_PATH')

--- a/spack-repos/coredaq-repo-template/packages/dbe/package.py
+++ b/spack-repos/coredaq-repo-template/packages/dbe/package.py
@@ -30,6 +30,6 @@ class Dbe(CMakePackage):
     def setup_run_environment(self, env):
         env.set(self.__module__.split(".")[-1].upper().replace("-", "_") + "_SHARE", self.prefix + "/share" )
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
+        env.prepend_path("DUNEDAQ_DB_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
-        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/dbe/package.py
+++ b/spack-repos/coredaq-repo-template/packages/dbe/package.py
@@ -30,6 +30,6 @@ class Dbe(CMakePackage):
     def setup_run_environment(self, env):
         env.set(self.__module__.split(".")[-1].upper().replace("-", "_") + "_SHARE", self.prefix + "/share" )
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
-        env.prepend_path("DUNEDAQ_DB_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/detchannelmaps/package.py
+++ b/spack-repos/coredaq-repo-template/packages/detchannelmaps/package.py
@@ -32,5 +32,4 @@ class Detchannelmaps(CMakePackage):
         env.prepend_path('DUNEDAQ_SHARE_PATH', self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
-
-
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/detdataformats/package.py
+++ b/spack-repos/coredaq-repo-template/packages/detdataformats/package.py
@@ -32,5 +32,4 @@ class Detdataformats(CMakePackage):
         env.prepend_path('DUNEDAQ_SHARE_PATH', self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
-
-
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/dfmessages/package.py
+++ b/spack-repos/coredaq-repo-template/packages/dfmessages/package.py
@@ -33,4 +33,4 @@ class Dfmessages(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
-
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/dfmodules/package.py
+++ b/spack-repos/coredaq-repo-template/packages/dfmodules/package.py
@@ -35,4 +35,4 @@ class Dfmodules(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
-
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/ers/package.py
+++ b/spack-repos/coredaq-repo-template/packages/ers/package.py
@@ -32,4 +32,4 @@ class Ers(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
-
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/erses/package.py
+++ b/spack-repos/coredaq-repo-template/packages/erses/package.py
@@ -35,5 +35,4 @@ class Erses(CMakePackage):
         env.prepend_path('DUNEDAQ_SHARE_PATH', self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
-
-
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/erskafka/package.py
+++ b/spack-repos/coredaq-repo-template/packages/erskafka/package.py
@@ -31,4 +31,4 @@ class Erskafka(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
-
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/hdf5libs/package.py
+++ b/spack-repos/coredaq-repo-template/packages/hdf5libs/package.py
@@ -32,5 +32,4 @@ class Hdf5libs(CMakePackage):
         env.prepend_path('DUNEDAQ_SHARE_PATH', self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
-
-
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/hsilibs/package.py
+++ b/spack-repos/coredaq-repo-template/packages/hsilibs/package.py
@@ -31,6 +31,6 @@ class Hsilibs(CMakePackage):
     def setup_run_environment(self, env):
         env.set(self.__module__.split(".")[-1].upper().replace("-", "_") + "_SHARE", self.prefix + "/share" )
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
-        env.prepend_path("DUNEDAQ_DB_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/influxopmon/package.py
+++ b/spack-repos/coredaq-repo-template/packages/influxopmon/package.py
@@ -34,5 +34,4 @@ class Influxopmon(CMakePackage):
         env.prepend_path('DUNEDAQ_SHARE_PATH', self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
-
-
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/iomanager/package.py
+++ b/spack-repos/coredaq-repo-template/packages/iomanager/package.py
@@ -33,3 +33,4 @@ class Iomanager(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/ipm/package.py
+++ b/spack-repos/coredaq-repo-template/packages/ipm/package.py
@@ -32,4 +32,4 @@ class Ipm(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
-
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/kafkaopmon/package.py
+++ b/spack-repos/coredaq-repo-template/packages/kafkaopmon/package.py
@@ -31,5 +31,4 @@ class Kafkaopmon(CMakePackage):
         env.prepend_path('DUNEDAQ_SHARE_PATH', self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
-
-
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/listrev/package.py
+++ b/spack-repos/coredaq-repo-template/packages/listrev/package.py
@@ -32,6 +32,6 @@ class Listrev(CMakePackage):
     def setup_run_environment(self, env):
         env.set(self.__module__.split(".")[-1].upper().replace("-", "_") + "_SHARE", self.prefix + "/share" )
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
-        env.prepend_path("DUNEDAQ_DB_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/logging/package.py
+++ b/spack-repos/coredaq-repo-template/packages/logging/package.py
@@ -32,4 +32,4 @@ class Logging(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
-
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/minidaqapp/package.py
+++ b/spack-repos/coredaq-repo-template/packages/minidaqapp/package.py
@@ -32,4 +32,4 @@ class Minidaqapp(CMakePackage):
         env.set(self.__module__.split(".")[-1].upper().replace("-", "_") + "_SHARE", self.prefix + "/share" )
         env.prepend_path('DUNEDAQ_SHARE_PATH', self.prefix + "/share")
         env.prepend_path('PYTHONPATH', self.prefix.lib + "64/python")
-
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/networkmanager/package.py
+++ b/spack-repos/coredaq-repo-template/packages/networkmanager/package.py
@@ -33,3 +33,4 @@ class Networkmanager(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/nwqueueadapters/package.py
+++ b/spack-repos/coredaq-repo-template/packages/nwqueueadapters/package.py
@@ -33,3 +33,4 @@ class Nwqueueadapters(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/oks/package.py
+++ b/spack-repos/coredaq-repo-template/packages/oks/package.py
@@ -32,3 +32,4 @@ class Oks(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/oksconflibs/package.py
+++ b/spack-repos/coredaq-repo-template/packages/oksconflibs/package.py
@@ -30,6 +30,6 @@ class Oksconflibs(CMakePackage):
     def setup_run_environment(self, env):
         env.set(self.__module__.split(".")[-1].upper().replace("-", "_") + "_SHARE", self.prefix + "/share" )
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
-        env.prepend_path("DUNEDAQ_DB_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/oksdalgen/package.py
+++ b/spack-repos/coredaq-repo-template/packages/oksdalgen/package.py
@@ -32,3 +32,4 @@ class Oksdalgen(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/okssystem/package.py
+++ b/spack-repos/coredaq-repo-template/packages/okssystem/package.py
@@ -32,3 +32,4 @@ class Okssystem(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/oksutils/package.py
+++ b/spack-repos/coredaq-repo-template/packages/oksutils/package.py
@@ -30,6 +30,6 @@ class Oksutils(CMakePackage):
     def setup_run_environment(self, env):
         env.set(self.__module__.split(".")[-1].upper().replace("-", "_") + "_SHARE", self.prefix + "/share" )
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
-        env.prepend_path("DUNEDAQ_DB_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/opmonlib/package.py
+++ b/spack-repos/coredaq-repo-template/packages/opmonlib/package.py
@@ -33,3 +33,4 @@ class Opmonlib(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/rcif/package.py
+++ b/spack-repos/coredaq-repo-template/packages/rcif/package.py
@@ -33,3 +33,4 @@ class Rcif(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/readout/package.py
+++ b/spack-repos/coredaq-repo-template/packages/readout/package.py
@@ -36,4 +36,4 @@ class Readout(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
-
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/readoutlibs/package.py
+++ b/spack-repos/coredaq-repo-template/packages/readoutlibs/package.py
@@ -35,7 +35,7 @@ class Readoutlibs(CMakePackage):
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
         env.prepend_path('LIBRARY_PATH', self.spec['numactl'].prefix.lib)
         env.prune_duplicate_paths('LIBRARY_PATH')
-
+        XDBPATHX
 
     def setup_build_environment(self, env):
         env.prepend_path('LIBRARY_PATH', self.spec['numactl'].prefix.lib)

--- a/spack-repos/coredaq-repo-template/packages/readoutmodules/package.py
+++ b/spack-repos/coredaq-repo-template/packages/readoutmodules/package.py
@@ -33,3 +33,4 @@ class Readoutmodules(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/restcmd/package.py
+++ b/spack-repos/coredaq-repo-template/packages/restcmd/package.py
@@ -33,3 +33,4 @@ class Restcmd(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/serialization/package.py
+++ b/spack-repos/coredaq-repo-template/packages/serialization/package.py
@@ -34,3 +34,4 @@ class Serialization(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/timing/package.py
+++ b/spack-repos/coredaq-repo-template/packages/timing/package.py
@@ -34,4 +34,4 @@ class Timing(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
-
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/timinglibs/package.py
+++ b/spack-repos/coredaq-repo-template/packages/timinglibs/package.py
@@ -30,7 +30,6 @@ class Timinglibs(CMakePackage):
     def setup_run_environment(self, env):
         env.set(self.__module__.split(".")[-1].upper().replace("-", "_") + "_SHARE", self.prefix + "/share" )
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
-        env.prepend_path("DUNEDAQ_DB_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
-
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/trgdataformats/package.py
+++ b/spack-repos/coredaq-repo-template/packages/trgdataformats/package.py
@@ -32,5 +32,4 @@ class Trgdataformats(CMakePackage):
         env.prepend_path('DUNEDAQ_SHARE_PATH', self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
-
-
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/trgtools/package.py
+++ b/spack-repos/coredaq-repo-template/packages/trgtools/package.py
@@ -34,3 +34,4 @@ class Trgtools(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/trigemu/package.py
+++ b/spack-repos/coredaq-repo-template/packages/trigemu/package.py
@@ -34,5 +34,4 @@ class Trigemu(CMakePackage):
         env.prepend_path('DUNEDAQ_SHARE_PATH', self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
-
-
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/trigger/package.py
+++ b/spack-repos/coredaq-repo-template/packages/trigger/package.py
@@ -37,4 +37,4 @@ class Trigger(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
-
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/triggeralgs/package.py
+++ b/spack-repos/coredaq-repo-template/packages/triggeralgs/package.py
@@ -36,4 +36,4 @@ class Triggeralgs(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
-
+        XDBPATHX

--- a/spack-repos/coredaq-repo-template/packages/utilities/package.py
+++ b/spack-repos/coredaq-repo-template/packages/utilities/package.py
@@ -33,3 +33,4 @@ class Utilities(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/fddaq-repo-template/packages/asiolibs/package.py
+++ b/spack-repos/fddaq-repo-template/packages/asiolibs/package.py
@@ -30,5 +30,5 @@ class Asiolibs(CMakePackage):
         env.set(self.__module__.split(".")[-1].upper().replace("-", "_") + "_SHARE", self.prefix + "/share" )
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
-        env.prepend_path('DUNEDAQ_DB_PATH', self.prefix + "/share")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/fddaq-repo-template/packages/cibmodules/package.py
+++ b/spack-repos/fddaq-repo-template/packages/cibmodules/package.py
@@ -33,3 +33,4 @@ class Cibmodules(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/fddaq-repo-template/packages/crtmodules/package.py
+++ b/spack-repos/fddaq-repo-template/packages/crtmodules/package.py
@@ -32,5 +32,5 @@ class Crtmodules(CMakePackage):
         env.set(self.__module__.split(".")[-1].upper().replace("-", "_") + "_SHARE", self.prefix + "/share" )
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
-        env.prepend_path('DUNEDAQ_DB_PATH', self.prefix + "/share")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/fddaq-repo-template/packages/ctbmodules/package.py
+++ b/spack-repos/fddaq-repo-template/packages/ctbmodules/package.py
@@ -33,3 +33,4 @@ class Ctbmodules(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/fddaq-repo-template/packages/daphnemodules/package.py
+++ b/spack-repos/fddaq-repo-template/packages/daphnemodules/package.py
@@ -31,3 +31,4 @@ class Daphnemodules(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/fddaq-repo-template/packages/daqsystemtest/package.py
+++ b/spack-repos/fddaq-repo-template/packages/daqsystemtest/package.py
@@ -30,6 +30,5 @@ class Daqsystemtest(CMakePackage):
     def setup_run_environment(self, env):
         env.set(self.__module__.split(".")[-1].upper().replace("-", "_") + "_SHARE", self.prefix + "/share" )
         env.prepend_path('DUNEDAQ_SHARE_PATH', self.prefix + "/share")
-        env.prepend_path('DUNEDAQ_DB_PATH', self.prefix + "/share")
         env.prepend_path('PYTHONPATH', self.prefix.lib + "64/python")
-
+        XDBPATHX

--- a/spack-repos/fddaq-repo-template/packages/dpdklibs/package.py
+++ b/spack-repos/fddaq-repo-template/packages/dpdklibs/package.py
@@ -33,3 +33,4 @@ class Dpdklibs(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/fddaq-repo-template/packages/fddaqconf/package.py
+++ b/spack-repos/fddaq-repo-template/packages/fddaqconf/package.py
@@ -31,4 +31,4 @@ class Fddaqconf(CMakePackage):
         env.set(self.__module__.split(".")[-1].upper().replace("-", "_") + "_SHARE", self.prefix + "/share" )
         env.prepend_path('DUNEDAQ_SHARE_PATH', self.prefix + "/share")
         env.prepend_path('PYTHONPATH', self.prefix.lib + "64/python")
-
+        XDBPATHX

--- a/spack-repos/fddaq-repo-template/packages/fddetdataformats/package.py
+++ b/spack-repos/fddaq-repo-template/packages/fddetdataformats/package.py
@@ -32,5 +32,4 @@ class Fddetdataformats(CMakePackage):
         env.prepend_path('DUNEDAQ_SHARE_PATH', self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
-
-
+        XDBPATHX

--- a/spack-repos/fddaq-repo-template/packages/fdreadoutlibs/package.py
+++ b/spack-repos/fddaq-repo-template/packages/fdreadoutlibs/package.py
@@ -31,3 +31,4 @@ class Fdreadoutlibs(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/fddaq-repo-template/packages/fdreadoutmodules/package.py
+++ b/spack-repos/fddaq-repo-template/packages/fdreadoutmodules/package.py
@@ -33,3 +33,4 @@ class Fdreadoutmodules(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/fddaq-repo-template/packages/flxlibs/package.py
+++ b/spack-repos/fddaq-repo-template/packages/flxlibs/package.py
@@ -31,4 +31,4 @@ class Flxlibs(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
-
+        XDBPATHX

--- a/spack-repos/fddaq-repo-template/packages/hermesmodules/package.py
+++ b/spack-repos/fddaq-repo-template/packages/hermesmodules/package.py
@@ -31,3 +31,4 @@ class Hermesmodules(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/fddaq-repo-template/packages/rawdatautils/package.py
+++ b/spack-repos/fddaq-repo-template/packages/rawdatautils/package.py
@@ -33,3 +33,4 @@ class Rawdatautils(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/fddaq-repo-template/packages/snbmodules/package.py
+++ b/spack-repos/fddaq-repo-template/packages/snbmodules/package.py
@@ -34,5 +34,5 @@ class Snbmodules(CMakePackage):
         env.set(self.__module__.split(".")[-1].upper().replace("-", "_") + "_SHARE", self.prefix + "/share" )
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
-        env.prepend_path('DUNEDAQ_DB_PATH', self.prefix + "/share")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/fddaq-repo-template/packages/sspmodules/package.py
+++ b/spack-repos/fddaq-repo-template/packages/sspmodules/package.py
@@ -25,5 +25,4 @@ class Sspmodules(CMakePackage):
         env.prepend_path('DUNEDAQ_SHARE_PATH', self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
-
-
+        XDBPATHX

--- a/spack-repos/fddaq-repo-template/packages/tdemodules/package.py
+++ b/spack-repos/fddaq-repo-template/packages/tdemodules/package.py
@@ -31,3 +31,4 @@ class Tdemodules(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/fddaq-repo-template/packages/tpglibs/package.py
+++ b/spack-repos/fddaq-repo-template/packages/tpglibs/package.py
@@ -33,3 +33,4 @@ class Tpglibs(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/fddaq-repo-template/packages/tpgtools/package.py
+++ b/spack-repos/fddaq-repo-template/packages/tpgtools/package.py
@@ -34,3 +34,4 @@ class Tpgtools(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/fddaq-repo-template/packages/uhallibs/package.py
+++ b/spack-repos/fddaq-repo-template/packages/uhallibs/package.py
@@ -33,3 +33,4 @@ class Uhallibs(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
+        XDBPATHX

--- a/spack-repos/fddaq-repo-template/packages/wibmod/package.py
+++ b/spack-repos/fddaq-repo-template/packages/wibmod/package.py
@@ -33,6 +33,4 @@ class Wibmod(CMakePackage):
         env.prepend_path("DUNEDAQ_SHARE_PATH", self.prefix + "/share")
         env.prepend_path('CET_PLUGIN_PATH', self.prefix.lib + "64")
         env.prepend_path("PYTHONPATH", self.prefix.lib + "64/python")
-
-
-
+        XDBPATHX


### PR DESCRIPTION
This PR is very much in the spirit of https://github.com/DUNE-DAQ/daq-release/pull/352. In a nutshell, rather than Software Coordination needing to manually add a repo's addition to `DUNEDAQ_DB_PATH` to the repo's `package.py` file, `make-release-repo.py` has been updated to check for OKS data and schema files in a repo and, should they exist, to update `package.py` accordingly by substituting the `XDBPATHX` token. Note that `DDPFD_DEV_260204_A9` is built using this feature branch of daq-release and that it recreates the performance of the extended integration tests (https://github.com/DUNE-DAQ/daq-release/actions/runs/21680817046) and the classic integration tests (https://github.com/DUNE-DAQ/daq-release/actions/runs/21686107769). 