### PR TITLE
Send Slack message on timeout/cancellation of extended integration tests

### DIFF
--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -78,7 +78,7 @@ jobs:
   extended_integration_tests:
     name: extended_integration_tests
     runs-on: daq
-    timeout-minutes: 90
+    timeout-minutes: 1
     needs: make_variables
     outputs:
       integtest_log_dir: ${{ steps.integtests.outputs.integtest_log_dir }}

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -243,7 +243,8 @@ jobs:
       integtest_log_dir: ${{ needs.make_variables.outputs.persistent_log_dir }}
       artifact_name: nightly_extended_integtest_json
     secrets: 
-      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+      #slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+      slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
 
   cleanup_files:
     runs-on: daq

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -244,7 +244,8 @@ jobs:
       integtest_log_dir: ${{ needs.make_variables.outputs.persistent_log_dir }}
       artifact_name: nightly_extended_integtest_json
     secrets: 
-      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+      #slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+      slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
 
   cleanup_files:
     runs-on: daq

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -213,7 +213,7 @@ jobs:
     - name: Upload markdown summary as artifact
       uses: actions/upload-artifact@v7
       with:
-        if-no-files-found: error
+        if-no-files-found: warn
         name: nightly_extended_integtest_summary
         path: ${{ needs.make_variables.outputs.daq_release_path }}/scripts/github-ci/pytest_summary_table.md
     - name: Upload json summary as artifact

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -145,6 +145,9 @@ jobs:
         logs_exist="false"
         integtest_log_dir=$(readlink -f $DBT_AREA_ROOT/log/integtest_tests_* | tail -n 1)
 
+        echo "integtest_log_dir: $integtest_log_dir"
+        echo "integtest_log_dir=${integtest_log_dir}" >> "$GITHUB_OUTPUT"
+
         if [[ ! -d $integtest_log_dir ]]; then
           echo "ERROR: No integtest log directory found under $DBT_AREA_ROOT/log."
           exit 2
@@ -154,14 +157,11 @@ jobs:
           exit 3
         fi
 
-        echo "integtest_log_dir: $integtest_log_dir"
-        echo "integtest_log_dir=${integtest_log_dir}" >> "$GITHUB_OUTPUT"
-
         logs_exist="true"
         echo "logs_exist=${logs_exist}"
         echo "logs_exist=${logs_exist}" >> "$GITHUB_OUTPUT"
     - name: Store log files
-      if: ${{ steps.integtest_logs.conclusion == 'success' }}
+      if: ${{ steps.integtest_logs.outputs.logs_exist == 'true' }}
       id: move_logs
       run: |
         mkdir -p "$PERSISTENT_LOG_DIR"

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -236,7 +236,7 @@ jobs:
 
   send_slack_message:
     if: (success() || failure()) && ((github.event_name != 'workflow_dispatch') || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes'))
-    needs: [make_variables, extended_integration_tests, upload_logs]
+    needs: [make_variables, extended_integration_tests]
     uses: ./.github/workflows/slack-notification.yml
     with:
       release_tag: ${{ needs.make_variables.outputs.tag }}

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -235,7 +235,7 @@ jobs:
         path: ${{ needs.make_variables.outputs.persistent_log_dir  }}
 
   send_slack_message:
-    if: (success() || failure()) && ((github.event_name != 'workflow_dispatch') || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes'))
+    if: (always()) && ((github.event_name != 'workflow_dispatch') || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes'))
     needs: [make_variables, extended_integration_tests]
     uses: ./.github/workflows/slack-notification.yml
     with:

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -243,9 +243,8 @@ jobs:
       release_tag: ${{ needs.make_variables.outputs.tag }}
       integtest_log_dir: ${{ needs.make_variables.outputs.persistent_log_dir }}
       artifact_name: nightly_extended_integtest_json
-    secrets: 
-      #slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-      slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
+    secrets:
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   cleanup_files:
     runs-on: daq

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -78,7 +78,7 @@ jobs:
   extended_integration_tests:
     name: extended_integration_tests
     runs-on: daq
-    timeout-minutes: 1
+    timeout-minutes: 90
     needs: make_variables
     outputs:
       integtest_log_dir: ${{ steps.integtests.outputs.integtest_log_dir }}
@@ -244,8 +244,7 @@ jobs:
       integtest_log_dir: ${{ needs.make_variables.outputs.persistent_log_dir }}
       artifact_name: nightly_extended_integtest_json
     secrets: 
-      #slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-      slack_webhook_url: ${{ secrets.SLACK_TEST_WEBHOOK }}
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   cleanup_files:
     runs-on: daq

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -81,7 +81,7 @@ jobs:
     timeout-minutes: 90
     needs: make_variables
     outputs:
-      integtest_log_dir: ${{ steps.integtests.outputs.integtest_log_dir }}
+      integtest_log_dir: ${{ steps.integtest_logs.outputs.integtest_log_dir }}
       logs_exist: ${{ steps.integtests.outputs.logs_exist }}
     env:
       DBT_AREA_ROOT: ${{ needs.make_variables.outputs.tag }}

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -137,7 +137,6 @@ jobs:
         dbt-workarea-env
         dbt-build --integtest | tee integtest_full_output.log
 
-<<<<<<< HEAD
     - name: Check and set integration test log directory
       if: always()
       id: integtest_logs
@@ -161,11 +160,8 @@ jobs:
         logs_exist="true"
         echo "logs_exist=${logs_exist}"
         echo "logs_exist=${logs_exist}" >> "$GITHUB_OUTPUT"
-    - name:
-      if: ${{ steps.integtest_logs.conclusion == 'success' }}
-=======
     - name: Store log files
->>>>>>> 41fb5feb6035c11ae633e3f132f941ae0ae0cc97
+      if: ${{ steps.integtest_logs.conclusion == 'success' }}
       id: move_logs
       run: |
         mkdir -p "$PERSISTENT_LOG_DIR"
@@ -231,16 +227,7 @@ jobs:
       uses: actions/upload-artifact@v7
       with:
         name: pytest-logs-extended-${{ needs.make_variables.outputs.timestamp }}
-<<<<<<< HEAD
-        path: ${{ needs.make_variables.outputs.persistent_log_dir }}
-    - name: Delete old log directories
-      run: |
-        old_dirs=$(find /home/nfs/dunedaq/github-actions -mindepth 1 -maxdepth 1 -type d -mtime +7)
-        echo "Removing the following directories that are more than 7 days old: $old_dirs"
-        rm -rf $old_dirs
-=======
         path: ${{ needs.make_variables.outputs.persistent_log_dir  }}
->>>>>>> 41fb5feb6035c11ae633e3f132f941ae0ae0cc97
 
   send_slack_message:
     if: (success() || failure()) && ((github.event_name != 'workflow_dispatch') || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes'))

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -145,7 +145,7 @@ jobs:
         logs_exist="false"
         integtest_log_dir=$(readlink -f $DBT_AREA_ROOT/log/integtest_tests_* | tail -n 1)
 
-        if [[ ! -d $integtest_log_dir ]]; then 
+        if [[ ! -d $integtest_log_dir ]]; then
           echo "ERROR: No integtest log directory found under $DBT_AREA_ROOT/log."
           exit 2
         fi

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -82,6 +82,7 @@ jobs:
     needs: make_variables
     outputs:
       integtest_log_dir: ${{ steps.integtests.outputs.integtest_log_dir }}
+      logs_exist: ${{ steps.integtests.outputs.logs_exist }}
     env:
       DBT_AREA_ROOT: ${{ needs.make_variables.outputs.tag }}
       RELEASE_TAG: ${{ needs.make_variables.outputs.tag }}
@@ -135,12 +136,32 @@ jobs:
         source env.sh
         dbt-workarea-env
         dbt-build --integtest | tee integtest_full_output.log
-        # Log directory is the last non-empty line of output
-        integtest_log_dir=$(readlink -f $DBT_AREA_ROOT/log/integtest_tests_* | tail -n 1)
-        echo "integtest_log_dir=${integtest_log_dir}" >> "$GITHUB_OUTPUT"
-        echo "integtest_log_dir: $integtest_log_dir"
 
+    - name: Check and set integration test log directory
+      if: always()
+      id: integtest_logs
+      run: |
+        # Log directory is the last non-empty line of output
+        logs_exist="false"
+        integtest_log_dir=$(readlink -f $DBT_AREA_ROOT/log/integtest_tests_* | tail -n 1)
+
+        if [[ ! -d $integtest_log_dir ]]; then 
+          echo "ERROR: No integtest log directory found under $DBT_AREA_ROOT/log."
+          exit 2
+        fi
+        if [[ -z $(ls -A $integtest_log_dir) ]]; then
+          echo "ERROR: The log directory $integtest_log_dir is empty."
+          exit 3
+        fi
+
+        echo "integtest_log_dir: $integtest_log_dir"
+        echo "integtest_log_dir=${integtest_log_dir}" >> "$GITHUB_OUTPUT"
+
+        logs_exist="true"
+        echo "logs_exist=${logs_exist}"
+        echo "logs_exist=${logs_exist}" >> "$GITHUB_OUTPUT"
     - name:
+      if: ${{ steps.integtest_logs.conclusion == 'success' }}
       id: move_logs
       run: |
         mkdir -p $PERSISTENT_LOG_DIR
@@ -158,13 +179,18 @@ jobs:
     if: always()
     needs: [make_variables, extended_integration_tests]
     steps:
-    - name: Generate summary tables
+    - name: Generate summary files
       env:
         RELEASE_TAG: ${{ needs.make_variables.outputs.tag }}
         DAQ_RELEASE_PATH: ${{ needs.make_variables.outputs.daq_release_path }}
       run: |
+        args=()
+        if [[ -n "${{ needs.extended_integration_tests.outputs.integtest_log_dir }}" ]]; then
+          args+=(--input-directory "${{ needs.extended_integration_tests.outputs.integtest_log_dir }}")
+        fi
+
         cd $DAQ_RELEASE_PATH/scripts/github-ci/
-        python integtest_xml_parser.py --input-directory ${{ needs.extended_integration_tests.outputs.integtest_log_dir }}
+        python integtest_xml_parser.py "${args[@]}"
         cat pytest_summary_table.md >> $GITHUB_STEP_SUMMARY
     - name: Upload markdown summary as artifact
       uses: actions/upload-artifact@v7
@@ -186,13 +212,10 @@ jobs:
     if: success() || failure()
     steps:
     - name: Upload logs as artifact
-      env:
-        TIMESTAMP: ${{needs.make_variables.outputs.timestamp}}
-        PERSISTENT_LOG_DIR: ${{needs.make_variables.outputs.persistent_log_dir}}
       uses: actions/upload-artifact@v7
       with:
-        name: pytest-logs-extended-${{ env.TIMESTAMP }}
-        path: ${{ env.PERSISTENT_LOG_DIR }}
+        name: pytest-logs-extended-${{ needs.make_variables.outputs.timestamp }}
+        path: ${{ needs.make_variables.outputs.persistent_log_dir }}
     - name: Delete old log directories
       run: |
         old_dirs=$(find /home/nfs/dunedaq/github-actions -mindepth 1 -maxdepth 1 -type d -mtime +7)

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -200,6 +200,7 @@ jobs:
     needs: [make_variables, extended_integration_tests]
     steps:
     - name: Generate summary tables
+      continue-on-error: true
       run: |
         args=()
         if [[ -n "${{ needs.extended_integration_tests.outputs.integtest_log_dir }}" ]]; then
@@ -236,7 +237,7 @@ jobs:
 
   send_slack_message:
     if: (always()) && ((github.event_name != 'workflow_dispatch') || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes'))
-    needs: [make_variables, extended_integration_tests]
+    needs: [make_variables, extended_integration_tests, parse_and_upload_results]
     uses: ./.github/workflows/slack-notification.yml
     with:
       release_tag: ${{ needs.make_variables.outputs.tag }}

--- a/scripts/github-ci/integration_test_summary.py
+++ b/scripts/github-ci/integration_test_summary.py
@@ -116,7 +116,8 @@ class IntegrationTestSummary:
             self.totals['errors'] == 0
         ):
             return (
-            f"{self.which_emoji('no_tests')} No tests were run across {self.totals['num_modules']} modules. "
+            f"{self.which_emoji('no_tests')} No test results were collected "
+            f"from {self.totals['num_modules']} modules. "
             f"This may indicate that the tests were cancelled or timed out.\n"
             )
 

--- a/scripts/github-ci/integration_test_summary.py
+++ b/scripts/github-ci/integration_test_summary.py
@@ -116,8 +116,7 @@ class IntegrationTestSummary:
             self.totals['errors'] == 0
         ):
             return (
-            f"{self.which_emoji('no_tests')} No test results were collected "
-            f"from {self.totals['num_modules']} modules. "
+            f"{self.which_emoji('no_tests')} No test results were collected. "
             f"This may indicate that the tests were cancelled or timed out.\n"
             )
 

--- a/scripts/github-ci/integration_test_summary.py
+++ b/scripts/github-ci/integration_test_summary.py
@@ -72,6 +72,7 @@ class IntegrationTestSummary:
         'skipped': ':fast_forward:',
         'error': ':warning:',
         'all_passed': ':tada:',
+        'no_tests': ':no_entry_sign:',
     }
 
     def __len__(self):
@@ -107,6 +108,16 @@ class IntegrationTestSummary:
             return (
             f"All {self.totals['num_tests']} tests from {self.totals['num_modules']} "
             f"modules passed {self.which_emoji('all_passed')}\n"
+            )
+
+        if (self.totals['passed'] == 0 and
+            self.totals['failed'] == 0 and
+            self.totals['skipped'] == 0 and
+            self.totals['errors'] == 0
+        ):
+            return (
+            f"{self.which_emoji('no_tests')} No tests were run across {self.totals['num_modules']} modules. "
+            f"This may indicate that the tests were cancelled or timed out.\n"
             )
 
         return dedent(f"""\

--- a/scripts/github-ci/integtest_xml_parser.py
+++ b/scripts/github-ci/integtest_xml_parser.py
@@ -5,24 +5,40 @@ import argparse
 import html
 import xml.etree.ElementTree as ET
 from pathlib import Path
+from typing import Optional
 from integration_test_summary import IntegrationTestSummary, PytestResult, TestCaseResult
 
 class JUnitXMLParser:
-    def __init__(self, input_directory: str='', input_file: str=''):
-        self.input_directory = Path(input_directory) if Path(input_directory).is_dir() else None
-        self.input_file = Path(input_file) if Path(input_file).is_file() else None
+    def __init__(self, input_directory: Optional[str]=None, input_file: Optional[str]=None):
+        self.input_directory: Optional[Path] = None
+        self.input_file: Optional[Path] = None
         self.summary = IntegrationTestSummary()
 
-        if not self.input_directory and not self.input_file:
-            raise FileNotFoundError("No valid input file or directory specified.")
+        if input_directory:
+            self.input_directory = Path(input_directory)
+            if not self.input_directory.is_dir():
+                raise FileNotFoundError(f"Input directory {input_directory} doesn't exist or isn't a directory.")
+
+        if input_file:
+            self.input_file = Path(input_file)
+            if not self.input_file.is_file():
+                raise FileNotFoundError(f"Input file {input_file} doesn't exist or isn't a file.")
+
+        if self.input_file and self.input_directory:
+            raise ValueError("Specify one of --input-directory or --input-file, not both.")
+
+        if not input_file and not input_directory:
+            # Before throwing, write empty test results so that downstream workflows don't fail
+            self.summary.to_json()
+            raise ValueError("No valid input file or directory specified.")
 
     def get_xml_files(self, pattern="*.xml"):
-        xml_files = self.input_directory.rglob(pattern)
+        xml_files = list(self.input_directory.rglob(pattern))
         if not xml_files:
             raise FileNotFoundError(f"Error: No xml files found in {self.input_directory}.")
         return xml_files
 
-    # Junit xml file names should be structured as <package_name>_<pytest_name>_results.xml
+    # JUnit xml file names should be structured as <package_name>_<pytest_name>_results.xml
     def get_package_name(self, file) -> str:
         return file.stem.split('_')[0]
 
@@ -65,7 +81,7 @@ class JUnitXMLParser:
         self.summary.pytest_results.append(pytest_result)
 
 def main():
-    parser = argparse.ArgumentParser(description="Parse a JUnit XML file and extract test case results.")
+    parser = argparse.ArgumentParser(description="Parse JUnit XML file(s) and extract test case results.")
     parser.add_argument("--input-directory", "-d", type=str, default='',
                         help="Path to the directory containing junit xml files.")
     parser.add_argument("--input-file", "-i", type=str, default='',
@@ -73,17 +89,18 @@ def main():
 
     args = parser.parse_args()
 
-    if len(sys.argv) == 1:
-        parser.print_usage()
-        exit(1)
-
     integtest_parser = JUnitXMLParser(
         input_directory=args.input_directory,
         input_file=args.input_file,
     )
 
     if integtest_parser.input_directory:
-        xml_files = integtest_parser.get_xml_files()
+        try:
+            xml_files = integtest_parser.get_xml_files()
+        except FileNotFoundError:
+            print(f'WARNING: No JUnit XML files found in {integtest_parser.input_directory}; '
+                  f'test results will be empty.')
+            xml_files = []
         for file in xml_files:
             integtest_parser.parse_xml_file(file)
 

--- a/scripts/github-ci/slack_message_builder.py
+++ b/scripts/github-ci/slack_message_builder.py
@@ -196,7 +196,7 @@ class IntegrationTestMessageStrategy(BaseMessageStrategy):
 
     def _get_pytest_log_text(self):
         pytest_log_dir = self.summary.get("pytest_log_dir", None)
-        if pytest_log_dir:
+        if self.status != "cancelled":
             return (
                 f"The pytest logs for these tests will be stored for 7 days at:\n"
                 f"```daq.fnal.gov:{pytest_log_dir}```\n"

--- a/scripts/github-ci/slack_message_builder.py
+++ b/scripts/github-ci/slack_message_builder.py
@@ -196,20 +196,20 @@ class IntegrationTestMessageStrategy(BaseMessageStrategy):
 
     def _get_pytest_log_text(self):
         pytest_log_dir = self.summary.get("pytest_log_dir", None)
-        if self.status != "cancelled":
-            return (
-                f"The pytest logs for these tests will be stored for 7 days at:\n"
-                f"```daq.fnal.gov:{pytest_log_dir}```\n"
-                f"You can also download logs from the *Full report* link above."
-            )
+        return (
+            f"The pytest logs for these tests will be stored for 7 days at:\n"
+            f"```daq.fnal.gov:{pytest_log_dir}```\n"
+            f"You can also download logs from the *Full report* link above."
+        )
 
     def build_extra_blocks(self):
         extra_blocks = []
         summary_text = self._get_summary_text()
         extra_blocks.append(SectionBlock(summary_text))
 
-        pytest_log_text = self._get_pytest_log_text()
-        extra_blocks.append(SectionBlock(pytest_log_text))
+        if self.status != "cancelled":
+            pytest_log_text = self._get_pytest_log_text()
+            extra_blocks.append(SectionBlock(pytest_log_text))
 
         return extra_blocks
 

--- a/scripts/github-ci/slack_message_builder.py
+++ b/scripts/github-ci/slack_message_builder.py
@@ -196,11 +196,12 @@ class IntegrationTestMessageStrategy(BaseMessageStrategy):
 
     def _get_pytest_log_text(self):
         pytest_log_dir = self.summary.get("pytest_log_dir", None)
-        return (
-            f"The pytest logs for these tests will be stored for 7 days at:\n"
-            f"```daq.fnal.gov:{pytest_log_dir}```\n"
-            f"You can also download logs from the *Full report* link above."
-        )
+        if pytest_log_dir:
+            return (
+                f"The pytest logs for these tests will be stored for 7 days at:\n"
+                f"```daq.fnal.gov:{pytest_log_dir}```\n"
+                f"You can also download logs from the *Full report* link above."
+            )
 
     def build_extra_blocks(self):
         extra_blocks = []


### PR DESCRIPTION
Over the past couple weeks, we've had sporadic instances of the extended integration test workflow timing out, even after increasing the timeout from 60 to 90 minutes. See [here](https://github.com/DUNE-DAQ/daq-release/actions/runs/24068117817) for example. When this happens, no Slack message fires and the timeout isn't raised in any other way, so this is a silent failure. This PR addresses that by
- adjusting the Slack message logic to account for possible cancellation, i.e., `if: success() || failure()` -> `if: always()`
- checking if log files were written before proceeding
- handling missing or malformed inputs in `integtest_xml_parser.py`; if input is invalid, it will write an empty JSON summary for downstream use before raising `FileNotFoundError`
- adding a "no tests" summary to `integration_test_summary.py`
- adjusting `slack_message_builder.py` to only write "pytest logs will be stored at X directory for 7 days" if the workflow was not cancelled

This should make it more obvious when this workflow times out. I'm not sure of the cause of timeouts, whether it's a sporadic network issue, one particular test, or something else.

For testing, I changed `timeout-minutes` in the `extended_integration_tests` step from 90 minutes to 1. The screenshot below shows an example of the output message when this cancellation happens.

<img width="786" height="192" alt="Screenshot 2026-04-07 at 4 47 52 PM" src="https://github.com/user-attachments/assets/60c5af23-0dda-42f6-b138-beba5774d557" />


