### PR TITLE
Improve integtest reporting in Slack

### DIFF
--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -120,10 +120,10 @@ jobs:
         cd ${{ env.DBT_AREA_ROOT }}
         source env.sh
         cd ../$DAQ_RELEASE_PATH/scripts
-        ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -p dfmodules -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -p dfmodules -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
 
     - name: Run integration tests

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -122,7 +122,7 @@ jobs:
         cd ../$DAQ_RELEASE_PATH/scripts
         #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -p dfmodules -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -p dfmodules -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         ./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
 
@@ -208,7 +208,8 @@ jobs:
       release_tag: ${{ needs.make_variables.outputs.tag }}
       integtest_log_dir: ${{ needs.make_variables.outputs.persistent_log_dir }}
     secrets: 
-      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+      #slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+      slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
 
   cleanup_files:
     runs-on: daq

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -98,7 +98,6 @@ jobs:
       uses: actions/checkout@v6
       with:
         path: ${{ needs.make_variables.outputs.daq_release_path }}
-        ref: amogan/issue541_improve_integtest_reporting
 
     - name: Create build area
       run: |
@@ -120,10 +119,10 @@ jobs:
         cd ${{ env.DBT_AREA_ROOT }}
         source env.sh
         cd ../$DAQ_RELEASE_PATH/scripts
-        #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         #./checkout-daq-package.py -p dfmodules -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
 
     - name: Run integration tests
@@ -209,8 +208,7 @@ jobs:
       integtest_log_dir: ${{ needs.make_variables.outputs.persistent_log_dir }}
       artifact_name: nightly_extended_integtest_json
     secrets: 
-      #slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-      slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   cleanup_files:
     runs-on: daq

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -98,6 +98,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         path: ${{ needs.make_variables.outputs.daq_release_path }}
+        ref: amogan/issue541_improve_integtest_reporting
 
     - name: Create build area
       run: |

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -207,6 +207,7 @@ jobs:
     with:
       release_tag: ${{ needs.make_variables.outputs.tag }}
       integtest_log_dir: ${{ needs.make_variables.outputs.persistent_log_dir }}
+      artifact_name: nightly_extended_integtest_json
     secrets: 
       #slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
       slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -82,17 +82,17 @@ jobs:
         matrix:
 
             test_name: [
-                        #"listrev_test",
-                        #"3ru_1df_multirun_test",
-                        #"3ru_3df_multirun_test",
-                        #"example_system_test",
-                        #"fake_data_producer_test",
-                        #"long_window_readout_test",
+                        "listrev_test",
+                        "3ru_1df_multirun_test",
+                        "3ru_3df_multirun_test",
+                        "example_system_test",
+                        "fake_data_producer_test",
+                        "long_window_readout_test",
                         "minimal_system_quick_test",
-                        #"readout_type_scan_test",
-                        #"small_footprint_quick_test",
-                        #"tpreplay_test",
-                        #"tpstream_writing_test"
+                        "readout_type_scan_test",
+                        "small_footprint_quick_test",
+                        "tpreplay_test",
+                        "tpstream_writing_test"
                        ]
     defaults:
       run:
@@ -214,8 +214,7 @@ jobs:
       integtest_log_dir: ${{ needs.make_variables.outputs.persistent_log_dir }}
       artifact_name: nightly_integtest_json
     secrets: 
-      #slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-      slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   cleanup_files:
     runs-on: daq

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -83,16 +83,16 @@ jobs:
 
             test_name: [
                         "listrev_test",
-                        "3ru_1df_multirun_test",
-                        "3ru_3df_multirun_test",
-                        "example_system_test",
-                        "fake_data_producer_test",
-                        "long_window_readout_test",
+                        #"3ru_1df_multirun_test",
+                        #"3ru_3df_multirun_test",
+                        #"example_system_test",
+                        #"fake_data_producer_test",
+                        #"long_window_readout_test",
                         "minimal_system_quick_test",
-                        "readout_type_scan_test",
-                        "small_footprint_quick_test",
-                        "tpreplay_test",
-                        "tpstream_writing_test"
+                        #"readout_type_scan_test",
+                        #"small_footprint_quick_test",
+                        #"tpreplay_test",
+                        #"tpstream_writing_test"
                        ]
     defaults:
       run:
@@ -212,8 +212,10 @@ jobs:
     with:
       release_tag: ${{ needs.make_variables.outputs.tag }}
       integtest_log_dir: ${{ needs.make_variables.outputs.persistent_log_dir }}
+      artifact_name: nightly_integtest_json
     secrets: 
-      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+      slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
+      #slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   cleanup_files:
     runs-on: daq

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -214,7 +214,8 @@ jobs:
       integtest_log_dir: ${{ needs.make_variables.outputs.persistent_log_dir }}
       artifact_name: nightly_integtest_json
     secrets: 
-      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+      #slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+      slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
 
   cleanup_files:
     runs-on: daq

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -82,17 +82,17 @@ jobs:
         matrix:
 
             test_name: [
-                        "listrev_test",
-                        "3ru_1df_multirun_test",
-                        "3ru_3df_multirun_test",
-                        "example_system_test",
-                        "fake_data_producer_test",
-                        "long_window_readout_test",
+                        #"listrev_test",
+                        #"3ru_1df_multirun_test",
+                        #"3ru_3df_multirun_test",
+                        #"example_system_test",
+                        #"fake_data_producer_test",
+                        #"long_window_readout_test",
                         "minimal_system_quick_test",
-                        "readout_type_scan_test",
-                        "small_footprint_quick_test",
-                        "tpreplay_test",
-                        "tpstream_writing_test"
+                        #"readout_type_scan_test",
+                        #"small_footprint_quick_test",
+                        #"tpreplay_test",
+                        #"tpstream_writing_test"
                        ]
     defaults:
       run:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -83,16 +83,16 @@ jobs:
 
             test_name: [
                         "listrev_test",
-                        #"3ru_1df_multirun_test",
-                        #"3ru_3df_multirun_test",
-                        #"example_system_test",
-                        #"fake_data_producer_test",
-                        #"long_window_readout_test",
+                        "3ru_1df_multirun_test",
+                        "3ru_3df_multirun_test",
+                        "example_system_test",
+                        "fake_data_producer_test",
+                        "long_window_readout_test",
                         "minimal_system_quick_test",
-                        #"readout_type_scan_test",
-                        #"small_footprint_quick_test",
-                        #"tpreplay_test",
-                        #"tpstream_writing_test"
+                        "readout_type_scan_test",
+                        "small_footprint_quick_test",
+                        "tpreplay_test",
+                        "tpstream_writing_test"
                        ]
     defaults:
       run:
@@ -214,8 +214,7 @@ jobs:
       integtest_log_dir: ${{ needs.make_variables.outputs.persistent_log_dir }}
       artifact_name: nightly_integtest_json
     secrets: 
-      slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
-      #slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   cleanup_files:
     runs-on: daq

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -32,8 +32,7 @@ jobs:
     needs: run_dbt_commands
     uses: ./.github/workflows/slack-notification.yml
     secrets: 
-      slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
-      #slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   cleanup_test_area:
     runs-on: daq

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -32,7 +32,8 @@ jobs:
     needs: run_dbt_commands
     uses: ./.github/workflows/slack-notification.yml
     secrets: 
-      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+      slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
+      #slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   cleanup_test_area:
     runs-on: daq

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -46,25 +46,22 @@ jobs:
         name: ${{ inputs.artifact_name }}
         path: artifacts
     - name: Add metadata to workflow summary
+      if: ${{ inputs.artifact_name }}
       run: |
         ARTIFACT_JSON="{}"
-        if [[ -d artifacts ]]; then
-          if compgen -G "artifacts/*.json" > /dev/null; then
-            jq -s '.[0]' artifacts/*.json > artifacts.json
-          else
-            echo "ERROR: ${{ inputs.artifact_name }} does not contains any JSON files."
-            echo "ERROR: Continuing with empty artifact data..."
-            echo "[]" > artifacts.json
-          fi
-        
+        [[ -d artifacts ]] || echo "ERROR: There was an issue downloading ${{ inputs.artifact_name }}; exit 1"
+
+        if compgen -G "artifacts/*.json" > /dev/null; then
+          jq -s '.[0]' artifacts/*.json > artifacts.json
+        else
+          echo "WARNING: ${{ inputs.artifact_name }} does not contains any JSON files."
+          echo "WARNING: Continuing with empty artifact data..."
+          echo "[]" > artifacts.json
+        fi
+
         ARTIFACT_JSON="$(<artifacts.json)"
-      
         echo "Found additional artifact data:"
         echo "$ARTIFACT_JSON"
-        else
-          echo "ERROR: No artifacts directory found. Exiting..."
-          exit 123
-        fi
 
         jq --null-input \
            --arg release "${{ inputs.release_tag }}" \

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -95,4 +95,6 @@ jobs:
     - name: Cleanup files
       run: |
         rm workflow_summary.json additional_metadata.json workflow_summary_with_metadata.json slack_payload.json || true
+        rm pytest_summary.json artifacts.json || true
+        rm -rf artifacts || true
         rm -rf daq-release-slack-message

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -18,6 +18,10 @@ on:
         type: string
         default: ''
         description: Optional path to directory containing the full pytest output.
+      artifact_name:
+        type: string
+        default: ''
+        description: Optional artifact name to download for additional metadata.
     secrets:
       slack_webhook_url:
         required: true
@@ -35,16 +39,33 @@ jobs:
       run: |
         # Outputs workflow_summary.json
         ./daq-release-slack-message/scripts/github-ci/get_workflow_summary.sh ${{ github.run_id }}
+    - name: Download artifact if specified
+      if: ${{ inputs.artifact_name }}
+      uses: actions/download-artifact@v8
+      with:
+        name: ${{ inputs.artifact_name }}
     - name: Add metadata to workflow summary
       run: |
+        ARTIFACT_JSON="{}"
+        if [[ -f "${{ inputs.artifact_name}}" ]]; then
+          ARTIFACT_JSON="$(cat "${{ inputs.artifact_name }}")"
+          echo "Found additional artifact data:"
+          echo "$ARTIFACT_JSON"
+        else
+          echo "ERROR: Artifact ${{ inputs.artifact_name }} not found. Exiting..."
+          exit 123
+        fi
+
         jq --null-input \
            --arg release "${{ inputs.release_tag }}" \
            --arg caller  "${{ inputs.caller }}" \
            --arg pytest_log_dir "${{ inputs.integtest_log_dir }}" \
+           --argjson artifact_data "$ARTIFACT_JSON" \
            '{
               "release"        : $release,
               "caller"         : $caller,
-              "pytest_log_dir" : $pytest_log_dir
+              "pytest_log_dir" : $pytest_log_dir,
+              "artifact_data"  : $artifact_data
             }' > additional_metadata.json
 
         jq -s '.[0] + .[1]' workflow_summary.json additional_metadata.json > workflow_summary_with_metadata.json

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -50,7 +50,7 @@ jobs:
         ARTIFACT_JSON="{}"
         if [[ -d artifacts ]]; then
           if compgen -G "artifacts/*.json" > /dev/null; then
-            jq -s '.' artifacts/*.json > artifacts.json
+            jq -s '.[0]' artifacts/*.json > artifacts.json
           else
             echo "ERROR: ${{ inputs.artifact_name }} does not contains any JSON files."
             echo "ERROR: Continuing with empty artifact data..."

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -45,7 +45,7 @@ jobs:
       with:
         name: ${{ inputs.artifact_name }}
         path: artifacts
-    - name: Add metadata to workflow summary
+    - name: Determine artifact data
       if: ${{ inputs.artifact_name }}
       run: |
         ARTIFACT_JSON="{}"
@@ -59,10 +59,12 @@ jobs:
           echo "[]" > artifacts.json
         fi
 
-        ARTIFACT_JSON="$(<artifacts.json)"
         echo "Found additional artifact data:"
-        echo "$ARTIFACT_JSON"
+        cat artifacts.json
 
+    - name: Add metadata to workflow summary
+      run: |
+        ARTIFACT_JSON="$(<artifacts.json)"
         jq --null-input \
            --arg release "${{ inputs.release_tag }}" \
            --arg caller  "${{ inputs.caller }}" \

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -44,15 +44,25 @@ jobs:
       uses: actions/download-artifact@v8
       with:
         name: ${{ inputs.artifact_name }}
+        path: artifacts
     - name: Add metadata to workflow summary
       run: |
         ARTIFACT_JSON="{}"
-        if [[ -f "${{ inputs.artifact_name}}" ]]; then
-          ARTIFACT_JSON="$(cat "${{ inputs.artifact_name }}")"
-          echo "Found additional artifact data:"
-          echo "$ARTIFACT_JSON"
+        if [[ -d artifacts ]]; then
+          if compgen -G "artifacts/*.json" > /dev/null; then
+            jq -s '.' artifacts/*.json > artifacts.json
+          else
+            echo "ERROR: ${{ inputs.artifact_name }} does not contains any JSON files."
+            echo "ERROR: Continuing with empty artifact data..."
+            echo "[]" > artifacts.json
+          fi
+        
+        ARTIFACT_JSON="$(<artifacts.json)"
+      
+        echo "Found additional artifact data:"
+        echo "$ARTIFACT_JSON"
         else
-          echo "ERROR: Artifact ${{ inputs.artifact_name }} not found. Exiting..."
+          echo "ERROR: No artifacts directory found. Exiting..."
           exit 123
         fi
 

--- a/scripts/github-ci/integration_test_summary.py
+++ b/scripts/github-ci/integration_test_summary.py
@@ -67,8 +67,8 @@ class IntegrationTestSummary:
         'passed': ':white_check_mark:',
         'failed': ':x:',
         'skipped': ':fast_forward:',
-        'error': ':warning:'
-        'all_passed': ':tada:'
+        'error': ':warning:',
+        'all_passed': ':tada:',
     }
 
     def which_emoji(self, test_status: str) -> str:

--- a/scripts/github-ci/integration_test_summary.py
+++ b/scripts/github-ci/integration_test_summary.py
@@ -95,7 +95,7 @@ class IntegrationTestSummary:
             self.totals['skipped'] == 0 and
             self.totals['errors'] == 0
         ):
-            return f"All tests passed {self.which_emoji('all_passed')}"
+            return f"All tests passed {self.which_emoji('all_passed')}\n"
 
         return dedent(f"""\
             {self.totals['total_run']} total tests run.

--- a/scripts/github-ci/integration_test_summary.py
+++ b/scripts/github-ci/integration_test_summary.py
@@ -98,9 +98,9 @@ class IntegrationTestSummary:
             return f"All tests passed {self.which_emoji('all_passed')}"
 
         return dedent(f"""\
-            {self.totals['total_run']} total tests run. 
-            {self.totals['passed']} passed {self.which_emoji('passed')}, 
-            {self.totals['failed']} failed {self.which_emoji('failed')}, 
+            {self.totals['total_run']} total tests run.
+            {self.totals['passed']} passed {self.which_emoji('passed')},
+            {self.totals['failed']} failed {self.which_emoji('failed')},
             {self.totals['skipped']} were skipped {self.which_emoji('skipped')}, and
             {self.totals['errors']} had errors {self.which_emoji('error')} which prevented the test from completing.\n"""
         )

--- a/scripts/github-ci/integration_test_summary.py
+++ b/scripts/github-ci/integration_test_summary.py
@@ -101,7 +101,7 @@ class IntegrationTestSummary:
             {self.totals['total_run']} total tests run.
             {self.totals['passed']} passed {self.which_emoji('passed')},
             {self.totals['failed']} failed {self.which_emoji('failed')},
-            {self.totals['skipped']} were skipped {self.which_emoji('skipped')}, and
+            {self.totals['skipped']} skipped {self.which_emoji('skipped')}, and
             {self.totals['errors']} had errors {self.which_emoji('error')} which prevented the test from completing.\n"""
         )
 

--- a/scripts/github-ci/integration_test_summary.py
+++ b/scripts/github-ci/integration_test_summary.py
@@ -68,6 +68,7 @@ class IntegrationTestSummary:
         'failed': ':x:',
         'skipped': ':fast_forward:',
         'error': ':warning:'
+        'all_passed': ':tada:'
     }
 
     def which_emoji(self, test_status: str) -> str:
@@ -89,6 +90,13 @@ class IntegrationTestSummary:
 
     @property
     def summary_text(self) -> str:
+        if (self.totals['passed'] > 0 and
+            self.totals['failed'] == 0 and
+            self.totals['skipped'] == 0 and
+            self.totals['errors'] == 0
+        ):
+            return f"All tests passed {self.which_emoji('all_passed')}"
+
         return dedent(f"""\
             {self.totals['total_run']} total tests run. 
             {self.totals['passed']} passed {self.which_emoji('passed')}, 

--- a/scripts/github-ci/integration_test_summary.py
+++ b/scripts/github-ci/integration_test_summary.py
@@ -63,6 +63,16 @@ class PytestResult:
 class IntegrationTestSummary:
     pytest_results: list[PytestResult] = field(default_factory=list)
 
+    EMOJI_MAP = {
+        'passed': ':white_check_mark:',
+        'failed': ':x:',
+        'skipped': ':fast_forward:',
+        'error': ':warning:'
+    }
+
+    def which_emoji(self, test_status: str) -> str:
+        return self.EMOJI_MAP.get(test_status, ':question:')
+
     @property
     def totals(self) -> dict[str, int]:
         passed = sum(pr.passed for pr in self.pytest_results)
@@ -76,6 +86,16 @@ class IntegrationTestSummary:
             "errors": errors,
             "total_run": passed + failed
         }
+
+    @property
+    def summary_text(self) -> str:
+        return dedent(f"""\
+            {self.totals['total_run']} total tests run. 
+            {self.totals['passed']} passed {self.which_emoji('passed')}, 
+            {self.totals['failed']} failed {self.which_emoji('failed')}, 
+            {self.totals['skipped']} were skipped {self.which_emoji('skipped')}, and
+            {self.totals['errors']} had errors {self.which_emoji('error')} which prevented the test from completing.\n"""
+        )
 
     @classmethod
     def from_dict(cls, data: dict) -> IntegrationTestSummary:
@@ -107,6 +127,7 @@ class IntegrationTestSummary:
                 "errors": self.totals['errors'],
                 "total_run": self.totals['total_run'],
             },
+            "summary_text": self.summary_text,
             "pytest_results": grouped
         }
 
@@ -130,13 +151,7 @@ class IntegrationTestSummary:
             return f"| {testname} | {emoji} {result} |\n"
 
         with open(output_filename, 'w') as f:
-            summary_string = dedent(f"""\
-                {self.totals['total_run']} total tests run. 
-                {self.totals['passed']} passed {which_emoji('passed')}, 
-                {self.totals['failed']} failed {which_emoji('failed')}, 
-                {self.totals['skipped']} were skipped {which_emoji('skipped')}, and
-                {self.totals['errors']} had errors {which_emoji('error')} which prevented the test from completing.\n""")
-            f.write(summary_string)
+            f.write(self.summary_text)
 
             for idx, pytest_result in enumerate(self.pytest_results):
                 f.write(f"# {pytest_result.repo_name} {pytest_result.test_name} Results\n")

--- a/scripts/github-ci/slack_message_builder.py
+++ b/scripts/github-ci/slack_message_builder.py
@@ -186,17 +186,25 @@ class NewReleaseMessageStrategy(BaseMessageStrategy):
         )
 
 class IntegrationTestMessageStrategy(BaseMessageStrategy):
-    def build_extra_blocks(self):
+    def _get_summary_text(self):
+        return self.summary.get("artifact_data", {}).get("summary_text", "FAILED TO GET SUMMARY")
+
+    def _get_pytest_log_text(self):
         pytest_log_dir = self.summary.get("pytest_log_dir", None)
-        extra_blocks = []
-        extra_blocks.append(self.build_release_section())
-        extra_blocks.append(
-            SectionBlock(
-                f"The pytest logs for these tests will be stored for 7 days at:\n"
-                f"`daq.fnal.gov:{pytest_log_dir}`\n"
-                f"You can also download logs from the *Full report* link above."
-            )
+        return (
+            f"The pytest logs for these tests will be stored for 7 days at:\n"
+            f"`daq.fnal.gov:{pytest_log_dir}`\n"
+            f"You can also download logs from the *Full report* link above."
         )
+
+    def build_extra_blocks(self):
+        extra_blocks = []
+        summary_text = self._get_summary_text()
+        extra_blocks.append(SectionBlock(summary_text))
+
+        pytest_log_text = self._get_pytest_log_text()
+        extra_blocks.append(SectionBlock(pytest_log_text))
+
         return extra_blocks
 
 class CodeCoverageMessageStrategy(BaseMessageStrategy):


### PR DESCRIPTION
Addresses #541. This PR introduces the option for any workflow to pass an `artifact_name` to `slack-notification.yml`. If specified, the Slack notification workflow will attempt to download that artifact and combine any JSON files into additional metadata which will get added to the workflow summary file. If no JSON files are found, the workflow continues without appending additional data to the summary. 

For integration tests, this means we can pass the JSON summary artifact to `slack-notification.yml`, which will then get parsed by the updated `IntegrationTestMessageStrategy` of `slack_message_builder.py`. The `IntegrationTestSummary` class now exposes a `summary_text` property which handles the listing of passes, failures, errors, and skipped tests. If all tests pass, it will simply print `All tests passed`. Example results can be seen in the screenshot below.

Note that the extended integration test workflow will still show as successful even if some tests fail. Getting around this would probably require either parsing `dbt-build --integtest` output or modifying `dbt-build --integtest` to raise an exit code (but continue on error) if a test fails. I think that's outside the scope of this PR.

<img width="621" height="637" alt="Screenshot 2026-03-13 at 3 59 18 PM" src="https://github.com/user-attachments/assets/0d0f2450-1d58-4281-aceb-00baeccacdd7" />
