### PR TITLE
Improve logging size check in extended integration tests

### DIFF
--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -172,11 +172,8 @@ jobs:
     needs: [make_variables, extended_integration_tests]
     steps:
     - name: Generate summary tables
-      env:
-        RELEASE_TAG: ${{ needs.make_variables.outputs.tag }}
-        DAQ_RELEASE_PATH: ${{ needs.make_variables.outputs.daq_release_path }}
       run: |
-        cd $DAQ_RELEASE_PATH/scripts/github-ci/
+        cd ${{ needs.make_variables.outputs.daq_release_path }}/scripts/github-ci/
         python integtest_xml_parser.py --input-directory ${{ needs.extended_integration_tests.outputs.integtest_log_dir }}
         cat pytest_summary_table.md >> $GITHUB_STEP_SUMMARY
     - name: Upload markdown summary as artifact

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -221,16 +221,23 @@ jobs:
     env:
       RELEASE_TAG: ${{ needs.make_variables.outputs.tag }}
       DAQ_RELEASE_PATH: ${{ needs.make_variables.outputs.daq_release_path }}
+      INTEGTEST_XML_PATH: ${{ needs.make_variables.outputs.integtest_output_path }}
     steps:
       - name: Remove xml files
         run: |
           rm -rf ${{ needs.make_variables.outputs.integtest_output_path }}
       - name: Remove daq-release
         run: |
+          if [[ -d "$INTEGTEST_XML_PATH" ]]; then
+            echo "Removing $INTEGTEST_XML_PATH"
+            rm -rf $INTEGTEST_XML_PATH
+          fi
+
           if [[ -d "$DAQ_RELEASE_PATH" ]]; then
             echo "Removing $DAQ_RELEASE_PATH"
             rm -rf $DAQ_RELEASE_PATH
           fi
+
           if [[ -d "$RELEASE_TAG" ]]; then
             echo "Removing $RELEASE_TAG"
             rm -rf $RELEASE_TAG
@@ -238,8 +245,10 @@ jobs:
       - name: Delete old log directories
         run: |
           old_dirs=$(find /home/nfs/dunedaq/github-actions -mindepth 1 -maxdepth 1 -type d -mtime +7)
-          echo "Removing the following directories that are more than 7 days old: $old_dirs"
-          rm -rf $old_dirs
+          if [[ -n "$old_dirs" ]]; then
+            echo "Removing the following directories that are more than 7 days old: $old_dirs"
+            rm -rf $old_dirs
+          fi
 
   # Integration tests can sometimes collide with stale processes, leading to timeout
   cleanup_stale_gunicorn_processes:

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -119,10 +119,10 @@ jobs:
         cd ${{ env.DBT_AREA_ROOT }}
         source env.sh
         cd ../$DAQ_RELEASE_PATH/scripts
-        #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         #./checkout-daq-package.py -p dfmodules -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
 
     - name: Run integration tests
@@ -151,8 +151,6 @@ jobs:
         mapfile -t recent_pytest_dirs < <(find /tmp/pytest-of-dunedaq/ -mindepth 1 -maxdepth 1 -mmin -120 -type d)
         echo "Traversing pytest directories newer than 2 hours old: ${recent_pytest_dirs[@]}"
         for dir in "${recent_pytest_dirs[@]}"; do
-          echo "Contents of $dir:"
-          ls "$dir"
           if [[ ! -d "$dir" ]]; then
             echo "$dir is not a directory. Continuing..."
             continue
@@ -170,7 +168,7 @@ jobs:
             exit 2
           fi
 
-          rsync -av --no-links --prune-empty-dirs \
+          rsync -a --no-links --prune-empty-dirs \
             --chmod=D755,F644 \
             "$dir"/ "$PERSISTENT_LOG_DIR/$(basename "$dir")"/
         done

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -149,7 +149,7 @@ jobs:
         total_log_dir_size=0
 
         mapfile -t recent_pytest_dirs < <(find /tmp/pytest-of-dunedaq/ -mindepth 1 -maxdepth 1 -mmin -120 -type d)
-        echo "Traversing pytest directories newer than 2 hours old: ${recent_pytest_dirs[@]}"
+        echo "Traversing pytest directories less than 2 hours old: ${recent_pytest_dirs[@]}"
         for dir in "${recent_pytest_dirs[@]}"; do
           if [[ ! -d "$dir" ]]; then
             echo "$dir is not a directory. Continuing..."

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -119,10 +119,10 @@ jobs:
         cd ${{ env.DBT_AREA_ROOT }}
         source env.sh
         cd ../$DAQ_RELEASE_PATH/scripts
-        ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         #./checkout-daq-package.py -p dfmodules -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
 
     - name: Run integration tests

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -140,7 +140,7 @@ jobs:
         echo "integtest_log_dir=${integtest_log_dir}" >> "$GITHUB_OUTPUT"
         echo "integtest_log_dir: $integtest_log_dir"
 
-    - name: Move log files
+    - name: Store log files
       id: move_logs
       run: |
         mkdir -p "$PERSISTENT_LOG_DIR"
@@ -161,17 +161,9 @@ jobs:
 
           rsync -a --no-links --prune-empty-dirs \
             --chmod=D755,F644 \
+            --exclude='pytest-current/' \
             "$dir"/ "$PERSISTENT_LOG_DIR/$(basename "$dir")"/
         done
-
-        #cp -rL $(readlink -f /tmp/pytest-of-dunedaq/pytest-*/) $PERSISTENT_LOG_DIR/
-
-        #chmod -R 755 $PERSISTENT_LOG_DIR
-        #if [[ $(du -sk $PERSISTENT_LOG_DIR | awk '{print $1}') -gt 10000000 ]]; then
-        #  echo "The log directory $PERSISTENT_LOG_DIR has exceeded 10 GB. Deleting and exiting..."
-        #  rm -rf $PERSISTENT_LOG_DIR
-        #  exit 2
-        #fi
 
   parse_and_upload_results:
     runs-on: daq
@@ -199,29 +191,21 @@ jobs:
         name: nightly_extended_integtest_json
         path: ${{ needs.make_variables.outputs.daq_release_path }}/scripts/github-ci/pytest_summary.json
 
-  store_and_upload_logs:
+  upload_logs:
     runs-on: daq
     timeout-minutes: 5
     needs: [make_variables, extended_integration_tests]
     if: success() || failure()
     steps:
     - name: Upload logs as artifact
-      env:
-        TIMESTAMP: ${{needs.make_variables.outputs.timestamp}}
-        PERSISTENT_LOG_DIR: ${{needs.make_variables.outputs.persistent_log_dir}}
       uses: actions/upload-artifact@v7
       with:
-        name: pytest-logs-extended-${{ env.TIMESTAMP }}
-        path: ${{ env.PERSISTENT_LOG_DIR }}
-    - name: Delete old log directories
-      run: |
-        old_dirs=$(find /home/nfs/dunedaq/github-actions -mindepth 1 -maxdepth 1 -type d -mtime +7)
-        echo "Removing the following directories that are more than 7 days old: $old_dirs"
-        rm -rf $old_dirs
+        name: pytest-logs-extended-${{ needs.make_variables.outputs.timestamp }}
+        path: ${{ needs.make_variables.outputs.persistent_log_dir  }}
 
   send_slack_message:
     if: (success() || failure()) && ((github.event_name != 'workflow_dispatch') || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes'))
-    needs: [make_variables, extended_integration_tests, store_and_upload_logs]
+    needs: [make_variables, extended_integration_tests, upload_logs]
     uses: ./.github/workflows/slack-notification.yml
     with:
       release_tag: ${{ needs.make_variables.outputs.tag }}
@@ -251,6 +235,11 @@ jobs:
             echo "Removing $RELEASE_TAG"
             rm -rf $RELEASE_TAG
           fi
+      - name: Delete old log directories
+        run: |
+          old_dirs=$(find /home/nfs/dunedaq/github-actions -mindepth 1 -maxdepth 1 -type d -mtime +7)
+          echo "Removing the following directories that are more than 7 days old: $old_dirs"
+          rm -rf $old_dirs
 
   # Integration tests can sometimes collide with stale processes, leading to timeout
   cleanup_stale_gunicorn_processes:

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -140,18 +140,38 @@ jobs:
         echo "integtest_log_dir=${integtest_log_dir}" >> "$GITHUB_OUTPUT"
         echo "integtest_log_dir: $integtest_log_dir"
 
-    - name:
+    - name: Move log files
       id: move_logs
       run: |
-        mkdir -p $PERSISTENT_LOG_DIR
-        cp -rL $(readlink -f /tmp/pytest-of-dunedaq/pytest-*/) $PERSISTENT_LOG_DIR/
+        mkdir -p "$PERSISTENT_LOG_DIR"
 
-        chmod -R 755 $PERSISTENT_LOG_DIR
-        if [[ $(du -sk $PERSISTENT_LOG_DIR | awk '{print $1}') -gt 10000000 ]]; then
-          echo "The log directory $PERSISTENT_LOG_DIR has exceeded 10 GB. Deleting and exiting..."
-          rm -rf $PERSISTENT_LOG_DIR
-          exit 2
-        fi
+        max_kb=10000000
+        total_log_dir_size=0
+
+        for dir in /tmp/pytest-of-dunedaq/pytest-*; do
+          [[ -d "$dir" ]] || continue
+          dir_size_kb=$(du -sk $dir | awk '{print $1}')
+          echo "Size of $dir: $(du -sh $dir | awk '{print $1}')"
+
+          total_log_dir_size=$(( total_log_dir_size + dir_size_kb))
+          if (( total_log_dir_size > max_kb )); then
+            echo "ERROR: $dir of size $dir_size_kb would make $PERSISTENT_LOG_DIR exceed $max_kb. Exiting..." >&2
+            exit 2
+          fi
+
+          rsync -a --no-links --prune-empty-dirs \
+            --chmod=D755,F644 \
+            "$dir"/ "$PERSISTENT_LOG_DIR/$(basename "$dir")"/
+        done
+
+        #cp -rL $(readlink -f /tmp/pytest-of-dunedaq/pytest-*/) $PERSISTENT_LOG_DIR/
+
+        #chmod -R 755 $PERSISTENT_LOG_DIR
+        #if [[ $(du -sk $PERSISTENT_LOG_DIR | awk '{print $1}') -gt 10000000 ]]; then
+        #  echo "The log directory $PERSISTENT_LOG_DIR has exceeded 10 GB. Deleting and exiting..."
+        #  rm -rf $PERSISTENT_LOG_DIR
+        #  exit 2
+        #fi
 
   parse_and_upload_results:
     runs-on: daq

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -152,10 +152,10 @@ jobs:
         echo "Traversing pytest directories newer than 2 hours old: ${recent_pytest_dirs[@]}"
         for dir in "$recent_pytest_dirs"; do
           if [[ ! -d "$dir" ]]; then
-            echo "$dir" is not a directory. Continuing..."
+            echo "$dir is not a directory. Continuing..."
             continue
           fi
-          if [[ "$(basename $dir)" != "pytest-current" ]]; then
+          if [[ "$(basename $dir)" == "pytest-current" ]]; then
             echo "Skipping pytest-current..."
             continue
           fi
@@ -170,7 +170,6 @@ jobs:
 
           rsync -a --no-links --prune-empty-dirs \
             --chmod=D755,F644 \
-            --exclude='pytest-current/' \
             "$dir"/ "$PERSISTENT_LOG_DIR/$(basename "$dir")"/
         done
 

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -149,8 +149,16 @@ jobs:
         total_log_dir_size=0
 
         recent_pytest_dirs=$(find /tmp/pytest-of-dunedaq/ -mindepth 1 -maxdepth 1 -mmin -120)
+        echo "Traversing pytest directories newer than 2 hours old: ${recent_pytest_dirs[@]}"
         for dir in "$recent_pytest_dirs"; do
-          [[ -d "$dir" && "$dir" != "pytest-current" ]] || continue
+          if [[ ! -d "$dir" ]]; then
+            echo "$dir" is not a directory. Continuing..."
+            continue
+          fi
+          if [[ "$(basename $dir)" != "pytest-current" ]]; then
+            echo "Skipping pytest-current..."
+            continue
+          fi
           dir_size_kb=$(du -sk $dir | awk '{print $1}')
           echo "Size of $dir: $(du -sh $dir | awk '{print $1}')"
 

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -148,9 +148,9 @@ jobs:
         max_kb=10000000
         total_log_dir_size=0
 
-        recent_pytest_dirs=$(find /tmp/pytest-of-dunedaq/ -mindepth 1 -maxdepth 1 -mmin -120)
+        mapfile -t recent_pytest_dirs < <(find /tmp/pytest-of-dunedaq/ -mindepth 1 -maxdepth 1 -mmin -120 -type d)
         echo "Traversing pytest directories newer than 2 hours old: ${recent_pytest_dirs[@]}"
-        for dir in "$recent_pytest_dirs"; do
+        for dir in "${recent_pytest_dirs[@]}"; do
           echo "Contents of $dir:"
           ls "$dir"
           if [[ ! -d "$dir" ]]; then

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -151,6 +151,8 @@ jobs:
         recent_pytest_dirs=$(find /tmp/pytest-of-dunedaq/ -mindepth 1 -maxdepth 1 -mmin -120)
         echo "Traversing pytest directories newer than 2 hours old: ${recent_pytest_dirs[@]}"
         for dir in "$recent_pytest_dirs"; do
+          echo "Contents of $dir:"
+          ls "$dir"
           if [[ ! -d "$dir" ]]; then
             echo "$dir is not a directory. Continuing..."
             continue
@@ -168,7 +170,7 @@ jobs:
             exit 2
           fi
 
-          rsync -a --no-links --prune-empty-dirs \
+          rsync -av --no-links --prune-empty-dirs \
             --chmod=D755,F644 \
             "$dir"/ "$PERSISTENT_LOG_DIR/$(basename "$dir")"/
         done

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -148,8 +148,9 @@ jobs:
         max_kb=10000000
         total_log_dir_size=0
 
-        for dir in /tmp/pytest-of-dunedaq/pytest-*; do
-          [[ -d "$dir" ]] || continue
+        recent_pytest_dirs=$(find /tmp/pytest-of-dunedaq/ -mindepth 1 -maxdepth 1 -mmin -120)
+        for dir in "$recent_pytest_dirs"; do
+          [[ -d "$dir" && "$dir" != "pytest-current" ]] || continue
           dir_size_kb=$(du -sk $dir | awk '{print $1}')
           echo "Size of $dir: $(du -sh $dir | awk '{print $1}')"
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -142,6 +142,27 @@ jobs:
         pytest --tb=short --junit-xml=${TEST_SOURCE}_${{ matrix.test_name }}_results.xml \
                 $TEST_PATH/${{ matrix.test_name }}.py || { pytest_retval=$?; true; }
 
+    - name: Copy log to persistent area
+      env:
+        PERSISTENT_LOG_DIR: ${{needs.make_variables.outputs.persistent_log_dir}}
+      run: |
+        max_kb=10000000
+        total_log_dir_size=0
+        pytest_current_dir=/tmp/pytest-of-dunedaq/pytest-current/
+
+        [[ -d "$pytest_current_dir" ]] || { echo "No pytest directory found for ${{ matrix.test_name }}; exit 1" }
+        dir_size_kb=$(du -sk $pytest_current_dir | awk '{print $1}')
+        echo "Size of $pytest_current_dir: $(du -sh $pytest_current_dir | awk '{print $1}')"
+
+        if (( dir_size_kb > max_kb )); then
+          echo "ERROR: ${{ matrix.test_name }} log directory $pytest_current_dir of size $dir_size_kb would make $PERSISTENT_LOG_DIR exceed $max_kb. Exiting..." >&2
+          exit 2
+        fi
+
+        rsync -a --no-links --prune-empty-dirs \
+          --chmod=D755,F644 \
+          "$pytest_current_dir"/ "$PERSISTENT_LOG_DIR/${{ matrix.test_name }}"/
+
         mkdir -p $PERSISTENT_LOG_DIR
         cp -rL $(readlink -f /tmp/pytest-of-dunedaq/pytest-current/) $PERSISTENT_LOG_DIR/${{ matrix.test_name }}
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -159,6 +159,7 @@ jobs:
           exit 2
         fi
 
+        mkdir -p $PERSISTENT_LOG_DIR/${{ matrix.test_name }}
         rsync -a --no-links --prune-empty-dirs \
           --chmod=D755,F644 \
           "$pytest_current_dir"/ "$PERSISTENT_LOG_DIR/${{ matrix.test_name }}"/

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -141,6 +141,7 @@ jobs:
         pytest_retval=0
         pytest --tb=short --junit-xml=${TEST_SOURCE}_${{ matrix.test_name }}_results.xml \
                 $TEST_PATH/${{ matrix.test_name }}.py || { pytest_retval=$?; true; }
+        test $pytest_retval == 0 || false
 
     - name: Copy log to persistent area
       env:
@@ -163,8 +164,6 @@ jobs:
         rsync -a --no-links --prune-empty-dirs \
           --chmod=D755,F644 \
           "$pytest_current_dir"/ "$PERSISTENT_LOG_DIR/${{ matrix.test_name }}"/
-
-        test $pytest_retval == 0 || false
 
   parse_and_upload_results:
     runs-on: daq

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -150,7 +150,7 @@ jobs:
         total_log_dir_size=0
         pytest_current_dir=/tmp/pytest-of-dunedaq/pytest-current/
 
-        [[ -d "$pytest_current_dir" ]] || { echo "No pytest directory found for ${{ matrix.test_name }}"; exit 1 }
+        [[ -d "$pytest_current_dir" ]] || { echo "No pytest directory found for ${{ matrix.test_name }}"; exit 1; }
         dir_size_kb=$(du -sk $pytest_current_dir | awk '{print $1}')
         echo "Size of $pytest_current_dir: $(du -sh $pytest_current_dir | awk '{print $1}')"
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -83,16 +83,16 @@ jobs:
 
             test_name: [
                         "listrev_test",
-                        "3ru_1df_multirun_test",
-                        "3ru_3df_multirun_test",
-                        "example_system_test",
-                        "fake_data_producer_test",
-                        "long_window_readout_test",
+                        #"3ru_1df_multirun_test",
+                        #"3ru_3df_multirun_test",
+                        #"example_system_test",
+                        #"fake_data_producer_test",
+                        #"long_window_readout_test",
                         "minimal_system_quick_test",
-                        "readout_type_scan_test",
-                        "small_footprint_quick_test",
-                        "tpreplay_test",
-                        "tpstream_writing_test"
+                        #"readout_type_scan_test",
+                        #"small_footprint_quick_test",
+                        #"tpreplay_test",
+                        #"tpstream_writing_test"
                        ]
     defaults:
       run:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -150,7 +150,7 @@ jobs:
         total_log_dir_size=0
         pytest_current_dir=/tmp/pytest-of-dunedaq/pytest-current/
 
-        [[ -d "$pytest_current_dir" ]] || { echo "No pytest directory found for ${{ matrix.test_name }}; exit 1" }
+        [[ -d "$pytest_current_dir" ]] || { echo "No pytest directory found for ${{ matrix.test_name }}"; exit 1 }
         dir_size_kb=$(du -sk $pytest_current_dir | awk '{print $1}')
         echo "Size of $pytest_current_dir: $(du -sh $pytest_current_dir | awk '{print $1}')"
 
@@ -162,16 +162,6 @@ jobs:
         rsync -a --no-links --prune-empty-dirs \
           --chmod=D755,F644 \
           "$pytest_current_dir"/ "$PERSISTENT_LOG_DIR/${{ matrix.test_name }}"/
-
-        mkdir -p $PERSISTENT_LOG_DIR
-        cp -rL $(readlink -f /tmp/pytest-of-dunedaq/pytest-current/) $PERSISTENT_LOG_DIR/${{ matrix.test_name }}
-
-        chmod -R 755 $PERSISTENT_LOG_DIR
-        if [[ $(du -sk $PERSISTENT_LOG_DIR | awk '{print $1}') -gt 10000000 ]]; then
-          echo "The log directory $PERSISTENT_LOG_DIR has exceeded 10 GB. Deleting and exiting..."
-          rm -rf $PERSISTENT_LOG_DIR
-          exit 2
-        fi
 
         test $pytest_retval == 0 || false
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -213,18 +213,10 @@ jobs:
     if: success() || failure()
     steps:
     - name: Upload logs as artifact
-      env:
-        TIMESTAMP: ${{needs.make_variables.outputs.timestamp}}
-        PERSISTENT_LOG_DIR: ${{needs.make_variables.outputs.persistent_log_dir}}
       uses: actions/upload-artifact@v7
       with:
-        name: pytest-logs-${{ env.TIMESTAMP }}
-        path: ${{ env.PERSISTENT_LOG_DIR }}
-    - name: Delete old log directories
-      run: |
-        old_dirs=$(find /home/nfs/dunedaq/github-actions -mindepth 1 -maxdepth 1 -type d -mtime +7)
-        echo "Removing the following directories that are more than 7 days old: $old_dirs"
-        rm -rf $old_dirs
+        name: pytest-logs-${{ needs.make_variables.outputs.timestamp }}
+        path: ${{ needs.make_variables.outputs.persistent_log_dir }}
 
   send_slack_message:
     if: (success() || failure()) && ((github.event_name != 'workflow_dispatch') || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes'))
@@ -242,15 +234,14 @@ jobs:
     if: always()
     needs: [make_variables, parse_and_upload_results, send_slack_message]
     steps:
-      - name: Remove xml files
-        env:
-          RELEASE_TAG: ${{needs.make_variables.outputs.tag}}
+      - name: Remove xml files and daq-release
         run: |
-          rm -rf ${{ needs.make_variables.outputs.integtest_output_path }}
-          #echo "NOT removing ${{ needs.make_variables.outputs.integtest_output_path }} for now"
-      - name: Remove daq-release
+          rm -rf ${{ needs.make_variables.outputs.integtest_output_path }} ${{ github.workspace }}/daq-release-integtest/
+      - name: Delete old log directories
         run: |
-          rm -rf ${{ github.workspace }}/daq-release-integtest/
+          old_dirs=$(find /home/nfs/dunedaq/github-actions -mindepth 1 -maxdepth 1 -type d -mtime +7)
+          echo "Removing the following directories that are more than 7 days old: $old_dirs"
+          rm -rf $old_dirs
 
   # Integration tests can sometimes collide with stale processes, leading to timeout
   cleanup_stale_gunicorn_processes:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -83,16 +83,16 @@ jobs:
 
             test_name: [
                         "listrev_test",
-                        #"3ru_1df_multirun_test",
-                        #"3ru_3df_multirun_test",
-                        #"example_system_test",
-                        #"fake_data_producer_test",
-                        #"long_window_readout_test",
+                        "3ru_1df_multirun_test",
+                        "3ru_3df_multirun_test",
+                        "example_system_test",
+                        "fake_data_producer_test",
+                        "long_window_readout_test",
                         "minimal_system_quick_test",
-                        #"readout_type_scan_test",
-                        #"small_footprint_quick_test",
-                        #"tpreplay_test",
-                        #"tpstream_writing_test"
+                        "readout_type_scan_test",
+                        "small_footprint_quick_test",
+                        "tpreplay_test",
+                        "tpstream_writing_test"
                        ]
     defaults:
       run:


### PR DESCRIPTION
Over this past weekend, we had several days in a row where the extended integration tests failed due to the log files exceeding a 10 GB threshold. See [here](https://github.com/DUNE-DAQ/daq-release/actions/runs/23733360123/job/69136062962) for an example. Unfortunately, I've been unable to reproduce the issue, so I'm not sure what caused this. This PR improves the logging of directory sizes while copying the extended test logs. The step which copies the log files will now check the size of each directory and keep a running total which will make it easier to pinpoint which directory or directories are to blame in the future. If the log sizes exceed the 10 GB threshold, the workflow will fail as usual.

While I was at it, I found that `rsync` has built-in functionality for copying files with the correct permissions and ignoring symlinks, which slightly simplifies the copy logic.

Finally, some minor cleanup items: (re)named steps to better reflect what they do, (re)moved some redundant environment variables, and moved all file cleanup to the `cleanup_files` job.