### PR TITLE
Rename elisa-client-api to elisa_client_api where appropriate

### DIFF
--- a/.github/workflows/build-nightly-release-alma9.yml
+++ b/.github/workflows/build-nightly-release-alma9.yml
@@ -73,6 +73,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: daq-release
+        ref: amogan/rename_elisa_client_api
     
     - name: Set environment variables
       run: |

--- a/configs/fddaq/fddaq-develop/release.yaml
+++ b/configs/fddaq/fddaq-develop/release.yaml
@@ -153,7 +153,7 @@
         - name: druncschema
           version: develop
           source:  github_DUNE-DAQ
-        - name: elisa-client-api
+        - name: elisa_client_api
           version: develop
           source:  github_DUNE-DAQ
         - name: executing

--- a/scripts/checkout-daq-package.py
+++ b/scripts/checkout-daq-package.py
@@ -86,6 +86,9 @@ class DAQCheckoutPackage:
 
     def __init__(self, package_dict, checkout_area):
         self.name = package_dict.get("name")
+        # AJM Mar. 4, 2026: the next two lines are kept for backwards compatibility
+        if self.name == "elisa-client-api":
+            self.name = "elisa_client_api"
         self.commit = package_dict.get("commit")
         self.version = package_dict.get("version")
         self.source = package_dict.get("source")

--- a/scripts/checkout-daq-package.py
+++ b/scripts/checkout-daq-package.py
@@ -86,9 +86,6 @@ class DAQCheckoutPackage:
 
     def __init__(self, package_dict, checkout_area):
         self.name = package_dict.get("name")
-        # AJM Nov. 17, 2025: for now, keep next two lines for backwards compatibility
-        if self.name == "elisa-client-api":
-            self.name = "elisa_client_api"
         self.commit = package_dict.get("commit")
         self.version = package_dict.get("version")
         self.source = package_dict.get("source")

--- a/scripts/create-release-tag.py
+++ b/scripts/create-release-tag.py
@@ -156,8 +156,6 @@ if __name__ == "__main__":
             ref = i["version"]
             if not ref.startswith('v'):
                 ref = "v" + ref
-            if "elisa" in iname:
-                iname = iname.replace('-', '_')
             if args.delete:
                 checkout_and_delete_tag(iname, new_tag)
             else:
@@ -187,8 +185,6 @@ if __name__ == "__main__":
             iname = args.package
         if not ref.startswith('v'):
             ref = "v" + ref
-        if "elisa" in iname:
-            iname = iname.replace('-', '_')
         if args.delete:
             checkout_and_delete_tag(iname, new_tag)
         else:

--- a/scripts/github-ci/sync-ci-workflow-to-template.sh
+++ b/scripts/github-ci/sync-ci-workflow-to-template.sh
@@ -18,9 +18,6 @@ function git_checkout_and_update_ci {
   for repo in "${repo_list[@]}"; do
     irepo_arr=(${repo})
     repo_name=${irepo_arr[0]//_/-}
-    if [[ "$repo_name" == "elisa-client-api" ]]; then
-      repo_name="elisa_client_api"
-    fi
     echo "--------------------------------------------------------------"
     echo "********************* $repo_name *****************************"
     git clone --quiet https://github.com/DUNE-DAQ/${repo_name}.git -b "$branch" || exit 3

--- a/scripts/github-ci/sync-issue-forms-and-pr-template.sh
+++ b/scripts/github-ci/sync-issue-forms-and-pr-template.sh
@@ -54,9 +54,6 @@ git clone https://github.com/DUNE-DAQ/.github.git dunedaq_github || exit 2
 
 ORG="DUNE-DAQ"
 for REPO in "${repo_list[@]}"; do
-    if [[ "$REPO" == "elisa-client-api" ]]; then
-      REPO="elisa_client_api"
-    fi
     echo "--------------------------------------------------------------"
     echo "********************* $REPO *****************************"
     git clone --quiet https://github.com/${ORG}/${REPO}.git || exit 3

--- a/scripts/spack/make-release-repo.py
+++ b/scripts/spack/make-release-repo.py
@@ -14,7 +14,7 @@ import pathlib
 from time import sleep
 
 from dr_tools import parse_yaml_file
-from mappings import cmake_to_spack, pyvenv_url_names
+from mappings import cmake_to_spack
 
 contains_oks_file = {}
 
@@ -65,10 +65,6 @@ def get_contains_oks_file(repo_path_name):
 
 def get_commit_hash(repo, tag_or_branch, fall_back_tag="develop"):
     tmp_dir = tempfile.mkdtemp()
-
-    # Account for packages whose names in release manifest don't match the GitHub URL
-    if repo in pyvenv_url_names:
-        repo = pyvenv_url_names[repo].get('repo_name', repo)
 
     try:
         cmd = f"""cd {tmp_dir}; git clone --quiet https://github.com/DUNE-DAQ/{repo}.git"""
@@ -381,17 +377,14 @@ class DAQRelease:
                     iline = f'{iname}=={iversion}'
                 if i["source"].startswith("github"):
                     iuser = i["source"].replace("github_", "")
-                    # Special cases are handled using a dictionary in mappings.py
-                    repo_name = pyvenv_url_names.get(iname, {}).get("repo_name", iname)
-                    egg_name = pyvenv_url_names.get(iname, {}).get("egg_name", repo_name)
 
                     if iversion == "develop" and not iname == "moo":
                         (itag, ihash) = get_commit_hash(iname, iversion, iversion)
-                        iline = f"git+https://github.com/{iuser}/{repo_name}@{ihash}#egg={egg_name}"
+                        iline = f"git+https://github.com/{iuser}/{iname}@{ihash}#egg={iname}"
                     elif iname == "moo":
-                        iline = f"git+https://github.com/{iuser}/{repo_name}@{iversion}#egg={egg_name}"
+                        iline = f"git+https://github.com/{iuser}/{iname}@{iversion}#egg={iname}"
                     else:
-                        iline = f"git+https://github.com/{iuser}/{repo_name}@v{iversion}#egg={egg_name}"
+                        iline = f"git+https://github.com/{iuser}/{iname}@v{iversion}#egg={iname}"
                 f.write(iline + '\n')
         return
 

--- a/scripts/spack/mappings.py
+++ b/scripts/spack/mappings.py
@@ -14,6 +14,3 @@ cmake_to_spack = {
     'tbb': 'intel-tbb',
 }
 
-pyvenv_url_names = {
-    "elisa-client-api": {"repo_name": "elisa_client_api"},
-}


### PR DESCRIPTION
`elisa_client_api`'s URL was recently updated to replace dashes with underscores, making its name and URL consistent. This PR applies this change to `fddaq-develop/release.yaml`. This removes the need for some bespoke logic to map `elisa-client-api` to `elisa_client_api`, namely in `make-release-repo.py`.

The test build `ELFD_DEV_260303_A9` was built using the modified `make-release-repo.py`. To check that the generated `pyvenv_requirements.txt` is still generated correctly, I compared to that of the previous nightly:
```
diff /cvmfs/dunedaq-development.opensciencegrid.org/nightly/ELFD_DEV_260303_A9/pyvenv_requirements.txt \
     /cvmfs/dunedaq-development.opensciencegrid.org/nightly/NFD_DEV_260303_A9/pyvenv_requirements.txt
```
The output shows only a different hash for `drunc`, which corresponds to a commit pushed yesterday after the nightly but before `ELFD_DEV_260303_A9` was built. 

Integration test results [here](https://github.com/DUNE-DAQ/daq-release/actions/runs/22676290315). 