### PR TITLE
Composite action for getting release type

### DIFF
--- a/.github/actions/get-release-type/action.yml
+++ b/.github/actions/get-release-type/action.yml
@@ -36,3 +36,5 @@ runs:
       else
         echo "::error::Unrecognized tag format: ${TAG}"; exit 1
       fi
+      echo "TYPE=$TYPE"
+      echo "DBT_ARGS=$DBT_ARGS"

--- a/.github/actions/get-release-type/action.yml
+++ b/.github/actions/get-release-type/action.yml
@@ -34,7 +34,7 @@ runs:
         echo "DBT_ARGS=-b candidate" >> "$GITHUB_OUTPUT"
       elif [[ "$TAG" =~ ^[a-z]+-v[0-9]+\.[0-9]+\.[0-9]+-?[a-z]+[0-9]+$ ]]; then
         echo "TYPE=stable"        >> "$GITHUB_OUTPUT"
-        echo "DBT_ARGS=''"        >> "$GITHUB_OUTPUT"
+        echo "DBT_ARGS=$DBT_ARGS" >> "$GITHUB_OUTPUT"
       else
         echo "::error::Unrecognized tag format: ${TAG}"; exit 1
       fi

--- a/.github/actions/get-release-type/action.yml
+++ b/.github/actions/get-release-type/action.yml
@@ -26,13 +26,13 @@ runs:
       TAG="${{ inputs.tag }}"
       if [[ "$TAG" =~ ^[A-Z]+_DEV_[0-9]{6}_[A-Za-z0-9]+$ ]]; then
         echo "TYPE=nightly" >> "$GITHUB_OUTPUT"
-        echo "DBT_ARGS=(-n)"  >> "$GITHUB_OUTPUT"
+        echo "DBT_ARGS=-n"  >> "$GITHUB_OUTPUT"
       elif [[ "$TAG" =~ ^[a-z]+-v[0-9]+\.[0-9]+\.[0-9]+-?rc[0-9]+.*$ ]]; then
         echo "TYPE=candidate"        >> "$GITHUB_OUTPUT"
-        echo "DBT_ARGS=(-b candidate)" >> "$GITHUB_OUTPUT"
+        echo "DBT_ARGS=-b candidate" >> "$GITHUB_OUTPUT"
       elif [[ "$TAG" =~ ^[a-z]+-v[0-9]+\.[0-9]+\.[0-9]+-?[a-z]+[0-9]+$ ]]; then
-        echo "TYPE=stable"        >> "$GITHUB_OUTPUT"
-        echo "DBT_ARGS=()" >> "$GITHUB_OUTPUT"
+        echo "TYPE=stable" >> "$GITHUB_OUTPUT"
+        echo "DBT_ARGS="   >> "$GITHUB_OUTPUT"
       else
         echo "ERROR: Unrecognized tag format: ${TAG}"; exit 1
       fi

--- a/.github/actions/get-release-type/action.yml
+++ b/.github/actions/get-release-type/action.yml
@@ -1,0 +1,38 @@
+name: Get release type
+
+description: 'Get release type'
+
+inputs:
+  TAG:
+    description: 'Relese tag'
+    type: string
+    required: true
+
+outputs:
+  type:
+    description: 'One of nightly, stable, or candidate'
+    value: ${{ steps.get_release_type.outputs.TYPE }}
+  dbt_args:
+    description: 'Additional args for dbt-build, dbt-setup-release, etc.'
+    value: ${{ steps.get_release_type.outputs.DBT_ARGS }}
+
+runs:
+  using: "composite"
+  steps:
+  - name: Get release type
+    id: get_release_type
+    shell: bash
+    run: |
+      TAG="${{ inputs.tag }}"
+      if [[ "$TAG" =~ ^[A-Z]+_DEV_[0-9]{6}_[A-Za-z0-9]+$ ]]; then
+        echo "TYPE=nightly"       >> "$GITHUB_OUTPUT"
+        echo "DBT_ARGS=-n ${TAG}" >> "$GITHUB_OUTPUT"
+      elif [[ "$TAG" =~ ^[a-z]+-v[0-9]+\.[0-9]+\.[0-9]+-?rc[0-9]+.*$ ]]; then
+        echo "TYPE=candidate"        >> "$GITHUB_OUTPUT"
+        echo "DBT_ARGS=-b candidate" >> "$GITHUB_OUTPUT"
+      elif [[ "$TAG" =~ ^[a-z]+-v[0-9]+\.[0-9]+\.[0-9]+-?[a-z]+[0-9]+$ ]]; then
+        echo "TYPE=stable"        >> "$GITHUB_OUTPUT"
+        echo "DBT_ARGS=''"        >> "$GITHUB_OUTPUT"
+      else
+        echo "::error::Unrecognized tag format: ${TAG}"; exit 1
+      fi

--- a/.github/actions/get-release-type/action.yml
+++ b/.github/actions/get-release-type/action.yml
@@ -35,8 +35,8 @@ runs:
         echo "TYPE=nightly" >> "$GITHUB_OUTPUT"
         echo "DBT_ARGS=-n"  >> "$GITHUB_OUTPUT"
 
-        echo "FDDAQ_MANIFEST=configs/fddaq/fddaq-develop/release.yml" >> "$GITHUB_OUTPUT"
-        echo "COREDAQ_MANIFEST=configs/coredaq/fddaq-develop/release.yml" >> "$GITHUB_OUTPUT"
+        echo "FDDAQ_MANIFEST=configs/fddaq/fddaq-develop/release.yaml" >> "$GITHUB_OUTPUT"
+        echo "COREDAQ_MANIFEST=configs/coredaq/fddaq-develop/release.yaml" >> "$GITHUB_OUTPUT"
 
       # Tags containing vX.Y.Z are either candidate or stable
       elif [[ "$TAG" =~ -v([0-9]+)\.([0-9]+)\.[0-9]+- ]]; then
@@ -53,12 +53,12 @@ runs:
         # Backwards compatibility with previous manifest file name format
         VERSION_STRING=$(echo "$TAG" | cut -d "-" -f 2)
         if (( MAJOR_VERSION < 5 || (MAJOR_VERSION == 5 && MINOR_VERSION < 6) )); then
-          echo "COREDAQ_MANIFEST=configs/coredaq/coredaq-${VERSION_STRING}/release.yml" >> "$GITHUB_OUTPUT"
+          echo "COREDAQ_MANIFEST=configs/coredaq/coredaq-${VERSION_STRING}/release.yaml" >> "$GITHUB_OUTPUT"
         else
-          echo "COREDAQ_MANIFEST=configs/coredaq/fddaq-coredaq-${VERSION_STRING}/release.yml" >> "$GITHUB_OUTPUT"
+          echo "COREDAQ_MANIFEST=configs/coredaq/fddaq-coredaq-${VERSION_STRING}/release.yaml" >> "$GITHUB_OUTPUT"
         fi
 
-        echo "FDDAQ_MANIFEST=configs/fddaq/fddaq-${VERSION_STRING}/release.yml" >> "$GITHUB_OUTPUT"
+        echo "FDDAQ_MANIFEST=configs/fddaq/fddaq-${VERSION_STRING}/release.yaml" >> "$GITHUB_OUTPUT"
 
       else
         echo "::error::Unrecognized tag format: ${TAG}"; exit 1

--- a/.github/actions/get-release-type/action.yml
+++ b/.github/actions/get-release-type/action.yml
@@ -15,6 +15,12 @@ outputs:
   dbt_args:
     description: 'Additional args for dbt-build, dbt-setup-release, etc.'
     value: ${{ steps.get_release_type.outputs.DBT_ARGS }}
+  fddaq_manifest:
+    description: 'Path to far detector release manifest, relative to daq-release root'
+    value: ${{ steps.get_release_type.outputs.FDDAQ_MANIFEST }}
+  coredaq_manifest:
+    description: 'Path to core release manifest, relative to daq-release root'
+    value: ${{ steps.get_release_type.outputs.COREDAQ_MANIFEST }}
 
 runs:
   using: "composite"
@@ -24,16 +30,38 @@ runs:
     shell: bash
     run: |
       TAG="${{ inputs.tag }}"
+
       if [[ "$TAG" =~ ^[A-Z]+_DEV_[0-9]{6}_[A-Za-z0-9]+$ ]]; then
         echo "TYPE=nightly" >> "$GITHUB_OUTPUT"
         echo "DBT_ARGS=-n"  >> "$GITHUB_OUTPUT"
-      elif [[ "$TAG" =~ ^[a-z]+-v[0-9]+\.[0-9]+\.[0-9]+-?rc[0-9]+.*$ ]]; then
-        echo "TYPE=candidate"        >> "$GITHUB_OUTPUT"
-        echo "DBT_ARGS=-b candidate" >> "$GITHUB_OUTPUT"
-      elif [[ "$TAG" =~ ^[a-z]+-v[0-9]+\.[0-9]+\.[0-9]+-?[a-z]+[0-9]+$ ]]; then
-        echo "TYPE=stable" >> "$GITHUB_OUTPUT"
-        echo "DBT_ARGS="   >> "$GITHUB_OUTPUT"
+
+        echo "FDDAQ_MANIFEST=configs/fddaq/fddaq-develop/release.yml" >> "$GITHUB_OUTPUT"
+        echo "COREDAQ_MANIFEST=configs/coredaq/fddaq-develop/release.yml" >> "$GITHUB_OUTPUT"
+
+      # Tags containing vX.Y.Z are either candidate or stable
+      elif [[ "$TAG" =~ -v([0-9]+)\.([0-9]+)\.[0-9]+- ]]; then
+        MAJOR_VERSION="${BASH_REMATCH[1]}"
+        MINOR_VERSION="${BASH_REMATCH[2]}"
+        if [[ "$TAG" =~ -rc[0-9]+- ]]; then
+          echo "TYPE=candidate"        >> "$GITHUB_OUTPUT"
+          echo "DBT_ARGS=-b candidate" >> "$GITHUB_OUTPUT"
+        else
+          echo "TYPE=stable" >> "$GITHUB_OUTPUT"
+          echo "DBT_ARGS="   >> "$GITHUB_OUTPUT"
+        fi
+
+        # Backwards compatibility with previous manifest file name format
+        VERSION_STRING=$(echo "$TAG" | cut -d "-" -f 2)
+        if (( MAJOR_VERSION < 5 || (MAJOR_VERSION == 5 && MINOR_VERSION < 6) )); then
+          echo "COREDAQ_MANIFEST=configs/coredaq/coredaq-${VERSION_STRING}/release.yml" >> "$GITHUB_OUTPUT"
+        else
+          echo "COREDAQ_MANIFEST=configs/coredaq/fddaq-coredaq-${VERSION_STRING}/release.yml" >> "$GITHUB_OUTPUT"
+        fi
+
+        echo "FDDAQ_MANIFEST=configs/fddaq/fddaq-${VERSION_STRING}/release.yml" >> "$GITHUB_OUTPUT"
+
       else
-        echo "ERROR: Unrecognized tag format: ${TAG}"; exit 1
+        echo "::error::Unrecognized tag format: ${TAG}"; exit 1
       fi
+
       cat "$GITHUB_OUTPUT"

--- a/.github/actions/get-release-type/action.yml
+++ b/.github/actions/get-release-type/action.yml
@@ -31,7 +31,7 @@ runs:
     run: |
       TAG="${{ inputs.tag }}"
 
-      if [[ "$TAG" =~ ^[A-Z]+_DEV_[0-9]{6}_[A-Za-z0-9]+$ ]]; then
+      if [[ "$TAG" =~ ^[A-Z]+_DEV_[0-9]{6}_[A-Za-z0-9]+$ || "$TAG" == "last_fddaq" ]]; then
         echo "TYPE=nightly" >> "$GITHUB_OUTPUT"
         echo "DBT_ARGS=-n"  >> "$GITHUB_OUTPUT"
 

--- a/.github/actions/get-release-type/action.yml
+++ b/.github/actions/get-release-type/action.yml
@@ -26,13 +26,13 @@ runs:
       TAG="${{ inputs.tag }}"
       if [[ "$TAG" =~ ^[A-Z]+_DEV_[0-9]{6}_[A-Za-z0-9]+$ ]]; then
         echo "TYPE=nightly" >> "$GITHUB_OUTPUT"
-        echo "DBT_ARGS=-n"  >> "$GITHUB_OUTPUT"
+        echo "DBT_ARGS=(-n)"  >> "$GITHUB_OUTPUT"
       elif [[ "$TAG" =~ ^[a-z]+-v[0-9]+\.[0-9]+\.[0-9]+-?rc[0-9]+.*$ ]]; then
         echo "TYPE=candidate"        >> "$GITHUB_OUTPUT"
-        echo "DBT_ARGS=-b candidate" >> "$GITHUB_OUTPUT"
+        echo "DBT_ARGS=(-b candidate)" >> "$GITHUB_OUTPUT"
       elif [[ "$TAG" =~ ^[a-z]+-v[0-9]+\.[0-9]+\.[0-9]+-?[a-z]+[0-9]+$ ]]; then
         echo "TYPE=stable"        >> "$GITHUB_OUTPUT"
-        echo "DBT_ARGS=$DBT_ARGS" >> "$GITHUB_OUTPUT"
+        echo "DBT_ARGS=()" >> "$GITHUB_OUTPUT"
       else
         echo "ERROR: Unrecognized tag format: ${TAG}"; exit 1
       fi

--- a/.github/actions/get-release-type/action.yml
+++ b/.github/actions/get-release-type/action.yml
@@ -24,6 +24,8 @@ runs:
     shell: bash
     run: |
       TAG="${{ inputs.tag }}"
+      TYPE=""
+      DBT_ARGS=""
       if [[ "$TAG" =~ ^[A-Z]+_DEV_[0-9]{6}_[A-Za-z0-9]+$ ]]; then
         echo "TYPE=nightly"       >> "$GITHUB_OUTPUT"
         echo "DBT_ARGS=-n ${TAG}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/get-release-type/action.yml
+++ b/.github/actions/get-release-type/action.yml
@@ -4,7 +4,7 @@ description: 'Get release type'
 
 inputs:
   TAG:
-    description: 'Relese tag'
+    description: 'Release tag'
     type: string
     required: true
 

--- a/.github/actions/get-release-type/action.yml
+++ b/.github/actions/get-release-type/action.yml
@@ -25,8 +25,8 @@ runs:
     run: |
       TAG="${{ inputs.tag }}"
       if [[ "$TAG" =~ ^[A-Z]+_DEV_[0-9]{6}_[A-Za-z0-9]+$ ]]; then
-        echo "TYPE=nightly"       >> "$GITHUB_OUTPUT"
-        echo "DBT_ARGS=-n ${TAG}" >> "$GITHUB_OUTPUT"
+        echo "TYPE=nightly" >> "$GITHUB_OUTPUT"
+        echo "DBT_ARGS=-n"  >> "$GITHUB_OUTPUT"
       elif [[ "$TAG" =~ ^[a-z]+-v[0-9]+\.[0-9]+\.[0-9]+-?rc[0-9]+.*$ ]]; then
         echo "TYPE=candidate"        >> "$GITHUB_OUTPUT"
         echo "DBT_ARGS=-b candidate" >> "$GITHUB_OUTPUT"

--- a/.github/actions/get-release-type/action.yml
+++ b/.github/actions/get-release-type/action.yml
@@ -24,8 +24,6 @@ runs:
     shell: bash
     run: |
       TAG="${{ inputs.tag }}"
-      TYPE=""
-      DBT_ARGS=""
       if [[ "$TAG" =~ ^[A-Z]+_DEV_[0-9]{6}_[A-Za-z0-9]+$ ]]; then
         echo "TYPE=nightly"       >> "$GITHUB_OUTPUT"
         echo "DBT_ARGS=-n ${TAG}" >> "$GITHUB_OUTPUT"
@@ -36,7 +34,6 @@ runs:
         echo "TYPE=stable"        >> "$GITHUB_OUTPUT"
         echo "DBT_ARGS=$DBT_ARGS" >> "$GITHUB_OUTPUT"
       else
-        echo "::error::Unrecognized tag format: ${TAG}"; exit 1
+        echo "ERROR: Unrecognized tag format: ${TAG}"; exit 1
       fi
-      echo "TYPE=$TYPE"
-      echo "DBT_ARGS=$DBT_ARGS"
+      cat "$GITHUB_OUTPUT"

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -12,17 +12,12 @@ on:
       send-slack-message:
         description: 'whether to send a message to #daq-release-notifications on completion'
         default: 'no'
-      override-nightly-tag:
-        description: 'manually specify the nightly tag (optional)'
+      release-tag:
+        description: >-
+          Release to test, e.g., NFD_DEV_YYMMDD_A9, fddaq-vX.Y.Z-a9, etc. 
+          Default: last_fddaq (latest nightly)
         required: false
-      candidate-release-tag:
-        description: 'manually specify a candidate release tag (optional)'
-        required: false
-        default: ""
-      stable-release-tag:
-        description: 'manually specify a stable release tag (optional)'
-        required: false
-        default: ""
+        default: 'last_fddaq'
 
 jobs:
   make_variables:
@@ -44,23 +39,8 @@ jobs:
       - uses: actions/checkout@v6
       - id: create_variables
         run: |
-          if [[ -n "${{ github.event.inputs.candidate-release-tag }}" && -n "${{ github.event.inputs.stable-release-tag }}" ]]; then
-            echo "Error: You cannot specify both a candidate tag and a stable tag. Please choose one and try again. Exiting..."
-            exit 1
-          fi
-          if [ -n "${{ github.event.inputs.override-nightly-tag }}" ]; then
-            release_tag="${{ github.event.inputs.override-nightly-tag }}"
-            if [[ -n "${{ github.event.inputs.candidate-release-tag }}" || -n "${{ github.event.inputs.stable-release-tag }}" ]]; then
-              echo "WARNING: The provided nightly tag will supercede the provided candidate or stable release tag."
-            fi
-          elif [ -n "${{ github.event.inputs.candidate-release-tag }}" ]; then
-            release_tag="${{ github.event.inputs.candidate-release-tag }}"
-          elif [ -n "${{ github.event.inputs.stable-release-tag }}" ]; then
-            release_tag="${{ github.event.inputs.stable-release-tag }}"
-          else
-            date_tag=$(date +%y%m%d)
-            release_tag="NFD_DEV_${date_tag}_A9"
-          fi
+          tag="${{ inputs.release-tag }}"
+          release_tag="${tag:-last_fddaq}"
 
           timestamp=$(date +"%Y-%m-%d-%H%M%Z")
           persistent_log_dir=/home/nfs/dunedaq/github-actions/pytest-logs-extended-${timestamp}
@@ -115,13 +95,9 @@ jobs:
         cd $DBT_AREA_ROOT
         source env.sh
         cd ../$DAQ_RELEASE_PATH/scripts
-        echo "DEBUG LS:"
-        echo "$COREDAQ_MANIFEST"
-        ls -lrt ../
-        ls -lrt ../$COREDAQ_MANIFEST
-        #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -p dfmodules -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -i ../$COREDAQ_MANIFEST -a -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -i ../$FDDAQ_MANIFEST -a -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -p dfmodules -i ../$COREDAQ_MANIFEST -o ${DBT_AREA_ROOT}/sourcecode
         ./checkout-daq-package.py -p trigger -i ../$COREDAQ_MANIFEST -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
 

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -106,7 +106,7 @@ jobs:
         source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
         setup_dbt latest_v5
 
-        dbt-create "${DBT_ARGS[@]}" "$RELEASE_TAG"
+        dbt-create $DBT_ARGS "$RELEASE_TAG"
 
         cd ${{ env.DBT_AREA_ROOT }}
         source env.sh

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -113,7 +113,7 @@ jobs:
         cd ../$DAQ_RELEASE_PATH/scripts
         #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -p dfmodules -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -p dfmodules -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         ./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
 

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -106,9 +106,9 @@ jobs:
         source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
         setup_dbt latest_v5
 
-        dbt-create $DBT_ARGS "$RELEASE_TAG"
+        dbt-create $DBT_ARGS "$RELEASE_TAG" "$DBT_AREA_ROOT"
 
-        cd ${{ env.DBT_AREA_ROOT }}
+        cd $DBT_AREA_ROOT
         source env.sh
         cd ../$DAQ_RELEASE_PATH/scripts
         #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -30,20 +30,17 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.create_variables.outputs.release_tag }}
-      is_candidate_release: ${{ steps.create_variables.outputs.is_candidate }}
-      is_stable_release: ${{ steps.create_variables.outputs.is_stable }}
       timestamp: ${{ steps.create_variables.outputs.timestamp }}
       persistent_log_dir: ${{ steps.create_variables.outputs.persistent_log_dir }}
       integtest_output_path: ${{ steps.create_variables.outputs.integtest_output_path }}
       daq_release_path: ${{ steps.create_variables.outputs.daq_release_path }}
+      dbt_args: ${{ steps.release_type.outputs.DBT_ARGS }}
     defaults:
       run:
         shell: bash
     steps:
       - id: create_variables
         run: |
-          is_candidate=false
-          is_stable=false
           if [[ -n "${{ github.event.inputs.candidate-release-tag }}" && -n "${{ github.event.inputs.stable-release-tag }}" ]]; then
             echo "Error: You cannot specify both a candidate tag and a stable tag. Please choose one and try again. Exiting..."
             exit 1
@@ -55,10 +52,8 @@ jobs:
             fi
           elif [ -n "${{ github.event.inputs.candidate-release-tag }}" ]; then
             release_tag="${{ github.event.inputs.candidate-release-tag }}"
-            is_candidate=true
           elif [ -n "${{ github.event.inputs.stable-release-tag }}" ]; then
             release_tag="${{ github.event.inputs.stable-release-tag }}"
-            is_stable=true
           else
             date_tag=$(date +%y%m%d)
             release_tag="NFD_DEV_${date_tag}_A9"
@@ -70,13 +65,16 @@ jobs:
           daq_release_path="daq-release-extended-tests"
 
           echo "release_tag=${release_tag}"  >>  "$GITHUB_OUTPUT"
-          echo "is_candidate=${is_candidate}"  >>  "$GITHUB_OUTPUT"
-          echo "is_stable=${is_stable}"  >>  "$GITHUB_OUTPUT"
           echo "timestamp=${timestamp}" >> "$GITHUB_OUTPUT"
           echo "persistent_log_dir=${persistent_log_dir}" >> "$GITHUB_OUTPUT"
           echo "integtest_output_path=${integtest_output_path}" >> "$GITHUB_OUTPUT"
           echo "daq_release_path=${daq_release_path}" >> "$GITHUB_OUTPUT"
           cat "$GITHUB_OUTPUT"
+      - name: Get release type
+        id: release_type
+        uses: ./.github/actions/get-release-type
+        with:
+          TAG: ${{ steps.create_variables.outputs.release_tag }}
 
   extended_integration_tests:
     name: extended_integration_tests
@@ -102,31 +100,20 @@ jobs:
 
     - name: Create build area
       env:
-        IS_CANDIDATE_RELEASE: ${{ needs.make_variables.outputs.is_candidate_release }}
-        IS_STABLE_RELEASE: ${{ needs.make_variables.outputs.is_stable_release }}
+        DBT_ARGS: ${{ needs.make_variables.outputs.DBT_ARGS }}
       run: |
         source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
         setup_dbt latest_v5
-        if [[ "$IS_CANDIDATE_RELEASE" == "true" ]]; then
-          echo "create -b candidate $RELEASE_TAG"
-          [[ -e /cvmfs/dunedaq-development.opensciencegrid.org/candidates/$RELEASE_TAG/daq_app_rte.sh ]]
-          dbt-create -b candidate $RELEASE_TAG $RELEASE_TAG
-        elif [[ "$IS_STABLE_RELEASE" == "true" ]]; then
-          echo "create $RELEASE_TAG"
-          [[ -e /cvmfs/dunedaq.opensciencegrid.org/spack/releases/$RELEASE_TAG/daq_app_rte.sh ]]
-          dbt-create $RELEASE_TAG $RELEASE_TAG
-        else
-          echo "create -n $RELEASE_TAG"
-          [[ -e /cvmfs/dunedaq-development.opensciencegrid.org/nightly/$RELEASE_TAG/daq_app_rte.sh ]]
-          dbt-create -n $RELEASE_TAG $RELEASE_TAG
-        fi
+
+        dbt-create "$DBT_ARGS" "$RELEASE_TAG"
+
         cd ${{ env.DBT_AREA_ROOT }}
         source env.sh
         cd ../$DAQ_RELEASE_PATH/scripts
-        ./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -p dfmodules -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -p dfmodules -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
 
     - name: Run integration tests

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -95,10 +95,10 @@ jobs:
         cd $DBT_AREA_ROOT
         source env.sh
         cd ../$DAQ_RELEASE_PATH/scripts
-        #./checkout-daq-package.py -i ../$COREDAQ_MANIFEST -a -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -i ../$FDDAQ_MANIFEST -a -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -i ../$COREDAQ_MANIFEST -a -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -i ../$FDDAQ_MANIFEST -a -o ${DBT_AREA_ROOT}/sourcecode
         #./checkout-daq-package.py -p dfmodules -i ../$COREDAQ_MANIFEST -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -p trigger -i ../$COREDAQ_MANIFEST -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -p trigger -i ../$COREDAQ_MANIFEST -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
 
     - name: Run integration tests

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -34,7 +34,9 @@ jobs:
       persistent_log_dir: ${{ steps.create_variables.outputs.persistent_log_dir }}
       integtest_output_path: ${{ steps.create_variables.outputs.integtest_output_path }}
       daq_release_path: ${{ steps.create_variables.outputs.daq_release_path }}
-      dbt_args: ${{ steps.release_type.outputs.DBT_ARGS }}
+      dbt_args: ${{ steps.release_type.outputs.dbt_args }}
+      coredaq_manifest: ${{ steps.release_type.outputs.coredaq_manifest }}
+      fddaq_manifest: ${{ steps.release_type.outputs.fddaq_manifest }}
     defaults:
       run:
         shell: bash
@@ -101,7 +103,9 @@ jobs:
 
     - name: Create build area
       env:
-        DBT_ARGS: ${{ needs.make_variables.outputs.DBT_ARGS }}
+        DBT_ARGS: ${{ needs.make_variables.outputs.dbt_args }}
+        COREDAQ_MANIFEST: ${{ needs.make_variables.outputs.coredaq_manifest }}
+        FDDAQ_MANIFEST: ${{ needs.make_variables.outputs.fddaq_manifest }}
       run: |
         source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
         setup_dbt latest_v5
@@ -111,10 +115,14 @@ jobs:
         cd $DBT_AREA_ROOT
         source env.sh
         cd ../$DAQ_RELEASE_PATH/scripts
+        echo "DEBUG LS:"
+        echo "$COREDAQ_MANIFEST"
+        ls -lrt ../
+        ls -lrt ../$COREDAQ_MANIFEST
         #./checkout-daq-package.py -i ../configs/coredaq/coredaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         #./checkout-daq-package.py -i ../configs/fddaq/fddaq-develop/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
         #./checkout-daq-package.py -p dfmodules -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -p trigger -b develop -i ../configs/coredaq/coredaq-develop/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -p trigger -i ../$COREDAQ_MANIFEST -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
 
     - name: Run integration tests

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -39,6 +39,7 @@ jobs:
       run:
         shell: bash
     steps:
+      - uses: actions/checkout@v6
       - id: create_variables
         run: |
           if [[ -n "${{ github.event.inputs.candidate-release-tag }}" && -n "${{ github.event.inputs.stable-release-tag }}" ]]; then

--- a/.github/workflows/extended_integration_tests.yml
+++ b/.github/workflows/extended_integration_tests.yml
@@ -106,7 +106,7 @@ jobs:
         source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
         setup_dbt latest_v5
 
-        dbt-create "$DBT_ARGS" "$RELEASE_TAG"
+        dbt-create "${DBT_ARGS[@]}" "$RELEASE_TAG"
 
         cd ${{ env.DBT_AREA_ROOT }}
         source env.sh

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -63,18 +63,18 @@ jobs:
         matrix:
 
             test_name: [
-                        #"listrev_test",
-                        #"3ru_1df_multirun_test",
-                        #"3ru_3df_multirun_test",
-                        #"disabled_tpg_test",
-                        #"example_system_test",
-                        #"fake_data_producer_test",
-                        #"long_window_readout_test",
+                        "listrev_test",
+                        "3ru_1df_multirun_test",
+                        "3ru_3df_multirun_test",
+                        "disabled_tpg_test",
+                        "example_system_test",
+                        "fake_data_producer_test",
+                        "long_window_readout_test",
                         "minimal_system_quick_test",
-                        #"readout_type_scan_test",
-                        #"small_footprint_quick_test",
-                        #"tpreplay_test",
-                        #"tpstream_writing_test"
+                        "readout_type_scan_test",
+                        "small_footprint_quick_test",
+                        "tpreplay_test",
+                        "tpstream_writing_test"
                        ]
     defaults:
       run:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -12,17 +12,12 @@ on:
       send-slack-message:
         description: 'whether to send a message to #daq-release-notifications on completion'
         default: 'no'
-      override-nightly-tag:
-        description: 'manually specify the nightly tag (optional)'
+      release-tag:
+        description: >-
+          Release to test, e.g., NFD_DEV_YYMMDD_A9, fddaq-vX.Y.Z-a9, etc. 
+          Default: last_fddaq (latest nightly)
         required: false
-      candidate-release-tag:
-        description: 'manually specify a candidate release tag (optional)'
-        required: false
-        default: ""
-      stable-release-tag:
-        description: 'manually specify a stable release tag (optional)'
-        required: false
-        default: ""
+        default: 'last_fddaq'
 
 jobs:
   make_variables:
@@ -33,7 +28,7 @@ jobs:
       timestamp: ${{ steps.create_variables.outputs.timestamp }}
       persistent_log_dir: ${{ steps.create_variables.outputs.persistent_log_dir }}
       integtest_output_path: ${{ steps.create_variables.outputs.integtest_output_path }}
-      dbt_args: ${{ steps.release_type.outputs.DBT_ARGS }}
+      dbt_args: ${{ steps.release_type.outputs.dbt_args }}
     defaults:
       run:
         shell: bash
@@ -41,24 +36,8 @@ jobs:
       - uses: actions/checkout@v6
       - id: create_variables
         run: |
-          if [[ -n "${{ github.event.inputs.candidate-release-tag }}" && -n "${{ github.event.inputs.stable-release-tag }}" ]]; then
-            echo "Error: You cannot specify both a candidate tag and a stable tag. Please choose one and try again. Exiting..."
-            exit 1
-          fi
-          if [ -n "${{ github.event.inputs.override-nightly-tag }}" ]; then
-            release_tag="${{ github.event.inputs.override-nightly-tag }}"
-            if [[ -n "${{ github.event.inputs.candidate-release-tag }}" || -n "${{ github.event.inputs.stable-release-tag }}" ]]; then
-              echo "WARNING: The provided nightly tag will supercede the provided candidate or stable release tag."
-            fi
-          elif [ -n "${{ github.event.inputs.candidate-release-tag }}" ]; then
-            release_tag="${{ github.event.inputs.candidate-release-tag }}"
-          elif [ -n "${{ github.event.inputs.stable-release-tag }}" ]; then
-            release_tag="${{ github.event.inputs.stable-release-tag }}"
-          else
-            date_tag=$(date +%y%m%d)
-            release_tag="NFD_DEV_${date_tag}_A9"
-          fi
-
+          tag="${{ inputs.release-tag }}"
+          release_tag="${tag:-last_fddaq}"
           timestamp=$(date +"%Y-%m-%d-%H%M%Z")
           persistent_log_dir=/home/nfs/dunedaq/github-actions/pytest-logs-${timestamp}
           integtest_output_path=/home/nfs/dunedaq/actions-runner/_work/daq-release/daq-release/integration_tests_${release_tag}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -30,19 +30,16 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.create_variables.outputs.release_tag }}
-      is_candidate_release: ${{ steps.create_variables.outputs.is_candidate }}
-      is_stable_release: ${{ steps.create_variables.outputs.is_stable }}
       timestamp: ${{ steps.create_variables.outputs.timestamp }}
       persistent_log_dir: ${{ steps.create_variables.outputs.persistent_log_dir }}
       integtest_output_path: ${{ steps.create_variables.outputs.integtest_output_path }}
+      dbt_args: ${{ steps.release_type.outputs.DBT_ARGS }}
     defaults:
       run:
         shell: bash
     steps:
       - id: create_variables
         run: |
-          is_candidate=false
-          is_stable=false
           if [[ -n "${{ github.event.inputs.candidate-release-tag }}" && -n "${{ github.event.inputs.stable-release-tag }}" ]]; then
             echo "Error: You cannot specify both a candidate tag and a stable tag. Please choose one and try again. Exiting..."
             exit 1
@@ -54,10 +51,8 @@ jobs:
             fi
           elif [ -n "${{ github.event.inputs.candidate-release-tag }}" ]; then
             release_tag="${{ github.event.inputs.candidate-release-tag }}"
-            is_candidate=true
           elif [ -n "${{ github.event.inputs.stable-release-tag }}" ]; then
             release_tag="${{ github.event.inputs.stable-release-tag }}"
-            is_stable=true
           else
             date_tag=$(date +%y%m%d)
             release_tag="NFD_DEV_${date_tag}_A9"
@@ -68,12 +63,15 @@ jobs:
           integtest_output_path=/home/nfs/dunedaq/actions-runner/_work/daq-release/daq-release/integration_tests_${release_tag}
 
           echo "release_tag=${release_tag}"  >>  "$GITHUB_OUTPUT"
-          echo "is_candidate=${is_candidate}"  >>  "$GITHUB_OUTPUT"
-          echo "is_stable=${is_stable}"  >>  "$GITHUB_OUTPUT"
           echo "timestamp=${timestamp}" >> "$GITHUB_OUTPUT"
           echo "persistent_log_dir=${persistent_log_dir}" >> "$GITHUB_OUTPUT"
           echo "integtest_output_path=${integtest_output_path}" >> "$GITHUB_OUTPUT"
           cat "$GITHUB_OUTPUT"
+      - name: Get release type
+        id: release_type
+        uses: ./.github/actions/get-release-type
+        with:
+          TAG: ${{ steps.create_variables.outputs.release_tag }}
 
   integration_tests:
     name: integration_tests
@@ -85,18 +83,18 @@ jobs:
         matrix:
 
             test_name: [
-                        "listrev_test",
-                        "3ru_1df_multirun_test",
-                        "3ru_3df_multirun_test",
-                        "disabled_tpg_test",
-                        "example_system_test",
-                        "fake_data_producer_test",
-                        "long_window_readout_test",
+                        #"listrev_test",
+                        #"3ru_1df_multirun_test",
+                        #"3ru_3df_multirun_test",
+                        #"disabled_tpg_test",
+                        #"example_system_test",
+                        #"fake_data_producer_test",
+                        #"long_window_readout_test",
                         "minimal_system_quick_test",
-                        "readout_type_scan_test",
-                        "small_footprint_quick_test",
-                        "tpreplay_test",
-                        "tpstream_writing_test"
+                        #"readout_type_scan_test",
+                        #"small_footprint_quick_test",
+                        #"tpreplay_test",
+                        #"tpstream_writing_test"
                        ]
     defaults:
       run:
@@ -106,31 +104,19 @@ jobs:
     - name: setup release and run tests
       env:
         RELEASE_TAG: ${{needs.make_variables.outputs.tag}}
-        IS_CANDIDATE_RELEASE: ${{needs.make_variables.outputs.is_candidate_release}}
-        IS_STABLE_RELEASE: ${{needs.make_variables.outputs.is_stable_release}}
+        DBT_ARGS: ${{ needs.make_variables.outputs.dbt_args }}
         INTEGTEST_OUTPUT_PATH: ${{needs.make_variables.outputs.integtest_output_path}}
       id: setup_and_run_test
       run: |
-        DET=fd
         mkdir -p $INTEGTEST_OUTPUT_PATH
         cd $INTEGTEST_OUTPUT_PATH
         echo "Am in $(pwd)"
         echo "INTEGTEST_OUTPUT_PATH: $INTEGTEST_OUTPUT_PATH"
         source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
         setup_dbt latest_v5
-        if [[ "$IS_CANDIDATE_RELEASE" == "true" ]]; then
-          echo "dbt-setup-release -b candidate $RELEASE_TAG"
-          [[ -e /cvmfs/dunedaq-development.opensciencegrid.org/candidates/$RELEASE_TAG/daq_app_rte.sh ]]
-          dbt-setup-release -b candidate $RELEASE_TAG
-        elif [[ "$IS_STABLE_RELEASE" == "true" ]]; then
-          echo "dbt-setup-release $RELEASE_TAG"
-          [[ -e /cvmfs/dunedaq.opensciencegrid.org/spack/releases/$RELEASE_TAG/daq_app_rte.sh ]]
-          dbt-setup-release $RELEASE_TAG
-        else
-          echo "dbt-setup-release -n $RELEASE_TAG"
-          [[ -e /cvmfs/dunedaq-development.opensciencegrid.org/nightly/$RELEASE_TAG/daq_app_rte.sh ]]
-          dbt-setup-release -n $RELEASE_TAG
-        fi
+        
+        dbt-setup-release "$DBT_ARGS" "$RELEASE_TAG"
+
         TEST_PATH=""
         TEST_SOURCE=""
         if [[ "${{ matrix.test_name }}" == "listrev_test" ]]; then

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -116,7 +116,9 @@ jobs:
         source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
         setup_dbt latest_v5
         
-        dbt-setup-release "$DBT_ARGS" "$RELEASE_TAG"
+        cmd="dbt-setup-release $DBT_ARGS $RELEASE_TAG"
+        echo "Running $cmd"
+        $cmd
 
         TEST_PATH=""
         TEST_SOURCE=""

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -38,6 +38,7 @@ jobs:
       run:
         shell: bash
     steps:
+      - uses: actions/checkout@v6
       - id: create_variables
         run: |
           if [[ -n "${{ github.event.inputs.candidate-release-tag }}" && -n "${{ github.event.inputs.stable-release-tag }}" ]]; then

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -14,7 +14,7 @@ on:
         default: 'no'
       release-tag:
         description: >-
-          Release to test, e.g., NFD_DEV_YYMMDD_A9, fddaq-vX.Y.Z-a9, etc. 
+          Release to test, e.g., NFD_DEV_YYMMDD_A9, fddaq-vX.Y.Z-a9, etc.
           Default: last_fddaq (latest nightly)
         required: false
         default: 'last_fddaq'
@@ -95,9 +95,7 @@ jobs:
         source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
         setup_dbt latest_v5
         
-        cmd="dbt-setup-release $DBT_ARGS $RELEASE_TAG"
-        echo "Running $cmd"
-        $cmd
+        dbt-setup-release $DBT_ARGS $RELEASE_TAG
 
         TEST_PATH=""
         TEST_SOURCE=""

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -56,8 +56,10 @@ jobs:
         TAG: ${{ inputs.release_tag }}
     - name: Create build area
       env:
-        RELEASE_TYPE: ${{ steps.release_type.outputs.TYPE }}
-        DBT_ARGS: ${{ steps.release_type.outputs.DBT_ARGS }}
+        RELEASE_TYPE: ${{ steps.release_type.outputs.type }}
+        DBT_ARGS: ${{ steps.release_type.outputs.dbt_args }}
+        COREDAQ_MANIFEST: ${{ steps.release_type.outputs.coredaq_manifest }}
+        FDDAQ_MANIFEST: ${{ steps.release_type.outputs.fddaq_manifest }}
       run: |
         source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
         setup_dbt latest
@@ -67,19 +69,11 @@ jobs:
         cd "$RELEASE_TAG"
         source env.sh
 
-        if [[ "$RELEASE_TYPE" == "nightly" ]]; then
-          VERSION_TAG="develop"
-        else
-          # To find the correct release manifest, extract vX.Y.Z from the release name
-          VERSION_TAG=$(echo "$RELEASE_TAG" | grep -oP 'v[0-9]+\.[0-9]+\.[0-9]+')
-        fi
-        echo "VERSION_TAG: $VERSION_TAG"
-
         cd ../daq-release-unittests/scripts
-        #./checkout-daq-package.py -i ../configs/coredaq/coredaq-${VERSION_TAG}/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -i ../configs/fddaq/fddaq-${VERSION_TAG}/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-${VERSION_TAG}/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -p flxlibs -b develop -i ../configs/fddaq/fddaq-${VERSION_TAG}/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -i ../$COREDAQ_MANIFEST -a -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -i ../$FDDAQ_MANIFEST -a -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -p hdf5libs -i ../$COREDAQ_MANIFEST -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -p flxlibs -i ../$FDDAQ_MANIFEST -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
     - name: Run unit tests
       id: unit_tests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -70,10 +70,10 @@ jobs:
         source env.sh
 
         cd ../daq-release-unittests/scripts
-        #./checkout-daq-package.py -i ../$COREDAQ_MANIFEST -a -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -i ../$FDDAQ_MANIFEST -a -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -p hdf5libs -i ../$COREDAQ_MANIFEST -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -p flxlibs -i ../$FDDAQ_MANIFEST -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -i ../$COREDAQ_MANIFEST -a -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -i ../$FDDAQ_MANIFEST -a -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -p hdf5libs -i ../$COREDAQ_MANIFEST -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -p flxlibs -i ../$FDDAQ_MANIFEST -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
     - name: Run unit tests
       id: unit_tests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -51,7 +51,7 @@ jobs:
         path: daq-release-unittests
     - name: Determine release type
       id: release_type
-      uses: ./.github/actions/get-release-type
+      uses: ./daq-release-unittests/.github/actions/get-release-type
       with:
         TAG: ${{ inputs.release_tag }}
     - name: Create build area

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -64,7 +64,7 @@ jobs:
         source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
         setup_dbt latest
 
-        dbt-create "$DBT_ARGS" "$RELEASE_TAG"
+        dbt-create $DBT_ARGS "$RELEASE_TAG"
 
         cd "$RELEASE_TAG"
         source env.sh

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -39,6 +39,8 @@ jobs:
     name: Run unit tests
     runs-on: daq
     timeout-minutes: 30
+    env:
+      RELEASE_TAG: ${{ inputs.release_tag }}
     defaults:
       run:
         shell: bash
@@ -48,36 +50,20 @@ jobs:
       with:
         path: daq-release-unittests
     - name: Determine release type
-      env:
-        RELEASE_TAG: ${{ inputs.release_tag }}
-      run: |
-        RELEASE_TYPE=""
-        echo "RELEASE_TAG: $RELEASE_TAG"
-        if [[ "$RELEASE_TAG" == NFD* ]]; then
-          RELEASE_TYPE="nightly"
-        elif [[ "$RELEASE_TAG" == *rc* ]]; then
-          RELEASE_TYPE="candidate"
-        elif [[ "$RELEASE_TAG" =~ ^fddaq-v[0-9]+\.[0-9]+\.[0-9]+-a9 ]]; then
-          RELEASE_TYPE="stable"
-        else
-          echo "Could not determine release type. Exiting..."
-          exit 1
-        fi
-
-        echo "RELEASE_TAG=$RELEASE_TAG" >> $GITHUB_ENV
-        echo "RELEASE_TYPE=$RELEASE_TYPE" >> $GITHUB_ENV
-
+      id: release_type
+      uses: ./.github/actions/get-release-type
+      with:
+        TAG: ${{ inputs.release_tag }}
     - name: Create build area
+      env:
+        RELEASE_TYPE: ${{ steps.release_type.outputs.TYPE }}
+        DBT_ARGS: ${{ steps.release_type.outputs.DBT_ARGS }}
       run: |
         source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
         setup_dbt latest
-        if [[ "$RELEASE_TYPE" == "nightly" ]]; then
-          dbt-create -n "$RELEASE_TAG"
-        elif [[ "$RELEASE_TYPE" == "candidate" ]]; then
-          dbt-create -b candidate "$RELEASE_TAG"
-        else
-          dbt-create "$RELEASE_TAG" "$RELEASE_TAG"
-        fi
+
+        dbt-create "$DBT_ARGS" "$RELEASE_TAG"
+
         cd "$RELEASE_TAG"
         source env.sh
 
@@ -90,10 +76,10 @@ jobs:
         echo "VERSION_TAG: $VERSION_TAG"
 
         cd ../daq-release-unittests/scripts
-        ./checkout-daq-package.py -i ../configs/coredaq/coredaq-${VERSION_TAG}/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        ./checkout-daq-package.py -i ../configs/fddaq/fddaq-${VERSION_TAG}/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-${VERSION_TAG}/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
-        #./checkout-daq-package.py -p flxlibs -b develop -i ../configs/fddaq/fddaq-${VERSION_TAG}/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -i ../configs/coredaq/coredaq-${VERSION_TAG}/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        #./checkout-daq-package.py -i ../configs/fddaq/fddaq-${VERSION_TAG}/release.yaml -a -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -p hdf5libs -b develop -i ../configs/coredaq/coredaq-${VERSION_TAG}/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
+        ./checkout-daq-package.py -p flxlibs -b develop -i ../configs/fddaq/fddaq-${VERSION_TAG}/release.yaml -o ${DBT_AREA_ROOT}/sourcecode
         echo "DBT_AREA_ROOT=$DBT_AREA_ROOT" >> "$GITHUB_ENV"
     - name: Run unit tests
       id: unit_tests


### PR DESCRIPTION
Our integration test and unit test workflows all independently use the release tag to determine the release type (nightly, candidate, or stable), which is then used is used to determine the arguments needed for `dbt-create` and `dbt-setup-release`. These repeated checks are a violation of DRY.

This PR introduces a [composite action](https://docs.github.com/en/actions/tutorials/create-actions/create-a-composite-action#composite-actions-and-reusable-workflows) called `get-release-type` which, given a `release-tag` as input, returns the release type (`nightly`, `candidate`, or `stable`), along with the corresponding arguments for `dbt-build`/`dbt-setup-release` and a relative path to the coredaq and fddaq release manifests. This incidentally fixes an issue where the extended integration tests were effectively hard-coded to only work with nightly releases since they only looked at the nightly release manifest.

Successful test runs are listed below. Notice the `Get release type` step included in the `make_variables` jobs, where you can see the values of `TYPE`, `DBT_ARGS`, `COREDAQ_MANIFEST`, and `FDDAQ_MANIFEST`.
- [Extended integration tests](https://github.com/DUNE-DAQ/daq-release/actions/runs/26914269476) using a nightly tag
- [Integration tests](https://github.com/DUNE-DAQ/daq-release/actions/runs/26910529371) using a nightly tag
- [Nightly code check](https://github.com/DUNE-DAQ/daq-release/actions/runs/26910370298/job/79386503869)
- [Integration tests](https://github.com/DUNE-DAQ/daq-release/actions/runs/26909106875/job/79382029974) with a candidate tag
- [Integration tests](https://github.com/DUNE-DAQ/daq-release/actions/runs/26908938572/job/79381412772) with a manual nightly tag instead of `last_fddaq`
- [Extended tests](https://github.com/DUNE-DAQ/daq-release/actions/runs/26907584959/job/79376615199) with a stable tag
