### PR TITLE
Security Hardening

### DIFF
--- a/.github/workflows/build-candidate-release-alma9.yml
+++ b/.github/workflows/build-candidate-release-alma9.yml
@@ -1,5 +1,8 @@
 name: Alma9 build v5 candidate release
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/build-nightly-release-alma9.yml
+++ b/.github/workflows/build-nightly-release-alma9.yml
@@ -1,5 +1,8 @@
 name: Alma9 build v5 nightly release with externals v2.3
 
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: "0 3 * * *"

--- a/.github/workflows/build-nightly-release-alma9.yml
+++ b/.github/workflows/build-nightly-release-alma9.yml
@@ -48,7 +48,7 @@ jobs:
         echo "target_tag=$target_tag" >> "$GITHUB_ENV"
         echo "core_tag=$core_tag"
         echo "target_tag=$target_tag"
-    - uses: cvmfs-contrib/github-action-cvmfs@v5
+    - uses: cvmfs-contrib/github-action-cvmfs@d93d881391926e8146776c13345c3e23d6393acd
       with:
         cvmfs_repositories: 'dunedaq-development.opensciencegrid.org'
     - name: Check tag on cvmfs

--- a/.github/workflows/build-stable-release-alma9.yml
+++ b/.github/workflows/build-stable-release-alma9.yml
@@ -1,5 +1,8 @@
 name: Alma9 build v5 stable release 
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -125,7 +125,7 @@ jobs:
         cd ../$DAQ_RELEASE_PATH/scripts
         #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -p dfmodules -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -p dfmodules -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         ./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
 
@@ -264,6 +264,9 @@ jobs:
         cd scripts/github-ci/
         python scripts/github-ci/integtest_xml_parser.py --input-directory extended_integtest_log/
         cat pytest_summary_table.md >> $GITHUB_STEP_SUMMARY
+        echo "ls -lrt: $(ls -lrt)"
+        echo "Find?"
+        find . -name pytest_summary.json
     - name: Upload markdown summary as artifact
       uses: actions/upload-artifact@v7
       with:

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -1,5 +1,8 @@
 name: Extended integration test workflow
 
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: "0 6 * * *"
@@ -24,7 +27,7 @@ on:
 jobs:
   make_variables:
     name: create nightly tag, timestamp, etc.
-    runs-on: daq
+    runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.create_variables.outputs.release_tag }}
       is_candidate_release: ${{ steps.create_variables.outputs.is_candidate }}
@@ -63,7 +66,7 @@ jobs:
 
           timestamp=$(date +"%Y-%m-%d-%H%M%Z")
           persistent_log_dir=/home/nfs/dunedaq/github-actions/pytest-logs-extended-${timestamp}
-          integtest_output_path=${{ github.workspace }}/integration_tests_${release_tag}
+          integtest_output_path=/home/nfs/dunedaq/actions-runner/_work/daq-release/daq-release/integration_tests_${release_tag}
           daq_release_path="daq-release-extended-tests"
 
           echo "release_tag=${release_tag}"  >>  "$GITHUB_OUTPUT"
@@ -86,10 +89,7 @@ jobs:
     env:
       DBT_AREA_ROOT: ${{ needs.make_variables.outputs.tag }}
       RELEASE_TAG: ${{ needs.make_variables.outputs.tag }}
-      PERSISTENT_LOG_DIR: ${{ needs.make_variables.outputs.persistent_log_dir }}
       DAQ_RELEASE_PATH: ${{ needs.make_variables.outputs.daq_release_path }}
-      IS_CANDIDATE_RELEASE: ${{ needs.make_variables.outputs.is_candidate_release }}
-      IS_STABLE_RELEASE: ${{ needs.make_variables.outputs.is_stable_release }}
     defaults:
       run:
         shell: bash
@@ -101,6 +101,9 @@ jobs:
         path: ${{ needs.make_variables.outputs.daq_release_path }}
 
     - name: Create build area
+      env:
+        IS_CANDIDATE_RELEASE: ${{ needs.make_variables.outputs.is_candidate_release }}
+        IS_STABLE_RELEASE: ${{ needs.make_variables.outputs.is_stable_release }}
       run: |
         source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
         setup_dbt latest_v5
@@ -120,10 +123,10 @@ jobs:
         cd ${{ env.DBT_AREA_ROOT }}
         source env.sh
         cd ../$DAQ_RELEASE_PATH/scripts
-        ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -p dfmodules -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -p dfmodules -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
 
     - name: Run integration tests
@@ -138,7 +141,7 @@ jobs:
         dbt-build --integtest | tee integtest_full_output.log
 
     - name: Check and set integration test log directory
-      if: always()
+      if: success() || failure()
       id: integtest_logs
       run: |
         # Log directory is the last non-empty line of output
@@ -160,8 +163,15 @@ jobs:
         logs_exist="true"
         echo "logs_exist=${logs_exist}"
         echo "logs_exist=${logs_exist}" >> "$GITHUB_OUTPUT"
-    - name: Store log files
-      if: ${{ steps.integtest_logs.outputs.logs_exist == 'true' }}
+    - name: Upload integtest logs
+      uses: actions/upload-artifact@v7
+      with:
+        name: extended_integtest_logs
+        path: ${{ steps.integtest_logs.outputs.integtest_log_dir }}
+        if-no-files-found: error
+    - name: Store pytest logs
+      env:
+        PERSISTENT_LOG_DIR: ${{ needs.make_variables.outputs.persistent_log_dir }}
       id: move_logs
       run: |
         mkdir -p "$PERSISTENT_LOG_DIR"
@@ -193,47 +203,78 @@ jobs:
             --chmod=D755,F644 \
             "$dir"/ "$PERSISTENT_LOG_DIR/$(basename "$dir")"/
         done
+    - name: Upload logs as artifact
+      if: success() || failure()
+      uses: actions/upload-artifact@v7
+      with:
+        name: pytest-logs-extended-${{ needs.make_variables.outputs.timestamp }}
+        path: ${{ needs.make_variables.outputs.persistent_log_dir  }}
+    - name: Clean up files from daq.fnal.gov
+      if: always()
+      env:
+        RELEASE_TAG: ${{ needs.make_variables.outputs.tag }}
+        INTEGTEST_XML_PATH: ${{ needs.make_variables.outputs.integtest_output_path }}
+      run: |
+        rm -rf ${{ needs.make_variables.outputs.integtest_output_path }} || true
+
+        if [[ -d "$INTEGTEST_XML_PATH" ]]; then
+          echo "Removing $INTEGTEST_XML_PATH"
+          rm -rf $INTEGTEST_XML_PATH
+        fi
+
+        if [[ -d "$DAQ_RELEASE_PATH" ]]; then
+          echo "Removing $DAQ_RELEASE_PATH"
+          rm -rf $DAQ_RELEASE_PATH
+        fi
+
+        if [[ -d "$RELEASE_TAG" ]]; then
+          echo "Removing $RELEASE_TAG"
+          rm -rf $RELEASE_TAG
+        fi
+    - name: Delete old log directories
+      if: always()
+      run: |
+        old_dirs=$(find /home/nfs/dunedaq/github-actions -mindepth 1 -maxdepth 1 -type d -mtime +7)
+        if [[ -n "$old_dirs" ]]; then
+          echo "Removing the following directories that are more than 7 days old: $old_dirs"
+          rm -rf $old_dirs
+        fi
+    - name: Clean up stale gunicorn processes
+      if: always()
+      run: |
+        /home/nfs/dunedaq/kill_stale_gunicorn_processes.sh
 
   parse_and_upload_results:
-    runs-on: daq
+    runs-on: ubuntu-latest
     if: always()
     needs: [make_variables, extended_integration_tests]
     steps:
+    - uses: actions/checkout@v6
+    - uses: actions/download-artifact@v8
+      with:
+        name: extended_integtest_log
+        path: extended_integtest_log
+    - name: Sanity checks
+      run: |
+        echo "pwd: $(pwd)"
+        echo "ls -lrt: $(ls -lrt)"
     - name: Generate summary tables
       continue-on-error: true
       run: |
-        args=()
-        if [[ -n "${{ needs.extended_integration_tests.outputs.integtest_log_dir }}" ]]; then
-          args+=(--input-directory "${{ needs.extended_integration_tests.outputs.integtest_log_dir }}")
-        fi
-
-        cd ${{ needs.make_variables.outputs.daq_release_path }}/scripts/github-ci/
-        python integtest_xml_parser.py "${args[@]}"
+        cd scripts/github-ci/
+        python scripts/github-ci/integtest_xml_parser.py --input-directory extended_integtest_log/
         cat pytest_summary_table.md >> $GITHUB_STEP_SUMMARY
     - name: Upload markdown summary as artifact
       uses: actions/upload-artifact@v7
       with:
-        if-no-files-found: warn
         name: nightly_extended_integtest_summary
-        path: ${{ needs.make_variables.outputs.daq_release_path }}/scripts/github-ci/pytest_summary_table.md
+        path: pytest_summary_table.md
     - name: Upload json summary as artifact
       uses: actions/upload-artifact@v7
       with:
         if-no-files-found: error
         name: nightly_extended_integtest_json
-        path: ${{ needs.make_variables.outputs.daq_release_path }}/scripts/github-ci/pytest_summary.json
-
-  upload_logs:
-    runs-on: daq
-    timeout-minutes: 5
-    needs: [make_variables, extended_integration_tests]
-    if: success() || failure()
-    steps:
-    - name: Upload logs as artifact
-      uses: actions/upload-artifact@v7
-      with:
-        name: pytest-logs-extended-${{ needs.make_variables.outputs.timestamp }}
-        path: ${{ needs.make_variables.outputs.persistent_log_dir  }}
+        path: pytest_summary.json
 
   send_slack_message:
     if: (always()) && ((github.event_name != 'workflow_dispatch') || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes'))
@@ -245,51 +286,5 @@ jobs:
       artifact_name: nightly_extended_integtest_json
     secrets:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-  cleanup_files:
-    runs-on: daq
-    if: always()
-    needs: [make_variables, parse_and_upload_results, send_slack_message]
-    env:
-      RELEASE_TAG: ${{ needs.make_variables.outputs.tag }}
-      DAQ_RELEASE_PATH: ${{ needs.make_variables.outputs.daq_release_path }}
-      INTEGTEST_XML_PATH: ${{ needs.make_variables.outputs.integtest_output_path }}
-    steps:
-      - name: Remove xml files
-        run: |
-          rm -rf ${{ needs.make_variables.outputs.integtest_output_path }}
-      - name: Remove daq-release
-        run: |
-          if [[ -d "$INTEGTEST_XML_PATH" ]]; then
-            echo "Removing $INTEGTEST_XML_PATH"
-            rm -rf $INTEGTEST_XML_PATH
-          fi
-
-          if [[ -d "$DAQ_RELEASE_PATH" ]]; then
-            echo "Removing $DAQ_RELEASE_PATH"
-            rm -rf $DAQ_RELEASE_PATH
-          fi
-
-          if [[ -d "$RELEASE_TAG" ]]; then
-            echo "Removing $RELEASE_TAG"
-            rm -rf $RELEASE_TAG
-          fi
-      - name: Delete old log directories
-        run: |
-          old_dirs=$(find /home/nfs/dunedaq/github-actions -mindepth 1 -maxdepth 1 -type d -mtime +7)
-          if [[ -n "$old_dirs" ]]; then
-            echo "Removing the following directories that are more than 7 days old: $old_dirs"
-            rm -rf $old_dirs
-          fi
-
-  # Integration tests can sometimes collide with stale processes, leading to timeout
-  cleanup_stale_gunicorn_processes:
-    runs-on: daq
-    if: always()
-    needs: extended_integration_tests
-    steps:
-      - name: Run cleanup script
-        run: |
-          /home/nfs/dunedaq/kill_stale_gunicorn_processes.sh
 
 

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -123,10 +123,10 @@ jobs:
         cd ${{ env.DBT_AREA_ROOT }}
         source env.sh
         cd ../$DAQ_RELEASE_PATH/scripts
-        #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         #./checkout-daq-package.py -p dfmodules -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
 
     - name: Run integration tests
@@ -254,18 +254,11 @@ jobs:
       with:
         name: extended_integtest_logs
         path: extended_integtest_logs
-    - name: Sanity checks
-      run: |
-        echo "pwd: $(pwd)"
-        echo "ls -lrt: $(ls -lrt)"
     - name: Generate summary tables
       continue-on-error: true
       run: |
         python scripts/github-ci/integtest_xml_parser.py --input-directory extended_integtest_logs/
         cat pytest_summary_table.md >> $GITHUB_STEP_SUMMARY
-        echo "ls -lrt: $(ls -lrt)"
-        echo "Find?"
-        find . -name pytest_summary.json
     - name: Upload markdown summary as artifact
       uses: actions/upload-artifact@v7
       with:

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -252,8 +252,8 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/download-artifact@v8
       with:
-        name: extended_integtest_log
-        path: extended_integtest_log
+        name: extended_integtest_logs
+        path: extended_integtest_logs
     - name: Sanity checks
       run: |
         echo "pwd: $(pwd)"

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -261,7 +261,7 @@ jobs:
     - name: Generate summary tables
       continue-on-error: true
       run: |
-        python scripts/github-ci/integtest_xml_parser.py --input-directory extended_integtest_log/
+        python scripts/github-ci/integtest_xml_parser.py --input-directory extended_integtest_logs/
         cat pytest_summary_table.md >> $GITHUB_STEP_SUMMARY
         echo "ls -lrt: $(ls -lrt)"
         echo "Find?"

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -261,7 +261,6 @@ jobs:
     - name: Generate summary tables
       continue-on-error: true
       run: |
-        cd scripts/github-ci/
         python scripts/github-ci/integtest_xml_parser.py --input-directory extended_integtest_log/
         cat pytest_summary_table.md >> $GITHUB_STEP_SUMMARY
         echo "ls -lrt: $(ls -lrt)"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -183,6 +183,7 @@ jobs:
       with:
         name: junit-xml
         path: ${{ needs.make_variables.outputs.integtest_output_path }}
+        if-no-files-found: error
     - name: Cleanup files
       run: |
         rm -rf ${{ needs.make_variables.outputs.integtest_output_path }}
@@ -228,7 +229,6 @@ jobs:
         if-no-files-found: error
         name: nightly_integtest_json
         path: scripts/github-ci/pytest_summary.json
-
 
   send_slack_message:
     if: (always()) && ((github.event_name != 'workflow_dispatch') || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes'))

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -86,16 +86,16 @@ jobs:
 
             test_name: [
                         "listrev_test",
-                        "3ru_1df_multirun_test",
-                        "3ru_3df_multirun_test",
-                        "example_system_test",
-                        "fake_data_producer_test",
-                        "long_window_readout_test",
+                        #"3ru_1df_multirun_test",
+                        #"3ru_3df_multirun_test",
+                        #"example_system_test",
+                        #"fake_data_producer_test",
+                        #"long_window_readout_test",
                         "minimal_system_quick_test",
-                        "readout_type_scan_test",
-                        "small_footprint_quick_test",
-                        "tpreplay_test",
-                        "tpstream_writing_test"
+                        #"readout_type_scan_test",
+                        #"small_footprint_quick_test",
+                        #"tpreplay_test",
+                        #"tpstream_writing_test"
                        ]
     defaults:
       run:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -228,7 +228,7 @@ jobs:
 
   send_slack_message:
     if: (always()) && ((github.event_name != 'workflow_dispatch') || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes'))
-    needs: [make_variables, store_and_upload_logs]
+    needs: [make_variables, parse_and_upload_results]
     uses: ./.github/workflows/slack-notification.yml
     with:
       release_tag: ${{ needs.make_variables.outputs.tag }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,5 +1,8 @@
 name: Integration test workflow
 
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: "0 5 * * *"
@@ -24,7 +27,7 @@ on:
 jobs:
   make_variables:
     name: create nightly tag, timestamp, etc.
-    runs-on: daq
+    runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.create_variables.outputs.release_tag }}
       is_candidate_release: ${{ steps.create_variables.outputs.is_candidate }}
@@ -62,7 +65,7 @@ jobs:
 
           timestamp=$(date +"%Y-%m-%d-%H%M%Z")
           persistent_log_dir=/home/nfs/dunedaq/github-actions/pytest-logs-${timestamp}
-          integtest_output_path=${{ github.workspace }}/integration_tests_${release_tag}
+          integtest_output_path=/home/nfs/dunedaq/actions-runner/_work/daq-release/daq-release/integration_tests_${release_tag}
 
           echo "release_tag=${release_tag}"  >>  "$GITHUB_OUTPUT"
           echo "is_candidate=${is_candidate}"  >>  "$GITHUB_OUTPUT"
@@ -144,8 +147,6 @@ jobs:
         test $pytest_retval == 0 || false
 
     - name: Copy log to persistent area
-      env:
-        PERSISTENT_LOG_DIR: ${{needs.make_variables.outputs.persistent_log_dir}}
       run: |
         max_kb=10000000
         total_log_dir_size=0
@@ -165,48 +166,68 @@ jobs:
           --chmod=D755,F644 \
           "$pytest_current_dir"/ "$PERSISTENT_LOG_DIR/${{ matrix.test_name }}"/
 
-  parse_and_upload_results:
-    runs-on: daq
-    if: always()
-    needs: [make_variables, integration_tests]
-    steps:
-    - name: Checkout daq-release
-      uses: actions/checkout@v6
-      with:
-        repository: DUNE-DAQ/daq-release
-        path: daq-release-integtest
-    - name: Generate summary tables
-      env:
-        RELEASE_TAG: ${{needs.make_variables.outputs.tag}}
-      run: |
-        cd daq-release-integtest/scripts/github-ci/
-        python integtest_xml_parser.py \
-               --input-directory ${{ needs.make_variables.outputs.integtest_output_path }}
-        cat pytest_summary_table.md >> $GITHUB_STEP_SUMMARY
-    - name: Upload markdown summary as artifact
-      uses: actions/upload-artifact@v7
-      with:
-        if-no-files-found: error
-        name: nightly_integtest_summary
-        path: daq-release-integtest/scripts/github-ci/pytest_summary_table.md
-    - name: Upload json summary as artifact
-      uses: actions/upload-artifact@v7
-      with:
-        if-no-files-found: error
-        name: nightly_integtest_json
-        path: daq-release-integtest/scripts/github-ci/pytest_summary.json
-
   store_and_upload_logs:
     runs-on: daq
     timeout-minutes: 5
     needs: [make_variables, integration_tests]
     if: success() || failure()
     steps:
-    - name: Upload logs as artifact
+    - name: Upload pytest logs
       uses: actions/upload-artifact@v7
       with:
         name: pytest-logs-${{ needs.make_variables.outputs.timestamp }}
         path: ${{ needs.make_variables.outputs.persistent_log_dir }}
+    - name: Upload junit xml files
+      uses: actions/upload-artifact@v7
+      with:
+        name: junit-xml
+        path: ${{ needs.make_variables.outputs.integtest_output_path }}
+    - name: Cleanup files
+      run: |
+        rm -rf ${{ needs.make_variables.outputs.integtest_output_path }}
+    - name: Delete old log directories
+      run: |
+        old_dirs=$(find /home/nfs/dunedaq/github-actions -mindepth 1 -maxdepth 1 -type d -mtime +7)
+        echo "Removing the following directories that are more than 7 days old: $old_dirs"
+        rm -rf $old_dirs
+    # Integration tests can sometimes collide with stale processes, leading to timeout
+    - name: Kill stale gunicorn processes
+      run: |
+        /home/nfs/dunedaq/kill_stale_gunicorn_processes.sh
+
+  parse_and_upload_results:
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [make_variables, store_and_upload_logs]
+    steps:
+    - name: Checkout daq-release
+      uses: actions/checkout@v6
+    - name: Download pytest logs
+      uses: actions/download-artifact@v8
+    - name: Generate summary tables
+      run: |
+        echo "pwd:"
+        pwd
+        echo "ls -lrt:"
+        ls -lrt
+        cd scripts/github-ci/
+        echo "Now in $(pwd)"
+        python integtest_xml_parser.py \
+               --input-directory ${{ github.workspace }}/junit-xml
+        cat pytest_summary_table.md >> $GITHUB_STEP_SUMMARY
+    - name: Upload markdown summary as artifact
+      uses: actions/upload-artifact@v7
+      with:
+        if-no-files-found: error
+        name: nightly_integtest_summary
+        path: scripts/github-ci/pytest_summary_table.md
+    - name: Upload json summary as artifact
+      uses: actions/upload-artifact@v7
+      with:
+        if-no-files-found: error
+        name: nightly_integtest_json
+        path: scripts/github-ci/pytest_summary.json
+
 
   send_slack_message:
     if: (always()) && ((github.event_name != 'workflow_dispatch') || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes'))
@@ -218,29 +239,5 @@ jobs:
       artifact_name: nightly_integtest_json
     secrets: 
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-  cleanup_files:
-    runs-on: daq
-    if: always()
-    needs: [make_variables, parse_and_upload_results, send_slack_message]
-    steps:
-      - name: Remove xml files and daq-release
-        run: |
-          rm -rf ${{ needs.make_variables.outputs.integtest_output_path }} ${{ github.workspace }}/daq-release-integtest/
-      - name: Delete old log directories
-        run: |
-          old_dirs=$(find /home/nfs/dunedaq/github-actions -mindepth 1 -maxdepth 1 -type d -mtime +7)
-          echo "Removing the following directories that are more than 7 days old: $old_dirs"
-          rm -rf $old_dirs
-
-  # Integration tests can sometimes collide with stale processes, leading to timeout
-  cleanup_stale_gunicorn_processes:
-    runs-on: daq
-    if: always()
-    needs: integration_tests
-    steps:
-      - name: Run cleanup script
-        run: |
-          /home/nfs/dunedaq/kill_stale_gunicorn_processes.sh
 
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -107,7 +107,6 @@ jobs:
         RELEASE_TAG: ${{needs.make_variables.outputs.tag}}
         IS_CANDIDATE_RELEASE: ${{needs.make_variables.outputs.is_candidate_release}}
         IS_STABLE_RELEASE: ${{needs.make_variables.outputs.is_stable_release}}
-        PERSISTENT_LOG_DIR: ${{needs.make_variables.outputs.persistent_log_dir}}
         INTEGTEST_OUTPUT_PATH: ${{needs.make_variables.outputs.integtest_output_path}}
       id: setup_and_run_test
       run: |
@@ -147,6 +146,8 @@ jobs:
         test $pytest_retval == 0 || false
 
     - name: Copy log to persistent area
+      env:
+        PERSISTENT_LOG_DIR: ${{needs.make_variables.outputs.persistent_log_dir}}
       run: |
         max_kb=10000000
         total_log_dir_size=0

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -86,16 +86,16 @@ jobs:
 
             test_name: [
                         "listrev_test",
-                        #"3ru_1df_multirun_test",
-                        #"3ru_3df_multirun_test",
-                        #"example_system_test",
-                        #"fake_data_producer_test",
-                        #"long_window_readout_test",
+                        "3ru_1df_multirun_test",
+                        "3ru_3df_multirun_test",
+                        "example_system_test",
+                        "fake_data_producer_test",
+                        "long_window_readout_test",
                         "minimal_system_quick_test",
-                        #"readout_type_scan_test",
-                        #"small_footprint_quick_test",
-                        #"tpreplay_test",
-                        #"tpstream_writing_test"
+                        "readout_type_scan_test",
+                        "small_footprint_quick_test",
+                        "tpreplay_test",
+                        "tpstream_writing_test"
                        ]
     defaults:
       run:
@@ -208,12 +208,7 @@ jobs:
       uses: actions/download-artifact@v8
     - name: Generate summary tables
       run: |
-        echo "pwd:"
-        pwd
-        echo "ls -lrt:"
-        ls -lrt
         cd scripts/github-ci/
-        echo "Now in $(pwd)"
         python integtest_xml_parser.py \
                --input-directory ${{ github.workspace }}/junit-xml
         cat pytest_summary_table.md >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/nightly-ci-dashboard.yml
+++ b/.github/workflows/nightly-ci-dashboard.yml
@@ -1,6 +1,7 @@
 name: Nightly CI Dashboard Publication
 
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/nightly-ci-dashboard.yml
+++ b/.github/workflows/nightly-ci-dashboard.yml
@@ -1,5 +1,7 @@
 name: Nightly CI Dashboard Publication
 
+permissions: read-all
+
 on:
   workflow_dispatch:
     inputs:
@@ -10,20 +12,16 @@ on:
     - cron: "0 10 * * *"
 
 jobs:
-  download_artifacts:
-    name: Download artifacts
-    runs-on: daq
-    outputs:
-      lcov_html_report_path: ${{ steps.set_paths.outputs.lcov_html_report_path }}
-      code_check_summary_path: ${{ steps.set_paths.outputs.code_check_summary_path }}
-      integration_test_summary_path: ${{ steps.set_paths.outputs.integration_test_summary_path }}
-      extended_integration_test_summary_path: ${{ steps.set_paths.outputs.extended_integration_test_summary_path }}
+  build_site:
+    name: Build CI site and upload
+    runs-on: ubuntu-latest
     defaults:
       run: 
         shell: bash
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
+    - uses: actions/checkout@v6
     - name: Set paths to artifacts
       id: set_paths
       run : |
@@ -108,20 +106,9 @@ jobs:
         path: ${{ steps.set_paths.outputs.extended_integration_test_summary_path }}
         run-id: ${{ steps.run_ids.outputs.extended_integration_test_id }}
   
-  build_ci_dashboard:
-    runs-on: daq
-    needs: download_artifacts
-    defaults:
-      run:
-        shell: bash
-    steps:
-    - name: Checkout daq-release
-      uses: actions/checkout@v6
-      with:
-        path: daq-release-ci-dashboard
     - name: Copy artifacts and generate dashboard
       env:
-        CI_DASHBOARD_DIR: daq-release-ci-dashboard/scripts/github-ci/ci-dashboard
+        CI_DASHBOARD_DIR: scripts/github-ci/ci-dashboard
       run: |
         cp -r lcov_report ${{ env.CI_DASHBOARD_DIR }}/site/code_coverage
         cp -r code_check_summary/ ${{ env.CI_DASHBOARD_DIR }}/code_check_summary
@@ -136,10 +123,17 @@ jobs:
                                    --core_pytest_summary integration_test_summary/pytest_summary.json \
                                    --extended_pytest_summary extended_integration_test_summary/pytest_summary.json \
 
+    - name: Upload pages artifact
+      uses: actions/upload-pages-artifact@v5
+      env:
+        CI_DASHBOARD_DIR: scripts/github-ci/ci-dashboard
+      with:
+        path: ${{ env.CI_DASHBOARD_DIR }}/site
+
   deploy_to_github_pages:
     name: Deploy to GitHub Pages
-    runs-on: daq
-    needs: build_ci_dashboard
+    runs-on: ubuntu-latest
+    needs: build_site
     permissions:
         contents: read
         pages: write
@@ -150,20 +144,8 @@ jobs:
     steps:
     - name: Configure GitHub Pages
       uses: actions/configure-pages@v6
-    - name: Upload pages artifact
-      uses: actions/upload-pages-artifact@v5
-      with:
-        path: ${{ github.workspace }}/daq-release-ci-dashboard/scripts/github-ci/ci-dashboard/site
     - name: Deploy to GitHub Pages
       id: deployment
       uses: actions/deploy-pages@v5
 
-  cleanup_test_area:
-    runs-on: daq
-    if: always()
-    needs: [deploy_to_github_pages]
-    steps:
-    - name: Remove test directory
-      run: |
-        rm -rf daq-release-ci-dashboard/
 

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -111,7 +111,7 @@ jobs:
       with:
         if-no-files-found: error
         name: clang_formatting_summary
-        path: ./${{ env.IMAGE }}/clang_format_summary_table.md
+        path: ./${{ env.DBT_AREA_ROOT }}/clang_format_summary_table.md
 
   send_slack_message:
     if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -67,10 +67,10 @@ jobs:
           echo "ls -lrt: $(ls -lrt)"
           source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
           setup_dbt latest_v5
-          dbt-create -n $DBT_AREA_ROOT
+          dbt-create -n $DBT_AREA_ROOT /ghw/$DBT_AREA_ROOT
           echo "After dbt-create: $(pwd)"
           echo "ls -lrt: $(ls -lrt)"
-          cd $DBT_AREA_ROOT
+          cd /ghw/$DBT_AREA_ROOT
           source env.sh
           #cd ../daq-release-code-checks/scripts
           cd ../scripts
@@ -78,20 +78,20 @@ jobs:
           echo "ls -lrt: $(ls -lrt)"
           #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
           #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-          ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-          ./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+          ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o /ghw/${DBT_AREA_ROOT}/sourcecode
+          ./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o /ghw/${DBT_AREA_ROOT}/sourcecode
 
-          cd $DBT_AREA_ROOT
+          cd /ghw/$DBT_AREA_ROOT
           echo "DBT_AREA_ROOT is $(pwd)"
           dbt-clang-format.sh sourcecode --view-differences-only --markdown-summary
           echo "pwd: $(pwd)"
           echo "ls -lrt: $(ls -lrt)"
-          find . -name "clang_format_summary_table.md"
+          find /ghw -name "clang_format_summary_table.md"
           echo "======Exit container======="
         EOF
 
-        chmod +x run_clang_formatting.sh
-        cat run_clang_formatting.sh
+        chmod +x /ghw/run_clang_formatting.sh
+        cat /ghw/run_clang_formatting.sh
     - name: Run clang formatting script in Docker container
       run: |
         echo "Outside container, DBT_AREA_ROOT=$DBT_AREA_ROOT"

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -53,10 +53,6 @@ jobs:
     -  uses: actions/checkout@v6
     - name: Pull build image
       run: docker pull ${{ env.IMAGE }}
-    #- name: Checkout daq-release
-    #  uses: actions/checkout@v6
-    #  with:
-    #    path: daq-release-code-checks
     - name: Generate clang formatting script
       id: build_script
       run: |
@@ -109,34 +105,13 @@ jobs:
         echo "pwd: $(pwd)"
         echo "ls -lrt: $(ls -lrt)"
         find . -name "clang_format_summary_table.md"
-        cat ./scripts/NFD_DEV_260528_A9/clang_format_summary_table.md >> $GITHUB_STEP_SUMMARY
-    #- name: Create build area
-    #  run: |
-    #    source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
-    #    setup_dbt latest_v5
-    #    dbt-create -n ${{ env.DBT_AREA_ROOT }}
-    #    cd ${{ env.DBT_AREA_ROOT }}
-    #    source env.sh
-    #    #cd ../daq-release-code-checks/scripts
-    #    cd ../scripts
-    #    ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-    #    ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-    #    #./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-    #    #./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-    #    echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
-    #- name: Run clang formatting
-    #  run: |
-    #    cd ${{ env.DBT_AREA_ROOT }}
-    #    source env.sh
-    #    dbt-clang-format.sh sourcecode --view-differences-only --markdown-summary
-    #    cat clang_format_summary_table.md >> $GITHUB_STEP_SUMMARY
+        cat ./NFD_DEV_260528_A9/clang_format_summary_table.md >> $GITHUB_STEP_SUMMARY
     - name: Upload clang formatting summary
       uses: actions/upload-artifact@v7
       with:
         if-no-files-found: error
         name: clang_formatting_summary
-        #path: ${{ env.DBT_AREA_ROOT }}/clang_format_summary_table.md
-        path: ./scripts/NFD_DEV_260528_A9/clang_format_summary_table.md
+        path: ./${{ env.IMAGE }}/clang_format_summary_table.md
 
   send_slack_message:
     if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -77,6 +77,11 @@ jobs:
 
           cd $DBT_AREA_ROOT
           dbt-clang-format.sh sourcecode --view-differences-only --markdown-summary
+          echo "======In container======="
+          echo "pwd: $(pwd)"
+          echo "ls -lrt: $(ls -lrt)"
+          find . -name "clang_format_summary_table.md"
+          echo "======Exit container======="
         EOF
 
         chmod +x run_clang_formatting.sh

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -89,7 +89,7 @@ jobs:
           ${{ env.IMAGE }} \
           /ghw/run_clang_formatting.sh
 
-        cat ./NFD_DEV_260528_A9/clang_format_summary_table.md >> $GITHUB_STEP_SUMMARY
+        cat ./${{ env.DBT_AREA_ROOT }}/clang_format_summary_table.md >> $GITHUB_STEP_SUMMARY
     - name: Upload clang formatting summary
       uses: actions/upload-artifact@v7
       with:

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -27,12 +27,12 @@ jobs:
           date_tag=$(date +%y%m%d)
           echo "nightly_tag=NFD_DEV_${date_tag}_A9"  >>  "$GITHUB_OUTPUT"
   
-  #run_unittests:
-  #  needs: make_variables
-  #  uses: ./.github/workflows/unit-tests.yml
-  #  with:
-  #    release_tag: ${{ needs.make_variables.outputs.tag }}
-  #    upload_logs: 'yes'
+  run_unittests:
+    needs: make_variables
+    uses: ./.github/workflows/unit-tests.yml
+    with:
+      release_tag: ${{ needs.make_variables.outputs.tag }}
+      upload_logs: 'yes'
 
   run_clang_formatting:
     name: Run clang formatting
@@ -58,42 +58,29 @@ jobs:
       run: |
         cat << EOF > run_clang_formatting.sh
           #!/bin/bash
-          echo "======Start container======="
-          echo "Inside container, DBT_AREA_ROOT=$DBT_AREA_ROOT"
-          echo "Starting in: $(pwd)"
-          echo "ls -lrt: $(ls -lrt)"
           source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
           setup_dbt latest_v5
 
           dbt-create -n $DBT_AREA_ROOT /ghw/$DBT_AREA_ROOT
-          echo "After dbt-create: $(pwd)"
-          echo "ls -lrt: $(ls -lrt)"
           cd /ghw/$DBT_AREA_ROOT
           source env.sh
-          #cd ../daq-release-code-checks/scripts
 
-          cd ../scripts
+          cd /ghw/scripts
           echo "cd to scripts? $(pwd)"
           echo "ls -lrt: $(ls -lrt)"
-          #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-          #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-          ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o /ghw/${DBT_AREA_ROOT}/sourcecode
-          ./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o /ghw/${DBT_AREA_ROOT}/sourcecode
+          ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+          ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+          #./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o /ghw/${DBT_AREA_ROOT}/sourcecode
+          #./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o /ghw/${DBT_AREA_ROOT}/sourcecode
 
           cd /ghw/$DBT_AREA_ROOT
-          echo "DBT_AREA_ROOT is $(pwd)"
           dbt-clang-format.sh sourcecode --view-differences-only --markdown-summary
-          echo "pwd: $(pwd)"
-          echo "ls -lrt: $(ls -lrt)"
-          find /ghw -name "clang_format_summary_table.md"
-          echo "======Exit container======="
         EOF
 
         chmod +x run_clang_formatting.sh
         cat run_clang_formatting.sh
     - name: Run clang formatting script in Docker container
       run: |
-        echo "Outside container, DBT_AREA_ROOT=$DBT_AREA_ROOT"
         docker run --rm \
           -v /cvmfs:/cvmfs:shared \
           -v "${GITHUB_WORKSPACE}:/ghw" \
@@ -102,9 +89,6 @@ jobs:
           ${{ env.IMAGE }} \
           /ghw/run_clang_formatting.sh
 
-        echo "pwd: $(pwd)"
-        echo "ls -lrt: $(ls -lrt)"
-        find . -name "clang_format_summary_table.md"
         cat ./NFD_DEV_260528_A9/clang_format_summary_table.md >> $GITHUB_STEP_SUMMARY
     - name: Upload clang formatting summary
       uses: actions/upload-artifact@v7

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -77,7 +77,6 @@ jobs:
 
           cd $DBT_AREA_ROOT
           dbt-clang-format.sh sourcecode --view-differences-only --markdown-summary
-          cat clang_format_summary_table.md >> $GITHUB_STEP_SUMMARY
         EOF
 
         chmod +x run_clang_formatting.sh
@@ -85,12 +84,15 @@ jobs:
     - name: Run clang formatting script in Docker container
       run: |
         docker run --rm \
-        -v /cvmfs:/cvmfs:shared \
-        -v "${GITHUB_WORKSPACE}:/ghw" \
-        -e "$DBT_AREA_ROOT" \
-        -w /ghw \
-        ${{ env.IMAGE }} \
-        /ghw/run_clang_formatting.sh
+          -v /cvmfs:/cvmfs:shared \
+          -v "${GITHUB_WORKSPACE}:/ghw" \
+          -e "$DBT_AREA_ROOT" \
+          -w /ghw \
+          ${{ env.IMAGE }} \
+          /ghw/run_clang_formatting.sh
+        echo "pwd: $(pwd)"
+        echo "ls -lrt: $(ls -lrt)"
+        cat clang_format_summary_table.md >> $GITHUB_STEP_SUMMARY
     #- name: Create build area
     #  run: |
     #    source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -27,12 +27,12 @@ jobs:
           date_tag=$(date +%y%m%d)
           echo "nightly_tag=NFD_DEV_${date_tag}_A9"  >>  "$GITHUB_OUTPUT"
   
-  run_unittests:
-    needs: make_variables
-    uses: ./.github/workflows/unit-tests.yml
-    with:
-      release_tag: ${{ needs.make_variables.outputs.tag }}
-      upload_logs: 'yes'
+  #run_unittests:
+  #  needs: make_variables
+  #  uses: ./.github/workflows/unit-tests.yml
+  #  with:
+  #    release_tag: ${{ needs.make_variables.outputs.tag }}
+  #    upload_logs: 'yes'
 
   run_clang_formatting:
     name: Run clang formatting
@@ -62,11 +62,14 @@ jobs:
       run: |
         cat << EOF > run_clang_formatting.sh
           echo "======Start container======="
+          echo "Inside container, DBT_AREA_ROOT=$DBT_AREA_ROOT"
           echo "Starting in: $(pwd)"
           echo "ls -lrt: $(ls -lrt)"
           source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
           setup_dbt latest_v5
           dbt-create -n $DBT_AREA_ROOT
+          echo "After dbt-create: $(pwd)"
+          echo "ls -lrt: $(ls -lrt)"
           cd $DBT_AREA_ROOT
           source env.sh
           #cd ../daq-release-code-checks/scripts
@@ -91,6 +94,7 @@ jobs:
         cat run_clang_formatting.sh
     - name: Run clang formatting script in Docker container
       run: |
+        echo "Outside container, DBT_AREA_ROOT=$DBT_AREA_ROOT"
         docker run --rm \
           -v /cvmfs:/cvmfs:shared \
           -v "${GITHUB_WORKSPACE}:/ghw" \

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -34,10 +34,10 @@ jobs:
       release_tag: ${{ needs.make_variables.outputs.tag }}
       upload_logs: 'yes'
 
-  run_checks:
+  run_clang_formatting:
     name: Run clang formatting
-    runs-on: daq
-    needs: [make_variables, run_unittests]
+    runs-on: ubuntu-latest
+    needs: [make_variables]
     timeout-minutes: 60
     env:
       DBT_AREA_ROOT: ${{ needs.make_variables.outputs.tag }}
@@ -45,10 +45,14 @@ jobs:
       run:
         shell: bash
     steps:
-    - name: Checkout daq-release
-      uses: actions/checkout@v6
+    - uses: cvmfs-contrib/github-action-cvmfs@d93d881391926e8146776c13345c3e23d6393acd
       with:
-        path: daq-release-code-checks
+        cvmfs_repositories: 'dunedaq-development.opensciencegrid.org'
+    -  uses: actions/checkout@v6
+    #- name: Checkout daq-release
+    #  uses: actions/checkout@v6
+    #  with:
+    #    path: daq-release-code-checks
     - name: Create build area
       run: |
         source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
@@ -56,7 +60,8 @@ jobs:
         dbt-create -n ${{ env.DBT_AREA_ROOT }}
         cd ${{ env.DBT_AREA_ROOT }}
         source env.sh
-        cd ../daq-release-code-checks/scripts
+        #cd ../daq-release-code-checks/scripts
+        cd ../scripts
         ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         #./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
@@ -66,31 +71,20 @@ jobs:
       run: |
         cd ${{ env.DBT_AREA_ROOT }}
         source env.sh
-        cd sourcecode
-        dbt-clang-format.sh . --view-differences-only --markdown-summary
+        dbt-clang-format.sh sourcecode --view-differences-only --markdown-summary
         cat clang_format_summary_table.md >> $GITHUB_STEP_SUMMARY
     - name: Upload clang formatting summary
       uses: actions/upload-artifact@v7
       with:
         if-no-files-found: error
         name: clang_formatting_summary
-        path: ${{ env.DBT_AREA_ROOT }}/sourcecode/clang_format_summary_table.md
+        path: ${{ env.DBT_AREA_ROOT }}/clang_format_summary_table.md
 
   send_slack_message:
     if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')
-    needs: [make_variables, run_checks]
+    needs: [make_variables, run_clang_formatting]
     uses: ./.github/workflows/slack-notification.yml
     secrets: 
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
     with:
       release_tag: ${{ needs.make_variables.outputs.tag }}
-
-  cleanup_test_area:
-    runs-on: daq
-    if: always()
-    needs: [make_variables, send_slack_message]
-    steps:
-      - name: Remove test directory and daq-release
-        run: |
-          rm -rf daq-release-code-checks
-          rm -rf ${{ needs.make_variables.outputs.tag }}

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -50,7 +50,7 @@ jobs:
     - uses: cvmfs-contrib/github-action-cvmfs@d93d881391926e8146776c13345c3e23d6393acd
       with:
         cvmfs_repositories: 'dunedaq-development.opensciencegrid.org'
-    -  uses: actions/checkout@v6
+    - uses: actions/checkout@v6
     - name: Pull build image
       run: docker pull ${{ env.IMAGE }}
     - name: Generate clang formatting script
@@ -66,12 +66,8 @@ jobs:
           source env.sh
 
           cd /ghw/scripts
-          echo "cd to scripts? $(pwd)"
-          echo "ls -lrt: $(ls -lrt)"
-          ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-          ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-          #./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o /ghw/${DBT_AREA_ROOT}/sourcecode
-          #./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o /ghw/${DBT_AREA_ROOT}/sourcecode
+          ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o /ghw/${DBT_AREA_ROOT}/sourcecode
+          ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o /ghw/${DBT_AREA_ROOT}/sourcecode
 
           cd /ghw/$DBT_AREA_ROOT
           dbt-clang-format.sh sourcecode --view-differences-only --markdown-summary

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -61,18 +61,21 @@ jobs:
       id: build_script
       run: |
         cat << EOF > run_clang_formatting.sh
+          #!/bin/bash
           echo "======Start container======="
           echo "Inside container, DBT_AREA_ROOT=$DBT_AREA_ROOT"
           echo "Starting in: $(pwd)"
           echo "ls -lrt: $(ls -lrt)"
           source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
           setup_dbt latest_v5
+
           dbt-create -n $DBT_AREA_ROOT /ghw/$DBT_AREA_ROOT
           echo "After dbt-create: $(pwd)"
           echo "ls -lrt: $(ls -lrt)"
           cd /ghw/$DBT_AREA_ROOT
           source env.sh
           #cd ../daq-release-code-checks/scripts
+
           cd ../scripts
           echo "cd to scripts? $(pwd)"
           echo "ls -lrt: $(ls -lrt)"
@@ -90,8 +93,8 @@ jobs:
           echo "======Exit container======="
         EOF
 
-        chmod +x /ghw/run_clang_formatting.sh
-        cat /ghw/run_clang_formatting.sh
+        chmod +x run_clang_formatting.sh
+        cat run_clang_formatting.sh
     - name: Run clang formatting script in Docker container
       run: |
         echo "Outside container, DBT_AREA_ROOT=$DBT_AREA_ROOT"
@@ -102,6 +105,7 @@ jobs:
           -w /ghw \
           ${{ env.IMAGE }} \
           /ghw/run_clang_formatting.sh
+
         echo "pwd: $(pwd)"
         echo "ls -lrt: $(ls -lrt)"
         find . -name "clang_format_summary_table.md"

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -70,10 +70,10 @@ jobs:
           source env.sh
           #cd ../daq-release-code-checks/scripts
           cd ../scripts
-          ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-          ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-          #./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-          #./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+          #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+          #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+          ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+          ./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
 
           cd $DBT_AREA_ROOT
           dbt-clang-format.sh sourcecode --view-differences-only --markdown-summary
@@ -92,6 +92,7 @@ jobs:
           /ghw/run_clang_formatting.sh
         echo "pwd: $(pwd)"
         echo "ls -lrt: $(ls -lrt)"
+        find . -name "clang_format_summary_table.md"
         cat clang_format_summary_table.md >> $GITHUB_STEP_SUMMARY
     #- name: Create build area
     #  run: |

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -27,12 +27,12 @@ jobs:
           date_tag=$(date +%y%m%d)
           echo "nightly_tag=NFD_DEV_${date_tag}_A9"  >>  "$GITHUB_OUTPUT"
   
-  run_unittests:
-    needs: make_variables
-    uses: ./.github/workflows/unit-tests.yml
-    with:
-      release_tag: ${{ needs.make_variables.outputs.tag }}
-      upload_logs: 'yes'
+  #run_unittests:
+  #  needs: make_variables
+  #  uses: ./.github/workflows/unit-tests.yml
+  #  with:
+  #    release_tag: ${{ needs.make_variables.outputs.tag }}
+  #    upload_logs: 'yes'
 
   run_clang_formatting:
     name: Run clang formatting
@@ -41,38 +41,76 @@ jobs:
     timeout-minutes: 60
     env:
       DBT_AREA_ROOT: ${{ needs.make_variables.outputs.tag }}
+      IMAGE: ghcr.io/dune-daq/nightly-release-alma9:development_v5
     defaults:
       run:
         shell: bash
     steps:
+    - uses: actions/checkout@v6
     - uses: cvmfs-contrib/github-action-cvmfs@d93d881391926e8146776c13345c3e23d6393acd
       with:
         cvmfs_repositories: 'dunedaq-development.opensciencegrid.org'
     -  uses: actions/checkout@v6
+    - name: Pull build image
+      run: docker pull ${{ env.IMAGE }}
     #- name: Checkout daq-release
     #  uses: actions/checkout@v6
     #  with:
     #    path: daq-release-code-checks
-    - name: Create build area
+    - name: Generate clang formatting script
+      id: build_script
       run: |
-        source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
-        setup_dbt latest_v5
-        dbt-create -n ${{ env.DBT_AREA_ROOT }}
-        cd ${{ env.DBT_AREA_ROOT }}
-        source env.sh
-        #cd ../daq-release-code-checks/scripts
-        cd ../scripts
-        ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
-    - name: Run clang formatting
+        cat << EOF > run_clang_formatting.sh
+          echo "pwd: $(pwd)"
+          echo "ls -lrt: $(ls -lrt)"
+          source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
+          setup_dbt latest_v5
+          dbt-create -n $DBT_AREA_ROOT
+          cd $DBT_AREA_ROOT
+          source env.sh
+          #cd ../daq-release-code-checks/scripts
+          cd ../scripts
+          ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+          ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+          #./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+          #./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+
+          cd $DBT_AREA_ROOT
+          dbt-clang-format.sh sourcecode --view-differences-only --markdown-summary
+          cat clang_format_summary_table.md >> $GITHUB_STEP_SUMMARY
+        EOF
+
+        chmod +x run_clang_formatting.sh
+        cat run_clang_formatting.sh
+    - name: Run clang formatting script in Docker container
       run: |
-        cd ${{ env.DBT_AREA_ROOT }}
-        source env.sh
-        dbt-clang-format.sh sourcecode --view-differences-only --markdown-summary
-        cat clang_format_summary_table.md >> $GITHUB_STEP_SUMMARY
+        docker run --rm \
+        -v /cvmfs:/cvmfs:shared \
+        -v "${GITHUB_WORKSPACE}:/ghw" \
+        -e "$DBT_AREA_ROOT" \
+        -w /ghw \
+        ${{ env.IMAGE }} \
+        /ghw/run_clang_formatting.sh
+    #- name: Create build area
+    #  run: |
+    #    source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
+    #    setup_dbt latest_v5
+    #    dbt-create -n ${{ env.DBT_AREA_ROOT }}
+    #    cd ${{ env.DBT_AREA_ROOT }}
+    #    source env.sh
+    #    #cd ../daq-release-code-checks/scripts
+    #    cd ../scripts
+    #    ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+    #    ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+    #    #./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+    #    #./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+    #    echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
+    #- name: Run clang formatting
+    #  run: |
+    #    cd ${{ env.DBT_AREA_ROOT }}
+    #    source env.sh
+    #    dbt-clang-format.sh sourcecode --view-differences-only --markdown-summary
+    #    cat clang_format_summary_table.md >> $GITHUB_STEP_SUMMARY
     - name: Upload clang formatting summary
       uses: actions/upload-artifact@v7
       with:

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -1,5 +1,8 @@
 name: Nightly code check workflow
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:
@@ -32,7 +35,7 @@ jobs:
       upload_logs: 'yes'
 
   run_checks:
-    name: Run integration tests and clang formatting
+    name: Run clang formatting
     runs-on: daq
     needs: [make_variables, run_unittests]
     timeout-minutes: 60
@@ -54,7 +57,6 @@ jobs:
         cd ${{ env.DBT_AREA_ROOT }}
         source env.sh
         cd ../daq-release-code-checks/scripts
-        #cd ${{ github.workspace }}/daq-release-code-checks/scripts
         ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         #./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -61,7 +61,8 @@ jobs:
       id: build_script
       run: |
         cat << EOF > run_clang_formatting.sh
-          echo "pwd: $(pwd)"
+          echo "======Start container======="
+          echo "Starting in: $(pwd)"
           echo "ls -lrt: $(ls -lrt)"
           source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
           setup_dbt latest_v5
@@ -70,14 +71,16 @@ jobs:
           source env.sh
           #cd ../daq-release-code-checks/scripts
           cd ../scripts
+          echo "cd to scripts? $(pwd)"
+          echo "ls -lrt: $(ls -lrt)"
           #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
           #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
           ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
           ./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
 
           cd $DBT_AREA_ROOT
+          echo "DBT_AREA_ROOT is $(pwd)"
           dbt-clang-format.sh sourcecode --view-differences-only --markdown-summary
-          echo "======In container======="
           echo "pwd: $(pwd)"
           echo "ls -lrt: $(ls -lrt)"
           find . -name "clang_format_summary_table.md"
@@ -98,7 +101,7 @@ jobs:
         echo "pwd: $(pwd)"
         echo "ls -lrt: $(ls -lrt)"
         find . -name "clang_format_summary_table.md"
-        cat clang_format_summary_table.md >> $GITHUB_STEP_SUMMARY
+        cat ./scripts/NFD_DEV_260528_A9/clang_format_summary_table.md >> $GITHUB_STEP_SUMMARY
     #- name: Create build area
     #  run: |
     #    source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
@@ -124,7 +127,8 @@ jobs:
       with:
         if-no-files-found: error
         name: clang_formatting_summary
-        path: ${{ env.DBT_AREA_ROOT }}/clang_format_summary_table.md
+        #path: ${{ env.DBT_AREA_ROOT }}/clang_format_summary_table.md
+        path: ./scripts/NFD_DEV_260528_A9/clang_format_summary_table.md
 
   send_slack_message:
     if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')

--- a/.github/workflows/nightly-code-check.yml
+++ b/.github/workflows/nightly-code-check.yml
@@ -27,17 +27,17 @@ jobs:
           date_tag=$(date +%y%m%d)
           echo "nightly_tag=NFD_DEV_${date_tag}_A9"  >>  "$GITHUB_OUTPUT"
   
-  #run_unittests:
-  #  needs: make_variables
-  #  uses: ./.github/workflows/unit-tests.yml
-  #  with:
-  #    release_tag: ${{ needs.make_variables.outputs.tag }}
-  #    upload_logs: 'yes'
+  run_unittests:
+    needs: make_variables
+    uses: ./.github/workflows/unit-tests.yml
+    with:
+      release_tag: ${{ needs.make_variables.outputs.tag }}
+      upload_logs: 'yes'
 
   run_clang_formatting:
     name: Run clang formatting
     runs-on: ubuntu-latest
-    needs: [make_variables]
+    needs: make_variables
     timeout-minutes: 60
     env:
       DBT_AREA_ROOT: ${{ needs.make_variables.outputs.tag }}

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -1,5 +1,8 @@
 name: Nightly dbt regression tests
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:
@@ -12,20 +15,19 @@ on:
 jobs:
   run_dbt_commands:
     name: Run dbt test script
-    runs-on: daq
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     defaults:
       run:
         shell: bash
     steps:
-    - name: Checkout daq-release
-      uses: actions/checkout@v6
+    - uses: cvmfs-contrib/github-action-cvmfs@d93d881391926e8146776c13345c3e23d6393acd
       with:
-        path: daq-release-dbt-tests
+        cvmfs_repositories: 'dunedaq-development.opensciencegrid.org'
+    - uses: actions/checkout@v6
     - name: Run dbt test script
       run: | 
-        cd daq-release-dbt-tests/scripts
-        ./test_daq-buildtools.sh
+        ./scripts/test_daq-buildtools.sh
 
   send_slack_message:
     if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')
@@ -33,12 +35,3 @@ jobs:
     uses: ./.github/workflows/slack-notification.yml
     secrets: 
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-  cleanup_test_area:
-    runs-on: daq
-    if: always()
-    needs: run_dbt_commands
-    steps:
-      - name: Remove test directory
-        run: |
-          rm -rf daq-release-dbt-tests

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -21,9 +21,6 @@ jobs:
       run:
         shell: bash
     steps:
-    - uses: cvmfs-contrib/github-action-cvmfs@d93d881391926e8146776c13345c3e23d6393acd
-      with:
-        cvmfs_repositories: 'dunedaq-development.opensciencegrid.org'
     - uses: actions/checkout@v6
       with:
         path: daq-release-dbt-tests

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -16,6 +16,8 @@ jobs:
   run_dbt_commands:
     name: Run dbt test script
     runs-on: ubuntu-latest
+    container:
+      image: almalinux:9
     timeout-minutes: 20
     defaults:
       run:

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -18,7 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: almalinux:9
-      volumes: /cvmfs:/cvmfs:shared
+      volumes: 
+        - /cvmfs:/cvmfs:shared
     timeout-minutes: 20
     defaults:
       run:

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -15,22 +15,30 @@ on:
 jobs:
   run_dbt_commands:
     name: Run dbt test script
-    runs-on: daq
+    runs-on: ubuntu-latest
+    env:
+      IMAGE: ghcr.io/dune-daq/nightly-release-alma9:development_v5
     timeout-minutes: 20
     defaults:
       run:
         shell: bash
     steps:
     - uses: actions/checkout@v6
+    - uses: cvmfs-contrib/github-action-cvmfs@d93d881391926e8146776c13345c3e23d6393acd
       with:
-        path: daq-release-dbt-tests
+        cvmfs_repositories: 'dunedaq-development.opensciencegrid.org'
+    - name: Pull build image
+      run: docker pull ${{ env.IMAGE }}
     - name: Run dbt test script
       run: | 
-        ./daq-release-dbt-tests/scripts/test_daq-buildtools.sh
-    - name: Remove test directory
-      if: always()
-      run: |
-        rm -rf daq-release-dbt-tests || true
+        docker run --rm \
+        -v /cvmfs:/cvmfs:shared \
+        -v "${GITHUB_WORKSPACE}:/ghw" \
+        -w /ghw \
+        ${{ env.IMAGE }} \
+        /ghw/scripts/test_daq-buildtools.sh
+
+        #./scripts/test_daq-buildtools.sh
 
   send_slack_message:
     if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -15,11 +15,7 @@ on:
 jobs:
   run_dbt_commands:
     name: Run dbt test script
-    runs-on: ubuntu-latest
-    container:
-      image: almalinux:9
-      volumes: 
-        - /cvmfs:/cvmfs:shared
+    runs-on: daq
     timeout-minutes: 20
     defaults:
       run:
@@ -29,9 +25,15 @@ jobs:
       with:
         cvmfs_repositories: 'dunedaq-development.opensciencegrid.org'
     - uses: actions/checkout@v6
+      with:
+        path: daq-release-dbt-tests
     - name: Run dbt test script
       run: | 
-        ./scripts/test_daq-buildtools.sh
+        ./daq-release-dbt-tests/scripts/test_daq-buildtools.sh
+    - name: Remove test directory
+      if: always()
+      run: |
+        rm -rf daq-release-dbt-tests || true
 
   send_slack_message:
     if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -38,8 +38,6 @@ jobs:
         ${{ env.IMAGE }} \
         /ghw/scripts/test_daq-buildtools.sh
 
-        #./scripts/test_daq-buildtools.sh
-
   send_slack_message:
     if: (github.event_name != 'workflow_dispatch' && failure()) || (github.event_name == 'workflow_dispatch' && github.event.inputs.send-slack-message == 'yes')
     needs: run_dbt_commands

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: almalinux:9
+      volumes: /cvmfs:/cvmfs:shared
     timeout-minutes: 20
     defaults:
       run:

--- a/.github/workflows/nightly-dbt-tests.yml
+++ b/.github/workflows/nightly-dbt-tests.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       IMAGE: ghcr.io/dune-daq/nightly-release-alma9:development_v5
-    timeout-minutes: 20
+    timeout-minutes: 60
     defaults:
       run:
         shell: bash

--- a/.github/workflows/poll-cvmfs-for-release.yml
+++ b/.github/workflows/poll-cvmfs-for-release.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-    - uses: cvmfs-contrib/github-action-cvmfs@v5
+    - uses: cvmfs-contrib/github-action-cvmfs@d93d881391926e8146776c13345c3e23d6393acd
       with:
         cvmfs_repositories: 'dunedaq.opensciencegrid.org, 
                              dunedaq-development.opensciencegrid.org'

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -41,6 +41,8 @@ jobs:
         pwd
         ls -lrt
     - name: Get workflow summary from GitHub API
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         # Outputs workflow_summary.json
         scripts/github-ci/get_workflow_summary.sh ${{ github.run_id }}

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -1,5 +1,7 @@
 name: Slack Notification
 
+permissions: read-all
+
 on:
   workflow_call:
     inputs:
@@ -28,17 +30,16 @@ on:
 
 jobs:
   generate_and_send_slack_message:
-    runs-on: daq
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     steps:
-    - name: Checkout daq-release
-      uses: actions/checkout@v6
-      with:
-        repository: DUNE-DAQ/daq-release
-        path: daq-release-slack-message
+    - uses: actions/checkout@v6
     - name: Get workflow summary from GitHub API
       run: |
         # Outputs workflow_summary.json
-        ./daq-release-slack-message/scripts/github-ci/get_workflow_summary.sh ${{ github.run_id }}
+        ./daq-release/scripts/github-ci/get_workflow_summary.sh ${{ github.run_id }}
     - name: Download artifact if specified
       if: ${{ inputs.artifact_name }}
       uses: actions/download-artifact@v8
@@ -85,7 +86,7 @@ jobs:
         cat workflow_summary_with_metadata.json
     - name: Parse GitHub API output
       run: |
-        python daq-release-slack-message/scripts/github-ci/slack_message_builder.py \
+        python daq-release/scripts/github-ci/slack_message_builder.py \
                --workflow-summary workflow_summary_with_metadata.json
         cat slack_payload.json
     - name: Send Slack Message
@@ -96,9 +97,3 @@ jobs:
         payload-file-path: "./slack_payload.json"
         payload-templated: true
         errors: true
-    - name: Cleanup files
-      run: |
-        rm workflow_summary.json additional_metadata.json workflow_summary_with_metadata.json slack_payload.json || true
-        rm pytest_summary.json artifacts.json || true
-        rm -rf artifacts || true
-        rm -rf daq-release-slack-message

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -36,10 +36,14 @@ jobs:
         shell: bash
     steps:
     - uses: actions/checkout@v6
+    - name: Troubleshoot paths
+      run: |
+        pwd
+        ls -lrt
     - name: Get workflow summary from GitHub API
       run: |
         # Outputs workflow_summary.json
-        ./daq-release/scripts/github-ci/get_workflow_summary.sh ${{ github.run_id }}
+        scripts/github-ci/get_workflow_summary.sh ${{ github.run_id }}
     - name: Download artifact if specified
       if: ${{ inputs.artifact_name }}
       uses: actions/download-artifact@v8
@@ -86,7 +90,7 @@ jobs:
         cat workflow_summary_with_metadata.json
     - name: Parse GitHub API output
       run: |
-        python daq-release/scripts/github-ci/slack_message_builder.py \
+        python scripts/github-ci/slack_message_builder.py \
                --workflow-summary workflow_summary_with_metadata.json
         cat slack_payload.json
     - name: Send Slack Message

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -1,6 +1,8 @@
 name: Slack Notification
 
-permissions: read-all
+permissions: 
+  contents: read
+
 
 on:
   workflow_call:

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -1,8 +1,7 @@
 name: Slack Notification
 
-permissions: 
+permissions:
   contents: read
-
 
 on:
   workflow_call:
@@ -38,10 +37,6 @@ jobs:
         shell: bash
     steps:
     - uses: actions/checkout@v6
-    - name: Troubleshoot paths
-      run: |
-        pwd
-        ls -lrt
     - name: Get workflow summary from GitHub API
       env:
         GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,5 +1,8 @@
 name: Run Unit Tests on a Given Release
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:
@@ -111,6 +114,11 @@ jobs:
         if-no-files-found: error
         name: unit_test_summary
         path: ${{ steps.unit_tests.outputs.unit_test_summary }}
+    - name: Remove files
+      if: always()
+      run: |
+        rm -rf $RELEASE_TAG || true
+        rm -rf ${{ github.workspace }}/daq-release-unittests || true
 
   send_slack_message:
     if: (success() || failure()) && (inputs.send-slack-message == 'yes' && github.event_name == 'workflow_dispatch')
@@ -120,15 +128,3 @@ jobs:
       release_tag: ${{ inputs.release_tag }}
     secrets: 
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-  cleanup_files:
-    if: always()
-    needs: run_unittests
-    runs-on: daq
-    env:
-      RELEASE_TAG: ${{ inputs.release_tag }}
-    steps:
-    - name: Remove files
-      run: |
-        rm -rf $RELEASE_TAG
-        rm -rf ${{ github.workspace }}/daq-release-unittests


### PR DESCRIPTION
Addresses #555. Notable changes:
- Explicitly set `permissions: contents: read` and only override where necessary
- Enable some workflows/jobs to run on `ubuntu-latest` instead of `daq.fnal.gov`. This includes the clang formatting job of the nightly code checks, the dbt regression test workflow, and the parsing jobs in the integration test workflows
- SHA pin `github-action-cvmfs`
- Some minor cleaning/renaming where appropriate. For example, the clang formatting job was named `Run integration tests and clang formatting` despite only running clang formatting

Successful test workflows using this branch:
- [Nightly build](https://github.com/DUNE-DAQ/daq-release/actions/runs/26456427934)
- [dbt regression tests](https://github.com/DUNE-DAQ/daq-release/actions/runs/26587094048)
- [Nightly code checks](https://github.com/DUNE-DAQ/daq-release/actions/runs/26644447075)
- [Extended integration tests with Slack message](https://github.com/DUNE-DAQ/daq-release/actions/runs/26656513694)
- [Core integration tests with Slack message](https://github.com/DUNE-DAQ/daq-release/actions/runs/26653743951)