### PR TITLE
Restructure CI dashboard to use single-repo CI artifacts

### DIFF
--- a/.github/workflows/nightly-ci-dashboard.yml
+++ b/.github/workflows/nightly-ci-dashboard.yml
@@ -21,8 +21,6 @@ jobs:
         shell: bash
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    permissions:
-      actions: read
     steps:
     - uses: actions/checkout@v6
     - name: Set paths to artifacts
@@ -112,6 +110,7 @@ jobs:
     - name: Copy artifacts and generate dashboard
       env:
         CI_DASHBOARD_DIR: scripts/github-ci/ci-dashboard
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         cp -r lcov_report ${{ env.CI_DASHBOARD_DIR }}/site/code_coverage
         cp -r integration_test_summary/ ${{ env.CI_DASHBOARD_DIR }}/integration_test_summary

--- a/.github/workflows/nightly-ci-dashboard.yml
+++ b/.github/workflows/nightly-ci-dashboard.yml
@@ -134,7 +134,7 @@ jobs:
     - name: Upload site artifact
       uses: actions/upload-artifact@v7
       with:
-        name: Site
+        name: site
         path: ${{ env.CI_DASHBOARD_DIR }}/site
 
   deploy_to_github_pages:

--- a/.github/workflows/nightly-ci-dashboard.yml
+++ b/.github/workflows/nightly-ci-dashboard.yml
@@ -21,6 +21,8 @@ jobs:
         shell: bash
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      actions: read
     steps:
     - uses: actions/checkout@v6
     - name: Set paths to artifacts

--- a/.github/workflows/nightly-ci-dashboard.yml
+++ b/.github/workflows/nightly-ci-dashboard.yml
@@ -21,6 +21,7 @@ jobs:
         shell: bash
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CI_DASHBOARD_DIR: scripts/github-ci/ci-dashboard
     steps:
     - uses: actions/checkout@v6
     - name: Set paths to artifacts
@@ -108,9 +109,6 @@ jobs:
         run-id: ${{ steps.run_ids.outputs.extended_integration_test_id }}
   
     - name: Copy artifacts and generate dashboard
-      env:
-        CI_DASHBOARD_DIR: scripts/github-ci/ci-dashboard
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         cp -r lcov_report ${{ env.CI_DASHBOARD_DIR }}/site/code_coverage
         cp -r integration_test_summary/ ${{ env.CI_DASHBOARD_DIR }}/integration_test_summary
@@ -137,7 +135,7 @@ jobs:
       uses: actions/upload-artifact@v7
       with:
         name: Site
-        path: ./site
+        path: ${{ env.CI_DASHBOARD_DIR }}/site
 
   deploy_to_github_pages:
     name: Deploy to GitHub Pages

--- a/.github/workflows/nightly-ci-dashboard.yml
+++ b/.github/workflows/nightly-ci-dashboard.yml
@@ -27,7 +27,6 @@ jobs:
       id: set_paths
       run : |
         echo "lcov_html_report_path=lcov_report" >> "$GITHUB_OUTPUT"
-        echo "code_check_summary_path=code_check_summary" >> "$GITHUB_OUTPUT"
         echo "integration_test_summary_path=integration_test_summary" >> "$GITHUB_OUTPUT"
         echo "extended_integration_test_summary_path=extended_integration_test_summary" >> "$GITHUB_OUTPUT"
     - name: Get workflow run IDs
@@ -55,12 +54,10 @@ jobs:
             echo "$run_id"
         }
 
-        code_check_id=$(get_run_id "nightly-code-check.yml")
         lcov_id=$(get_run_id "Weekly code coverage workflow")
         integration_test_id=$(get_run_id "integration_tests.yml")
         extended_integration_test_id=$(get_run_id "extended_integration_tests.yml")
 
-        echo "code_check_id=$code_check_id" | tee -a "$GITHUB_OUTPUT"
         echo "lcov_id=$lcov_id" | tee -a "$GITHUB_OUTPUT"
         echo "integration_test_id=$integration_test_id" | tee -a "$GITHUB_OUTPUT"
         echo "extended_integration_test_id=$extended_integration_test_id" | tee -a "$GITHUB_OUTPUT"
@@ -74,14 +71,6 @@ jobs:
         path: ${{ steps.set_paths.outputs.lcov_html_report_path }}
         run-id: ${{ steps.run_ids.outputs.lcov_id }}
         
-    - name: Download code check summaries
-      id: download_code_checks
-      uses: actions/download-artifact@v8
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        path: ${{ steps.set_paths.outputs.code_check_summary_path }}
-        run-id: ${{ steps.run_ids.outputs.code_check_id }}
-
     - name: Download integration test markdown
       id: download_integration_test
       uses: actions/download-artifact@v8
@@ -123,7 +112,6 @@ jobs:
         CI_DASHBOARD_DIR: scripts/github-ci/ci-dashboard
       run: |
         cp -r lcov_report ${{ env.CI_DASHBOARD_DIR }}/site/code_coverage
-        cp -r code_check_summary/ ${{ env.CI_DASHBOARD_DIR }}/code_check_summary
         cp -r integration_test_summary/ ${{ env.CI_DASHBOARD_DIR }}/integration_test_summary
         cp -r extended_integration_test_summary/ ${{ env.CI_DASHBOARD_DIR }}/extended_integration_test_summary
         cd ${{ env.CI_DASHBOARD_DIR }}
@@ -131,7 +119,7 @@ jobs:
         echo "Collected the following metrics:"
         cat ci_summary.json
         python generate_ci_site.py --json_input ci_summary.json \
-                                   --unit_test_summary code_check_summary/unit_test_summary/unit_test_summary.log \
+                                   --artifacts_dir artifacts \
                                    --core_pytest_summary integration_test_summary/pytest_summary.json \
                                    --extended_pytest_summary extended_integration_test_summary/pytest_summary.json \
 
@@ -141,6 +129,12 @@ jobs:
         CI_DASHBOARD_DIR: scripts/github-ci/ci-dashboard
       with:
         path: ${{ env.CI_DASHBOARD_DIR }}/site
+
+    - name: Upload site artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: Site
+        path: ./site
 
   deploy_to_github_pages:
     name: Deploy to GitHub Pages

--- a/.github/workflows/nightly-ci-dashboard.yml
+++ b/.github/workflows/nightly-ci-dashboard.yml
@@ -117,6 +117,8 @@ jobs:
         cp -r extended_integration_test_summary/ ${{ env.CI_DASHBOARD_DIR }}/extended_integration_test_summary
         cd ${{ env.CI_DASHBOARD_DIR }}
         ./collect-ci-metrics.sh
+        echo "ls -lrt:"
+        ls -lrt
         echo "Collected the following metrics:"
         cat ci_summary.json
         python generate_ci_site.py --json_input ci_summary.json \

--- a/scripts/github-ci/ci-dashboard/collect-ci-metrics.sh
+++ b/scripts/github-ci/ci-dashboard/collect-ci-metrics.sh
@@ -36,13 +36,24 @@ OUTFILE="ci_summary.json"
 echo "[" > "$OUTFILE"
 FIRST=true
 
-for REPO in "${dune_packages_with_ci[@]}"; do
+#for REPO in "${dune_packages_with_ci[@]}"; do
+for REPO in "hdf5libs" "timing" "dfmodules"; do
   FULL_NAME="$ORG/$REPO"
   echo "Collecting metrics for $FULL_NAME..."
 
-  OPEN_ISSUES=$(gh issue list -R "$FULL_NAME" --state open --limit 1000 --json number --jq 'length' || echo 0)
+  OPEN_ISSUES=$(gh issue list \
+                --repo "$FULL_NAME" \
+                --state open \
+                --limit 1000 \
+                --json number \
+                --jq 'length' || echo 0)
+  OPEN_PRS=$(gh pr list \
+             --repo "$FULL_NAME" \
+             --state open \
+             --limit 1000 \
+             --json number \
+             --jq 'length' || echo 0)
   ISSUES_URL=$(echo "https://github.com/DUNE-DAQ/$REPO/issues")
-  OPEN_PRS=$(gh pr list -R "$FULL_NAME" --state open --limit 1000 --json number --jq 'length' || echo 0)
   PRS_URL=$(echo "https://github.com/DUNE-DAQ/$REPO/pulls")
 
   # Get most recent single-repo CI build status
@@ -87,6 +98,11 @@ for REPO in "${dune_packages_with_ci[@]}"; do
   fi
 
   echo "$JSON_ENTRY" >> "$OUTFILE"
+
+  gh run download --repo "$FULL_NAME" --name unit_test_summary       --dir "artifacts/$REPO/" 2>/dev/null
+  gh run download --repo "$FULL_NAME" --name link_checker_log        --dir "artifacts/$REPO/" 2>/dev/null
+  gh run download --repo "$FULL_NAME" --name nightly_linting_results --dir "artifacts/$REPO/" 2>/dev/null
+  gh run download --repo "$FULL_NAME" --name clang_format_summary    --dir "artifacts/$REPO/" 2>/dev/null
 
   # Reset workflow inactivity timer
   gh api -X PUT "repos/$FULL_NAME/actions/workflows/dunedaq-develop-cpp-ci.yml/enable"

--- a/scripts/github-ci/ci-dashboard/collect-ci-metrics.sh
+++ b/scripts/github-ci/ci-dashboard/collect-ci-metrics.sh
@@ -6,6 +6,29 @@ export DEVLINE="develop"
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source $SCRIPT_DIR/../repo.sh || exit $?
 
+get_run_id() {
+  local repo=$1
+  local workflow=$2
+
+  run_id=$(
+    gh run list \
+      --repo "DUNE-DAQ/$repo" \
+      --workflow "$workflow" \
+      --status completed \
+      --limit 10 \
+      --json databaseId,conclusion \
+      --jq '[.[] | select(.conclusion=="success" or .conclusion=="failure")] | first | .databaseId'
+    ) \
+    || { echo "::error::get_run_id: Failed to get workflow ID for '${workflow}'" >&2; return 1; }
+
+    if [[ -z "$run_id" || "$run_id" == "null" ]]; then
+      echo "::error::get_run_id: Got null or empty workflow ID for '${workflow}'"
+      return 1
+    fi
+
+    echo "$run_id"
+}
+
 ORG="DUNE-DAQ"
 REPOS=$(gh repo list "$ORG" --limit 100 --json name -q '.[].name')
 OUTFILE="ci_summary.json"

--- a/scripts/github-ci/ci-dashboard/collect-ci-metrics.sh
+++ b/scripts/github-ci/ci-dashboard/collect-ci-metrics.sh
@@ -37,7 +37,7 @@ echo "[" > "$OUTFILE"
 FIRST=true
 
 #for REPO in "${dune_packages_with_ci[@]}"; do
-for REPO in "hdf5libs" "timing" "dfmodules"; do
+for REPO in "hdf5libs" "timing" "dfmodules" "triggeralgs"; do
   FULL_NAME="$ORG/$REPO"
   echo "Collecting metrics for $FULL_NAME..."
 

--- a/scripts/github-ci/ci-dashboard/collect-ci-metrics.sh
+++ b/scripts/github-ci/ci-dashboard/collect-ci-metrics.sh
@@ -36,8 +36,7 @@ OUTFILE="ci_summary.json"
 echo "[" > "$OUTFILE"
 FIRST=true
 
-#for REPO in "${dune_packages_with_ci[@]}"; do
-for REPO in "hdf5libs" "timing" "dfmodules" "triggeralgs"; do
+for REPO in "${dune_packages_with_ci[@]}"; do
   FULL_NAME="$ORG/$REPO"
   echo "Collecting metrics for $FULL_NAME..."
 

--- a/scripts/github-ci/ci-dashboard/data/clang_format_report.py
+++ b/scripts/github-ci/ci-dashboard/data/clang_format_report.py
@@ -7,18 +7,18 @@ class ClangFormatReport:
     repo_results: dict[str, list[tuple[str, str]]] = field(default_factory=dict)
 
     def parse(self, log_path):
-        """Parse clang formatting summary and store as a dictionary."""
-        if not Path(log_path).is_file():
-            raise FileNotFoundError
+        """Parse clang formatting summary and store as a dictionary.
+        Before parsing, the clang format markdown report looks something like
 
-        # Before parsing, the clang format markdown report looks something like
         # Clang-Format Report
         # ## hdf5libs 
         # | Test | Status| 
         # | --- | --- |
         # | sourcecode/hdf5libs/include/hdf5libs/HDF5FileLayout.hpp | :white_check_mark: Already formatted |
         # | sourcecode/hdf5libs/include/hdf5libs/HDF5FileLayoutParameters.hpp | :x: Needs formatting |
-        # We want to parse this down to tuples of (<file_name>, <status>)
+
+        We want to parse this down to tuples of (<file_name>, <status>), similar to unit tests
+        """
         with open(log_path, "r") as f:
             for line in f:
                 line = line.strip()

--- a/scripts/github-ci/ci-dashboard/data/clang_format_report.py
+++ b/scripts/github-ci/ci-dashboard/data/clang_format_report.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+from dataclasses import dataclass, field
+
+@dataclass
+class ClangFormatReport:
+    # Map repo_name to a list of tuples, where each tuple is ('file_name', 'status')
+    repo_results: dict[str, list[tuple[str, str]]] = field(default_factory=dict)
+
+    def parse(self, log_path):
+        """Parse clang formatting summary and store as a dictionary."""
+        if not Path(log_path).is_file():
+            raise FileNotFoundError
+
+        # Before parsing, the clang format markdown report looks something like
+        # Clang-Format Report
+        # ## hdf5libs 
+        # | Test | Status| 
+        # | --- | --- |
+        # | sourcecode/hdf5libs/include/hdf5libs/HDF5FileLayout.hpp | :white_check_mark: Already formatted |
+        # | sourcecode/hdf5libs/include/hdf5libs/HDF5FileLayoutParameters.hpp | :x: Needs formatting |
+        # We want to parse this down to tuples of (<file_name>, <status>)
+        with open(log_path, "r") as f:
+            for line in f:
+                line = line.strip()
+                if "##" in line:
+                    repo_name = line.lstrip("##").strip()
+                if not line.startswith('|') or '---' in line or 'Test' in line:
+                    continue
+
+                if repo_name not in self.repo_results:
+                    self.repo_results[repo_name] = []
+
+                cells = [c.strip() for c in line.split('|')[1:-1]]
+                cells[0] = cells[0].replace(f"sourcecode/{repo_name}/", "").strip()
+                cells[1] = cells[1].split(':')[-1].strip()
+                if len(cells) == 2:
+                    self.repo_results[repo_name].append((cells[0], cells[1]))
+        
+    def to_dict(self):
+        return {"repo_results": self.repo_results}
+
+
+if __name__ == "__main__":
+    pass

--- a/scripts/github-ci/ci-dashboard/data/link_checker_report.py
+++ b/scripts/github-ci/ci-dashboard/data/link_checker_report.py
@@ -1,0 +1,58 @@
+import re
+from dataclasses import dataclass, field
+
+@dataclass
+class LinkCheckerReport:
+    # Map repo_name to a list of files with links containing errors
+    repo_results: dict[str, dict[str, list[tuple[str, str]]]] = field(default_factory=dict)
+
+    def parse(self, log_path):
+        """Parse link checker output and store as a dictionary.
+        The lines we're looking look something like:
+
+        ### Errors in include/triggeralgs/MichelElectron/README.md
+
+        * [403] <BAD_LINK> (at 3:36) | Rejected status code: 403 Forbidden
+
+        We want to collect these into a list of files with bad links mapped by repo name
+        Also, each file should map to the link and http error code
+
+        repo_results = {
+            "hdf5libs": {
+                "file_1": [(link1, error1), (link2, error2)],
+                "file_2": [(link1, error1), (link2, error2)],
+            }
+        }
+
+        Note that LinkCheckerReport does not use a to_dict() method like the UnitTestReport
+        and ClangFormatReport classes. The extra layer of wrapping the results in another
+        dictionary turns out to be cumbersome and confusing.
+        """
+
+        with open(log_path, "r") as f:
+            lines = [line.strip() for line in f.readlines()]
+
+        # repo_name comes from the last line, which looks like:
+        # 'Full Github Actions output](https://github.com/DUNE-DAQ/<repo_name>/actions/runs/<run_number>?check_suite_focus=true)'
+        repo_name = lines[-1].split('/')[4]
+
+        current_file = None
+        pattern = re.compile(r"\[(\d+)]\s+<(\S+)>")
+        for line in lines:
+            if line.startswith("### Errors"):
+                if repo_name not in self.repo_results:
+                    self.repo_results[repo_name] = {}
+                current_file = line.replace("### Errors in ", "").strip()
+                if current_file not in self.repo_results[repo_name]:
+                    self.repo_results[repo_name][current_file] = []
+                    continue
+
+            match = pattern.search(line)
+            if match and current_file is not None:
+                error_code = match.group(1)
+                url        = match.group(2)
+                self.repo_results[repo_name][current_file].append((url, error_code))
+
+
+if __name__ == "__main__":
+    pass

--- a/scripts/github-ci/ci-dashboard/data/link_checker_report.py
+++ b/scripts/github-ci/ci-dashboard/data/link_checker_report.py
@@ -21,7 +21,6 @@ class LinkCheckerReport:
             "repo_name": {
                 "file_1": [(link1, error1), (link2, error2)],
                 "file_2": [(link1, error1), (link2, error2)],
-                "full_report": link,
             }
         }
 
@@ -36,14 +35,13 @@ class LinkCheckerReport:
         # repo_name comes from the last line, which looks like:
         # 'Full Github Actions output](https://github.com/DUNE-DAQ/<repo_name>/actions/runs/<run_number>?check_suite_focus=true)'
         repo_name = lines[-1].split('/')[4]
+        self.repo_results[repo_name] = {}
 
         current_file = None
         pattern = re.compile(r"\[(\S+)]\s+<(\S+)>[^|]*\|\s*(.+)")
 
         for line in lines:
             if line.startswith("### Errors"):
-                if repo_name not in self.repo_results:
-                    self.repo_results[repo_name] = {}
                 current_file = line.replace("### Errors in ", "").strip()
                 if current_file not in self.repo_results[repo_name]:
                     self.repo_results[repo_name][current_file] = []
@@ -55,11 +53,6 @@ class LinkCheckerReport:
                 url        = match.group(2)
                 message    = match.group(3)
                 self.repo_results[repo_name][current_file].append((url, error_code, message))
-
-            if line.startswith("[Full Github Actions output]"):
-                link = line.split('(')[-1].rstrip(')')
-                print('link:', link)
-                self.repo_results[repo_name]['full_report'] = link
 
 
 if __name__ == "__main__":

--- a/scripts/github-ci/ci-dashboard/data/link_checker_report.py
+++ b/scripts/github-ci/ci-dashboard/data/link_checker_report.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 @dataclass
 class LinkCheckerReport:
     # Map repo_name to a list of files with links containing errors
-    repo_results: dict[str, dict[str, list[tuple[str, str]]]] = field(default_factory=dict)
+    repo_results: dict[str, dict[str, list[tuple[str, str, str]]]] = field(default_factory=dict)
 
     def parse(self, log_path):
         """Parse link checker output and store as a dictionary.
@@ -18,15 +18,16 @@ class LinkCheckerReport:
         Also, each file should map to the link and http error code
 
         repo_results = {
-            "hdf5libs": {
+            "repo_name": {
                 "file_1": [(link1, error1), (link2, error2)],
                 "file_2": [(link1, error1), (link2, error2)],
+                "full_report": link,
             }
         }
 
         Note that LinkCheckerReport does not use a to_dict() method like the UnitTestReport
-        and ClangFormatReport classes. The extra layer of wrapping the results in another
-        dictionary turns out to be cumbersome and confusing.
+        and ClangFormatReport classes. The extra layer of wrapping turns out to be 
+        cumbersome and confusing in this case.
         """
 
         with open(log_path, "r") as f:
@@ -37,7 +38,8 @@ class LinkCheckerReport:
         repo_name = lines[-1].split('/')[4]
 
         current_file = None
-        pattern = re.compile(r"\[(\d+)]\s+<(\S+)>")
+        pattern = re.compile(r"\[(\S+)]\s+<(\S+)>[^|]*\|\s*(.+)")
+
         for line in lines:
             if line.startswith("### Errors"):
                 if repo_name not in self.repo_results:
@@ -51,7 +53,13 @@ class LinkCheckerReport:
             if match and current_file is not None:
                 error_code = match.group(1)
                 url        = match.group(2)
-                self.repo_results[repo_name][current_file].append((url, error_code))
+                message    = match.group(3)
+                self.repo_results[repo_name][current_file].append((url, error_code, message))
+
+            if line.startswith("[Full Github Actions output]"):
+                link = line.split('(')[-1].rstrip(')')
+                print('link:', link)
+                self.repo_results[repo_name]['full_report'] = link
 
 
 if __name__ == "__main__":

--- a/scripts/github-ci/ci-dashboard/data/linting_report.py
+++ b/scripts/github-ci/ci-dashboard/data/linting_report.py
@@ -1,46 +1,80 @@
 import re
 from dataclasses import dataclass, field
-from pathlib import Path
 
 @dataclass
 class LintingReport:
-    # repo_name -> file_name -> list of (line_number, message)
-    repo_results: dict[str, dict[str, list[tuple[str, str]]]] = field(default_factory=dict)
+
+    # repo -> file -> {"errors": [...], "warnings": [...]}
+    repo_results: dict[str, dict[str, dict[str, list[tuple[str, str]]]]] = field(default_factory=dict)
+
 
     CPPLINT_PATTERN   = re.compile(r"^sourcecode/\S+?:(\d+):\s+(.+?)\s+\[\S+\] \[\d\]$")
     CLANGTIDY_PATTERN = re.compile(r"^\S+?:(\d+):\d+: warning: (.+?) \[\S+\]$")
     FILE_PATTERN      = re.compile(r"^Applying \S+ to sourcecode/(\w+)/(.+)$")
+    ERRORS_PATTERN    = re.compile(r"Total errors found: (\d+)")
+
+    def _flush_warnings(self, repo_name, current_file, pending_warnings):
+        if repo_name and current_file and pending_warnings:
+            if current_file not in self.repo_results.get(repo_name, {}):
+                self.repo_results[repo_name][current_file] = {"errors": [], "warnings": []}
+            self.repo_results[repo_name][current_file]["warnings"] = pending_warnings
 
     def parse(self, log_path):
-        current_file = None
-        repo_name    = None
+        """Parse linting report and store results in a dictionary.
+
+        Parsing the linting report is a little complicated due to its format,
+        but basically the idea is to collect errors and warnings for each file
+        if errors/warnings are present.
+
+        repo_results = {
+            "repo_name": {
+                "file_1": {"errors": [...], "warnings": [...],
+                "file_2": {"errors": [...], "warnings": [...],
+                ...
+            }
+        }
+        """
+        current_file     = None
+        repo_name        = None
+        pending_errors   = []
+        pending_warnings = []
 
         with open(log_path, "r") as f:
-            lines = f.readlines()
+            for line in f:
+                line = line.strip()
 
-        for line in lines:
-            line = line.strip()
+                file_match = self.FILE_PATTERN.match(line)
+                if file_match:
+                    self._flush_warnings(repo_name, current_file, pending_warnings)
+                    repo_name    = file_match.group(1)
+                    current_file = file_match.group(2)
+                    pending_errors   = []
+                    pending_warnings = []
+                    if repo_name not in self.repo_results:
+                        self.repo_results[repo_name] = {}
+                    continue
 
-            file_match = self.FILE_PATTERN.match(line)
-            if file_match:
-                repo_name    = file_match.group(1)
-                current_file = file_match.group(2)
-                if repo_name not in self.repo_results:
-                    self.repo_results[repo_name] = {}
-                if current_file not in self.repo_results[repo_name]:
-                    self.repo_results[repo_name][current_file] = []
-                continue
+                if current_file is None or repo_name is None:
+                    continue
 
-            if current_file is None or repo_name is None:
-                continue
+                if line.startswith("Total errors found:"):
+                    count = int(line.split(":")[-1].strip())
+                    if count > 0:
+                        if current_file not in self.repo_results[repo_name]:
+                            self.repo_results[repo_name][current_file] = {"errors": [], "warnings": []}
+                        self.repo_results[repo_name][current_file]["errors"] = pending_errors
+                    continue
 
-            for pattern in (self.CPPLINT_PATTERN, self.CLANGTIDY_PATTERN):
-                match = pattern.match(line)
-                if match:
-                    line_number = match.group(1)
-                    message     = match.group(2)
-                    self.repo_results[repo_name][current_file].append((line_number, message))
-                    break
+                cpplint_match = self.CPPLINT_PATTERN.match(line)
+                if cpplint_match:
+                    pending_errors.append((cpplint_match.group(1), cpplint_match.group(2)))
+                    continue
+
+                clangtidy_match = self.CLANGTIDY_PATTERN.match(line)
+                if clangtidy_match:
+                    pending_warnings.append((clangtidy_match.group(1), clangtidy_match.group(2)))
+
+        self._flush_warnings(repo_name, current_file, pending_warnings)
 
     def to_dict(self):
         return {"repo_results": self.repo_results}

--- a/scripts/github-ci/ci-dashboard/data/linting_report.py
+++ b/scripts/github-ci/ci-dashboard/data/linting_report.py
@@ -1,0 +1,49 @@
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+@dataclass
+class LintingReport:
+    # repo_name -> file_name -> list of (line_number, message)
+    repo_results: dict[str, dict[str, list[tuple[str, str]]]] = field(default_factory=dict)
+
+    CPPLINT_PATTERN   = re.compile(r"^sourcecode/\S+?:(\d+):\s+(.+?)\s+\[\S+\] \[\d\]$")
+    CLANGTIDY_PATTERN = re.compile(r"^\S+?:(\d+):\d+: warning: (.+?) \[\S+\]$")
+    FILE_PATTERN      = re.compile(r"^Applying \S+ to sourcecode/(\w+)/(.+)$")
+
+    def parse(self, log_path):
+        current_file = None
+        repo_name    = None
+
+        with open(log_path, "r") as f:
+            lines = f.readlines()
+
+        for line in lines:
+            line = line.strip()
+
+            file_match = self.FILE_PATTERN.match(line)
+            if file_match:
+                repo_name    = file_match.group(1)
+                current_file = file_match.group(2)
+                if repo_name not in self.repo_results:
+                    self.repo_results[repo_name] = {}
+                if current_file not in self.repo_results[repo_name]:
+                    self.repo_results[repo_name][current_file] = []
+                continue
+
+            if current_file is None or repo_name is None:
+                continue
+
+            for pattern in (self.CPPLINT_PATTERN, self.CLANGTIDY_PATTERN):
+                match = pattern.match(line)
+                if match:
+                    line_number = match.group(1)
+                    message     = match.group(2)
+                    self.repo_results[repo_name][current_file].append((line_number, message))
+                    break
+
+    def to_dict(self):
+        return {"repo_results": self.repo_results}
+
+if __name__ == "__main__":
+    pass

--- a/scripts/github-ci/ci-dashboard/data/unit_tests.py
+++ b/scripts/github-ci/ci-dashboard/data/unit_tests.py
@@ -1,11 +1,12 @@
 import re
 from pathlib import Path
+from typing import Optional
 from dataclasses import dataclass, field
 
 @dataclass
 class UnitTestReport:
     # Map repo_name to a list of tuples, where each tuple is ('test_name', 'status')
-    repo_results: dict[str, list[tuple[str, str]]] = field(default_factory=dict)
+    repo_results: dict[str, list[tuple[Optional[str], str]]] = field(default_factory=dict)
 
     def _count_status(self, status: str) -> int:
         return sum(1 for tests in self.repo_results.values() for _, s in tests if s == status)
@@ -36,9 +37,6 @@ class UnitTestReport:
 
     def parse(self, log_path):
         """Parse unit test summary and store as a dictionary."""
-        if not Path(log_path).is_file():
-            raise FileNotFoundError
-
         with open(log_path, "r") as f:
             for line in f:
                 clean_line = strip_ansi(line.strip())
@@ -54,12 +52,12 @@ class UnitTestReport:
                 if this_package not in self.repo_results:
                     self.repo_results[this_package] = []
 
-                if "SUCCESS" in clean_line:
+                if "SUCCESS" in clean_line and test_name:
                     self.repo_results[this_package].append((test_name, "Passed"))
-                elif "FAILURE" in clean_line:
+                elif "FAILURE" in clean_line and test_name:
                     self.repo_results[this_package].append((test_name, "Failed"))
                 elif test_name is None:
-                    self.repo_results[this_package].append((test_name, "NoTests"))
+                    self.repo_results[this_package].append((None, "NoTests"))
         
     def to_dict(self):
         return {
@@ -74,22 +72,6 @@ class UnitTestReport:
 def strip_ansi(line):
     """Strip color coding from unit test summary log."""
     return re.sub(r"\x1B\[[0-9;]*[a-zA-Z]", "", line)
-
-def parse_unit_tests(artifacts_dir: str) -> dict[str, dict]:
-    """Returns {repo_name: {artifact_name: parsed_object}}"""
-    if not Path(artifacts_dir).is_dir():
-        raise FileNotFoundError
-
-    report = UnitTestReport()
-    for repo_dir in sorted(Path(artifacts_dir).iterdir()):
-        if not repo_dir.is_dir():
-            continue
-        if not Path(repo_dir / "unit_test_summary.log").is_file():
-            continue
-        report.parse(repo_dir / "unit_test_summary.log")
-
-    return report.to_dict()
-
 
 if __name__ == "__main__":
     pass

--- a/scripts/github-ci/ci-dashboard/data/unit_tests.py
+++ b/scripts/github-ci/ci-dashboard/data/unit_tests.py
@@ -1,16 +1,32 @@
 import re
-import json
 from pathlib import Path
 from dataclasses import dataclass, field
 
 @dataclass
-class UnitTestSummary:
-    passed: int = 0
-    failed: int = 0
-    other: int = 0
-    no_tests: list[str] = field(default_factory=list)
+class UnitTestReport:
     # Map repo_name to a list of tuples, where each tuple is ('test_name', 'status')
     repo_results: dict[str, list[tuple[str, str]]] = field(default_factory=dict)
+
+    def _count_status(self, status: str) -> int:
+        return sum(1 for tests in self.repo_results.values() for _, s in tests if s == status)
+
+    @property
+    def passed(self) -> int:
+        return self._count_status("Passed")
+
+    @property
+    def failed(self) -> int:
+        return self._count_status("Failed")
+
+    @property
+    def other(self) -> int:
+        return sum(1 for tests in self.repo_results.values()
+                   for _, s in tests if s not in ("Passed", "Failed", "NoTests"))
+
+    @property
+    def no_tests(self) -> list[str]:
+        return [repo for repo, tests in self.repo_results.items()
+                if any(s == "NoTests" for _, s in tests)]
 
     @property
     def total(self) -> int:
@@ -18,23 +34,38 @@ class UnitTestSummary:
         which actually ran, not skipped or errored tests."""
         return self.passed + self.failed
 
-    def get_totals(self):
-        for repo_name, tests in self.repo_results.items():
-            for _, status in tests:
-                if status == "Passed":
-                    self.passed += 1
-                elif status == "Failed":
-                    self.failed += 1
-                elif status == 'NoTests':
-                    if repo_name not in self.no_tests:
-                        self.no_tests.append(repo_name)
+    def parse(self, log_path):
+        """Parse unit test summary and store as a dictionary."""
+        if not Path(log_path).is_file():
+            raise FileNotFoundError
+
+        with open(log_path, "r") as f:
+            for line in f:
+                clean_line = strip_ansi(line.strip())
+
+                if "No unit tests" in clean_line:
+                    this_package = clean_line.split()[8]
+                    test_name = None
                 else:
-                    self.other += 1
+                    parts = clean_line.split("/")
+                    this_package = parts[1]
+                    test_name = parts[3].split(".")[0]
+
+                if this_package not in self.repo_results:
+                    self.repo_results[this_package] = []
+
+                if "SUCCESS" in clean_line:
+                    self.repo_results[this_package].append((test_name, "Passed"))
+                elif "FAILURE" in clean_line:
+                    self.repo_results[this_package].append((test_name, "Failed"))
+                elif test_name is None:
+                    self.repo_results[this_package].append((test_name, "NoTests"))
         
     def to_dict(self):
         return {
             "passed": self.passed,
             "failed": self.failed,
+            "total": self.total,
             "other": self.other,
             "no_tests": self.no_tests,
             "repo_results": self.repo_results
@@ -44,36 +75,21 @@ def strip_ansi(line):
     """Strip color coding from unit test summary log."""
     return re.sub(r"\x1B\[[0-9;]*[a-zA-Z]", "", line)
 
-def parse_unit_test_summary(log_path):
-    """Parse unit test summary and store as a dictionary."""
-    summary = UnitTestSummary()
-    current_package = None
+def parse_unit_tests(artifacts_dir: str) -> dict[str, dict]:
+    """Returns {repo_name: {artifact_name: parsed_object}}"""
+    if not Path(artifacts_dir).is_dir():
+        raise FileNotFoundError
 
-    with open(log_path, "r") as f:
-        for line in f:
-            clean_line = strip_ansi(line.strip())
+    report = UnitTestReport()
+    for repo_dir in sorted(Path(artifacts_dir).iterdir()):
+        if not repo_dir.is_dir():
+            continue
+        if not Path(repo_dir / "unit_test_summary.log").is_file():
+            continue
+        report.parse(repo_dir / "unit_test_summary.log")
 
-            if "No unit tests" in clean_line:
-                this_package = clean_line.split()[8]
-                test_name = None
-            else:
-                parts = clean_line.split("/")
-                this_package = parts[1]
-                test_name = parts[3].split(".")[0]
+    return report.to_dict()
 
-            if this_package not in summary.repo_results:
-                summary.repo_results[this_package] = []
-
-            if "SUCCESS" in clean_line:
-                summary.repo_results[this_package].append((test_name, "Passed"))
-            elif "FAILURE" in clean_line:
-                summary.repo_results[this_package].append((test_name, "Failed"))
-            elif test_name is None:
-                summary.repo_results[this_package].append((test_name, "NoTests"))
-
-    summary.get_totals()
-
-    return summary
 
 if __name__ == "__main__":
     pass

--- a/scripts/github-ci/ci-dashboard/data/unit_tests.py
+++ b/scripts/github-ci/ci-dashboard/data/unit_tests.py
@@ -1,5 +1,4 @@
 import re
-from pathlib import Path
 from typing import Optional
 from dataclasses import dataclass, field
 

--- a/scripts/github-ci/ci-dashboard/generate_ci_site.py
+++ b/scripts/github-ci/ci-dashboard/generate_ci_site.py
@@ -8,6 +8,7 @@ from data.integration_tests import load_integration_test_data
 from data.unit_tests import UnitTestReport
 from data.clang_format_report import ClangFormatReport
 from data.link_checker_report import LinkCheckerReport
+from data.linting_report import LintingReport
 from renderer.renderer import Renderer
 from pages.page import IndexPage, RepoPage, UnitTestPage, IntegrationTestPage
 
@@ -64,6 +65,7 @@ def generate_site(json_input_path, artifacts_dir, core_summary='', extended_summ
     }
 
     repo_pages = []
+    linting_report = LintingReport()
     for repo_dir in sorted(Path(artifacts_dir).iterdir()):
         if not repo_dir.is_dir():
             continue
@@ -73,9 +75,18 @@ def generate_site(json_input_path, artifacts_dir, core_summary='', extended_summ
             if path.is_file():
                 report.parse(path)
 
+        # Linting logs are treated separately since you need the repo
+        # name to find the linting file
+        linting_log = Path(repo_dir / f"{repo_dir.name}_linting.log")
+        if linting_log.is_file():
+            linting_report.parse(linting_log)
+        
+
     unit_test_data    = ARTIFACT_PARSERS["unit_test_summary.log"        ].to_dict()
     clang_format_data = ARTIFACT_PARSERS["clang_format_summary_table.md"].to_dict()
     link_checker_data = ARTIFACT_PARSERS["out.md"                       ].repo_results
+
+    linting_data      = linting_report.to_dict()
     integration_test_data = load_integration_test_data(core_summary, extended_summary)
 
     index_context = {
@@ -88,6 +99,7 @@ def generate_site(json_input_path, artifacts_dir, core_summary='', extended_summ
         "unit_test_summary"       : unit_test_data,
         "clang_format_summary"    : clang_format_data,
         "link_checker_results"    : link_checker_data,
+        "linting_results"         : linting_data,
         "integration_test_summary": integration_test_data['totals'],
     }
 
@@ -99,9 +111,10 @@ def generate_site(json_input_path, artifacts_dir, core_summary='', extended_summ
     for repo_name in repo_pages:
         pages.append(RepoPage(repo_name, {
             "repo": repo_name,
-            "unit_test_summary"   : unit_test_data   ["repo_results"].get(repo_name),
-            "clang_format_summary": clang_format_data["repo_results"].get(repo_name),
-            "link_checker_summary": link_checker_data.get(repo_name),
+            "unit_test_summary"    : unit_test_data   ["repo_results"].get(repo_name),
+            "clang_format_summary" : clang_format_data["repo_results"].get(repo_name),
+            "linting_summary"      : linting_data     ["repo_results"].get(repo_name),
+            "link_checker_summary" : link_checker_data.get(repo_name),
         }))
 
     renderer = Renderer(repo_pages)

--- a/scripts/github-ci/ci-dashboard/generate_ci_site.py
+++ b/scripts/github-ci/ci-dashboard/generate_ci_site.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from data.integration_tests import load_integration_test_data
 from data.unit_tests import UnitTestReport
 from data.clang_format_report import ClangFormatReport
+from data.link_checker_report import LinkCheckerReport
 from renderer.renderer import Renderer
 from pages.page import IndexPage, RepoPage, UnitTestPage, IntegrationTestPage
 
@@ -56,33 +57,37 @@ def generate_site(json_input_path, artifacts_dir, core_summary='', extended_summ
     ]
 
 
-    unit_test_report = UnitTestReport()
-    clang_format_report = ClangFormatReport()
+    ARTIFACT_PARSERS = {
+        "unit_test_summary.log":         UnitTestReport(),
+        "clang_format_summary_table.md": ClangFormatReport(),
+        "out.md":                        LinkCheckerReport(),
+    }
+
     repo_pages = []
     for repo_dir in sorted(Path(artifacts_dir).iterdir()):
         if not repo_dir.is_dir():
             continue
         repo_pages.append(repo_dir.name)
-        unit_test_log_path = Path(repo_dir / "unit_test_summary.log")
-        if unit_test_log_path.is_file():
-            unit_test_report.parse(unit_test_log_path)
-        clang_format_table_path = Path(repo_dir / "clang_format_summary_table.md")
-        if clang_format_table_path.is_file():
-            clang_format_report.parse(clang_format_table_path)
+        for filename, report in ARTIFACT_PARSERS.items():
+            path = repo_dir / filename
+            if path.is_file():
+                report.parse(path)
 
-    unit_test_data = unit_test_report.to_dict()
-    clang_format_data = clang_format_report.to_dict()
+    unit_test_data    = ARTIFACT_PARSERS["unit_test_summary.log"        ].to_dict()
+    clang_format_data = ARTIFACT_PARSERS["clang_format_summary_table.md"].to_dict()
+    link_checker_data = ARTIFACT_PARSERS["out.md"                       ].repo_results
     integration_test_data = load_integration_test_data(core_summary, extended_summary)
 
     index_context = {
-        "repos": repos,
-        "last_updated": last_updated,
-        "total_issues": total_issues,
-        "total_prs": total_prs,
-        "passing_percentage": passing_percentage,
-        "workflow_badges": workflow_badges,
-        "unit_test_summary": unit_test_data,
-        "clang_format_summary": clang_format_data,
+        "repos"                   : repos,
+        "last_updated"            : last_updated,
+        "total_issues"            : total_issues,
+        "total_prs"               : total_prs,
+        "passing_percentage"      : passing_percentage,
+        "workflow_badges"         : workflow_badges,
+        "unit_test_summary"       : unit_test_data,
+        "clang_format_summary"    : clang_format_data,
+        "link_checker_results"    : link_checker_data,
         "integration_test_summary": integration_test_data['totals'],
     }
 
@@ -94,8 +99,9 @@ def generate_site(json_input_path, artifacts_dir, core_summary='', extended_summ
     for repo_name in repo_pages:
         pages.append(RepoPage(repo_name, {
             "repo": repo_name,
-            "unit_test_summary": unit_test_data["repo_results"].get(repo_name),
+            "unit_test_summary"   : unit_test_data   ["repo_results"].get(repo_name),
             "clang_format_summary": clang_format_data["repo_results"].get(repo_name),
+            "link_checker_summary": link_checker_data.get(repo_name),
         }))
 
     renderer = Renderer(repo_pages)

--- a/scripts/github-ci/ci-dashboard/generate_ci_site.py
+++ b/scripts/github-ci/ci-dashboard/generate_ci_site.py
@@ -1,16 +1,16 @@
-import re
+#import re
 import argparse
 import json
-from jinja2 import Environment, FileSystemLoader
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 
 from data.integration_tests import load_integration_test_data
-from data.unit_tests import parse_unit_test_summary
+from data.unit_tests import UnitTestReport
+from data.clang_format_report import ClangFormatReport
 from renderer.renderer import Renderer
-from pages.page import Page, IndexPage, UnitTestPage, IntegrationTestPage
+from pages.page import IndexPage, RepoPage, UnitTestPage, IntegrationTestPage
 
-def generate_site(json_input_path, unit_test_summary='', core_summary='', extended_summary=''):
+def generate_site(json_input_path, artifacts_dir, core_summary='', extended_summary=''):
     """Render html files from templates to generate the site."""
     with open(json_input_path, 'r') as f:
         repos = json.load(f)
@@ -26,7 +26,8 @@ def generate_site(json_input_path, unit_test_summary='', core_summary='', extend
 
     passing_percentage = round((passing_repos / total_repos) * 100, 1) if total_repos else 0
 
-    last_updated=datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC")
+    last_updated = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
     workflow_badges = [
     {
         "image": "https://github.com/DUNE-DAQ/daq-release/actions/workflows/build-nightly-release-alma9.yml/badge.svg",
@@ -54,9 +55,25 @@ def generate_site(json_input_path, unit_test_summary='', core_summary='', extend
         "alt": "Weekly linting"},
     ]
 
-    unit_test_data = parse_unit_test_summary(unit_test_summary)
+
+    unit_test_report = UnitTestReport()
+    clang_format_report = ClangFormatReport()
+    repo_pages = []
+    for repo_dir in sorted(Path(artifacts_dir).iterdir()):
+        if not repo_dir.is_dir():
+            continue
+        repo_pages.append(repo_dir.name)
+        unit_test_log_path = Path(repo_dir / "unit_test_summary.log")
+        if unit_test_log_path.is_file():
+            unit_test_report.parse(unit_test_log_path)
+        clang_format_table_path = Path(repo_dir / "clang_format_summary_table.md")
+        if clang_format_table_path.is_file():
+            clang_format_report.parse(clang_format_table_path)
+
+    unit_test_data = unit_test_report.to_dict()
+    clang_format_data = clang_format_report.to_dict()
     integration_test_data = load_integration_test_data(core_summary, extended_summary)
-    
+
     index_context = {
         "repos": repos,
         "last_updated": last_updated,
@@ -65,16 +82,23 @@ def generate_site(json_input_path, unit_test_summary='', core_summary='', extend
         "passing_percentage": passing_percentage,
         "workflow_badges": workflow_badges,
         "unit_test_summary": unit_test_data,
+        "clang_format_summary": clang_format_data,
         "integration_test_summary": integration_test_data['totals'],
     }
 
     pages = [
         IndexPage(index_context),
-        UnitTestPage(unit_test_data.to_dict()),
+        UnitTestPage(unit_test_data),
         IntegrationTestPage(integration_test_data),
     ]
+    for repo_name in repo_pages:
+        pages.append(RepoPage(repo_name, {
+            "repo": repo_name,
+            "unit_test_summary": unit_test_data["repo_results"].get(repo_name),
+            "clang_format_summary": clang_format_data["repo_results"].get(repo_name),
+        }))
 
-    renderer = Renderer()
+    renderer = Renderer(repo_pages)
     for page in pages:
         page.render(renderer)
 
@@ -83,9 +107,13 @@ def generate_site(json_input_path, unit_test_summary='', core_summary='', extend
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Generate CI HTML site from a JSON summary file.")
     parser.add_argument("--json_input", required=True, help="Path to the JSON file containing CI summary data. See collect-ci-metrics.sh.")
-    parser.add_argument("--unit_test_summary", required=False, help="Path to the unit test summary output by dbt-build --unittest.")
+    parser.add_argument("--artifacts_dir", required=True, help="Path to single-repo artifacts directory output by collect-ci-metrics.sh.")
     parser.add_argument("--core_pytest_summary", required=False, help="Path to the json summary output by core integration test workflow.")
     parser.add_argument("--extended_pytest_summary", required=False, help="Path to the json summary output by extended integration test workflow.")
     args = parser.parse_args()
 
-    generate_site(args.json_input, args.unit_test_summary, args.core_pytest_summary, args.extended_pytest_summary)
+    if not Path(args.artifacts_dir).is_dir():
+        raise FileNotFoundError
+
+    generate_site(args.json_input, args.artifacts_dir, args.core_pytest_summary, args.extended_pytest_summary)
+

--- a/scripts/github-ci/ci-dashboard/pages/page.py
+++ b/scripts/github-ci/ci-dashboard/pages/page.py
@@ -18,6 +18,14 @@ class IndexPage(Page):
             output_file="index.html"
         )
 
+class RepoPage(Page):
+    def __init__(self, repo_name, context):
+        super().__init__(
+            template_name="repo_template.html",
+            context=context,
+            output_file=f"repos/{repo_name}.html"
+        )
+
 class UnitTestPage(Page):
     def __init__(self, unit_test_summary):
         super().__init__(

--- a/scripts/github-ci/ci-dashboard/renderer/renderer.py
+++ b/scripts/github-ci/ci-dashboard/renderer/renderer.py
@@ -15,24 +15,28 @@ def commit_age(time_since_last_commit):
         return ("More than a month ago", "status-stale")
 
 class Renderer:
-    def __init__(self):
+    def __init__(self, repo_names=None):
         self.templates_path = Path(__file__).parent.parent / "templates"
         self.output_path = Path("site")
         self.links = {
-            "Home": "index.html",
+            "Home": "/index.html",
             "Doxygen": "https://dune-daq.github.io/docs/",
-            "Unit Test Summary": "unit_test_summary.html",
-            "Integration Test Summary": "integtest_summary.html",
-            "Code Coverage Report": "code_coverage/index.html",
+            "Unit Test Summary": "/unit_test_summary.html",
+            "Integration Test Summary": "/integtest_summary.html",
+            "Code Coverage Report": "/code_coverage/index.html",
         }
         self.env = Environment(loader=FileSystemLoader(self.templates_path))
         self.env.filters["commit_age"] = commit_age
         self.env.globals["links"] = self.links
+        self.env.globals["repo_links"] = {
+            repo: f"/repos/{repo}.html"
+            for repo in (repo_names or [])
+        }
 
     def render_page(self, template_name, context, output_file):
         template = self.env.get_template(template_name)
         page_html = template.render(context)
         file_path = self.output_path / output_file
         file_path.parent.mkdir(parents=True, exist_ok=True)
-        file_path.write_text(page_html)        
+        file_path.write_text(page_html)
 

--- a/scripts/github-ci/ci-dashboard/site/static/style.css
+++ b/scripts/github-ci/ci-dashboard/site/static/style.css
@@ -11,6 +11,8 @@ body {
     height: 100vh;
     box-shadow: 2px 0 5px rgba(0,0,0,0.1);
     position: fixed;
+    overflow-y: auto;
+    box-sizing: border-box;
 }
 
 .content {

--- a/scripts/github-ci/ci-dashboard/templates/base_template.html
+++ b/scripts/github-ci/ci-dashboard/templates/base_template.html
@@ -1,10 +1,9 @@
-<!-- templates/base_template.html -->
 <!DOCTYPE html>
 <html>
 <head>
   <meta charset="UTF-8">
   <title>{% block title %}DAQ Report{% endblock %}</title>
-  <link rel="stylesheet" href="static/style.css">
+  <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
   <div class="sidebar">
@@ -16,6 +15,15 @@
         </li>
       {% endfor %}
     </ul>
+
+    {% if repo_links %}
+      <h3>Repo Summaries</h3>
+      <ul>
+        {% for repo, url in repo_links.items() %}
+          <li><a href="{{ url }}">{{ repo }}</a></li>
+        {% endfor %}
+      </ul>
+    {% endif %}
   </div>
   <div class="content">
     {% block content %}{% endblock %}

--- a/scripts/github-ci/ci-dashboard/templates/index_template.html
+++ b/scripts/github-ci/ci-dashboard/templates/index_template.html
@@ -26,13 +26,13 @@
       <p>
         {{ integration_test_summary.total_run }} total tests run.<br>
         <span class="status-success">
-          Passed: {{ integration_test_summary.passed }} 
-          ({{ (100 * integration_test_summary.passed / integration_test_summary.total_run) | round(1) }}%)
+          Passed: {{ integration_test_summary.passed }}
+          ({{ (100 * integration_test_summary.passed / (integration_test_summary.total_run or 1)) | round(1) }}%)
           <br>
         </span>
         <span class="status-failure">
           Failed: {{ integration_test_summary.failed }} 
-          ({{ (100 * integration_test_summary.failed / integration_test_summary.total_run) | round(1) }}%)
+          ({{ (100 * integration_test_summary.failed / (integration_test_summary.total_run or 1)) | round(1) }}%)
           <br>
         </span>
         <span class="status-skipped">
@@ -52,12 +52,12 @@
         {{ unit_test_summary.total }} tests run. <br>
           <span class="status-success">
             Passed: {{ unit_test_summary.passed }} 
-            ({{ (100 * unit_test_summary.passed // (unit_test_summary.passed + unit_test_summary.failed)) }}%)
+            ({{ (100 * unit_test_summary.passed // ((unit_test_summary.passed + unit_test_summary.failed or 1))) }}%)
             <br>
           </span>
           <span class="status-failure">
             Failed: {{ unit_test_summary.failed }} 
-            ({{ (100 * unit_test_summary.failed // (unit_test_summary.passed + unit_test_summary.failed)) }}%)
+            ({{ (100 * unit_test_summary.failed // ((unit_test_summary.passed + unit_test_summary.failed or 1))) }}%)
             <br>
           </span>
         {% if unit_test_summary.no_tests|length > 1 %}

--- a/scripts/github-ci/ci-dashboard/templates/index_template.html
+++ b/scripts/github-ci/ci-dashboard/templates/index_template.html
@@ -93,6 +93,7 @@
             <th>Open Issues</th>
             <th>Open PRs</th>
             <th>Develop Build Status</th>
+            <th>Broken Links</th>
         </tr>
     </thead>
     <tbody>
@@ -111,6 +112,14 @@
                         {{ repo.build_develop.conclusion | capitalize }}
                     </span>
                 </a>
+            </td>
+            <td>
+                {% if link_checker_results and repo.repo in link_checker_results %}
+                    {% set count = link_checker_results[repo.repo].values() | map('length') | sum %}
+                    <a href="/repos/{{ repo.repo }}.html">{{ count }}</a>
+                {% else %}
+                    —
+                {% endif %}
             </td>
         </tr>
         {% endfor %}

--- a/scripts/github-ci/ci-dashboard/templates/repo_template.html
+++ b/scripts/github-ci/ci-dashboard/templates/repo_template.html
@@ -6,7 +6,7 @@
 
 <h2>Unit Tests</h2>
 {% if unit_test_summary %}
-  {% if unit_test_summary[0] is none %}
+  {% if unit_test_summary[0][0] is none %}
     <p>No unit tests written.</p>
   {% else %}
     <table>

--- a/scripts/github-ci/ci-dashboard/templates/repo_template.html
+++ b/scripts/github-ci/ci-dashboard/templates/repo_template.html
@@ -55,15 +55,25 @@
 {% endif %}
 
 {% if linting_summary %}
-<h2>Linting Errors</h2>
-  {% for file, errors in linting_summary.items() %}
-    <h3>{{ file }}</h3>
+{% for file, results in linting_summary.items() %}
+  <h3>{{ file }}</h3>
+  {% if results.errors %}
+    <h4>Errors</h4>
     <ul>
-      {% for line_number, message in errors %}
+      {% for line_number, message in results.errors %}
         <li>Line {{ line_number }}: {{ message }}</li>
       {% endfor %}
     </ul>
-  {% endfor %}
+  {% endif %}
+  {% if results.warnings %}
+    <h4>Warnings</h4>
+    <ul>
+      {% for line_number, message in results.warnings %}
+        <li>Line {{ line_number }}: {{ message }}</li>
+      {% endfor %}
+    </ul>
+  {% endif %}
+{% endfor %}
 {% endif %}
 
 

--- a/scripts/github-ci/ci-dashboard/templates/repo_template.html
+++ b/scripts/github-ci/ci-dashboard/templates/repo_template.html
@@ -54,4 +54,17 @@
   <p>No clang formatting results found for this repo.</p>
 {% endif %}
 
+{% if linting_summary %}
+<h2>Linting Errors</h2>
+  {% for file, errors in linting_summary.items() %}
+    <h3>{{ file }}</h3>
+    <ul>
+      {% for line_number, message in errors %}
+        <li>Line {{ line_number }}: {{ message }}</li>
+      {% endfor %}
+    </ul>
+  {% endfor %}
+{% endif %}
+
+
 {% endblock %}

--- a/scripts/github-ci/ci-dashboard/templates/repo_template.html
+++ b/scripts/github-ci/ci-dashboard/templates/repo_template.html
@@ -6,7 +6,7 @@
 
 <h2>Unit Tests</h2>
 {% if unit_test_summary %}
-  {% if unit_test_summary[0][0] is none %}
+  {% if unit_test_summary[0] is none %}
     <p>No unit tests written.</p>
   {% else %}
     <table>
@@ -23,6 +23,18 @@
   {% endif %}
 {% else %}
   <p>No unit test results found for this repo.</p>
+{% endif %}
+
+{% if link_checker_summary %}
+<h2>Errors in Documentation Links</h2>
+  {% for file, links in link_checker_summary.items() %}
+    <h3>{{ file }}</h3>
+    <ul>
+      {% for url, error in links %}
+        <li>[{{ error }}] {{ url }}</li>
+      {% endfor %}
+    </ul>
+  {% endfor %}
 {% endif %}
 
 <h2>Clang Formatting</h2>

--- a/scripts/github-ci/ci-dashboard/templates/repo_template.html
+++ b/scripts/github-ci/ci-dashboard/templates/repo_template.html
@@ -1,0 +1,45 @@
+{% extends "base_template.html" %}
+
+{% block title %}{{ repo }}{% endblock %}
+{% block content %}
+<h1>{{ repo }}</h1>
+
+{% if unit_test_summary %}
+  <h2>Unit Tests</h2>
+  {% if unit_test_summary[0][0] is none %}
+    <p>No unit tests written.</p>
+  {% else %}
+    <table>
+      <thead><tr><th>Test</th><th>Status</th></tr></thead>
+      <tbody>
+        {% for test, status in unit_test_summary %}
+          <tr>
+            <td>{{ test }}</td>
+            <td>{% if status == 'Passed' %}&#x2705{% elif status == 'Failed' %}&#x274C{% else %}⚠️{% endif %} {{ status }}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% endif %}
+{% else %}
+  <p>No unit test results found for this repo.</p>
+{% endif %}
+
+{% if clang_format_summary %}
+  <h2>Clang Formatting</h2>
+  <table>
+    <thead><tr><th>File</th><th>Status</th></tr></thead>
+    <tbody>
+      {% for file, status in clang_format_summary %}
+        <tr>
+          <td>{{ file }}</td>
+          <td>{% if status == 'Already formatted' %}&#x2705{% elif status == 'Needs formatting' %}&#x274C{% else %}⚠️{% endif %} {{ status }}</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+{% else %}
+  <p>No clang formatting results found for this repo.</p>
+{% endif %}
+
+{% endblock %}

--- a/scripts/github-ci/ci-dashboard/templates/repo_template.html
+++ b/scripts/github-ci/ci-dashboard/templates/repo_template.html
@@ -4,8 +4,8 @@
 {% block content %}
 <h1>{{ repo }}</h1>
 
+<h2>Unit Tests</h2>
 {% if unit_test_summary %}
-  <h2>Unit Tests</h2>
   {% if unit_test_summary[0][0] is none %}
     <p>No unit tests written.</p>
   {% else %}
@@ -25,8 +25,8 @@
   <p>No unit test results found for this repo.</p>
 {% endif %}
 
+<h2>Clang Formatting</h2>
 {% if clang_format_summary %}
-  <h2>Clang Formatting</h2>
   <table>
     <thead><tr><th>File</th><th>Status</th></tr></thead>
     <tbody>

--- a/scripts/github-ci/ci-dashboard/templates/repo_template.html
+++ b/scripts/github-ci/ci-dashboard/templates/repo_template.html
@@ -30,8 +30,8 @@
   {% for file, links in link_checker_summary.items() %}
     <h3>{{ file }}</h3>
     <ul>
-      {% for url, error in links %}
-        <li>[{{ error }}] {{ url }}</li>
+      {% for url, error, message in links %}
+        <li>[{{ error }}] {{ url }} {{ message }}</li>
       {% endfor %}
     </ul>
   {% endfor %}

--- a/scripts/github-ci/integration_test_summary.py
+++ b/scripts/github-ci/integration_test_summary.py
@@ -13,6 +13,8 @@ class TestCaseResult:
 
     @classmethod
     def from_dict(cls, d: dict) -> TestCaseResult:
+        if not d:
+            return cls(case_name='', status='')
         return cls(**d)
 
     def summarize_failure(self) -> str:
@@ -55,7 +57,9 @@ class PytestResult:
 
     @classmethod
     def from_dict(cls, d: dict) -> PytestResult:
-        cases = [TestCaseResult.from_dict(case) for case in d["testcase_results"]]
+        if not d:
+            return cls(repo_name='', test_name='')
+        cases = [TestCaseResult.from_dict(case) for case in d.get("testcase_results", [])]
         return cls(
             repo_name=d["repo_name"],
             test_name=d["test_name"],
@@ -132,15 +136,16 @@ class IntegrationTestSummary:
     def from_dict(cls, data: dict) -> IntegrationTestSummary:
         pytest_results = [
             PytestResult.from_dict(test)
-            for repo_tests in data["pytest_results"].values()
+            for repo_tests in data.get("pytest_results", {}).values()
             for test in repo_tests
         ]
         return cls(pytest_results=pytest_results)
 
     @classmethod
     def from_json_file(cls, path: str | Path) -> IntegrationTestSummary:
+        if not path: return cls.from_dict({})
         path = Path(path)
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text()) if path.is_file() else {}
         return cls.from_dict(data)
 
     def to_dict(self) -> dict:


### PR DESCRIPTION
This PR restructures the CI dashboard to accommodate the new single-repo CI artifacts which will replace the nightly code check workflow. `collect-ci-metrics.sh` will now download the artifacts for unit tests, linting, link checking, and clang formatting, and the site generation scripts will render those in individual repo pages. Most of the code changes in this PR were made to parse these artifacts in a somewhat consistent manner. The main index page still contains the usual summaries, plus each row of the repo summary table includes the number of broken documentation links. Incidentally, I also modified `integration_test_summary.py` to better handle empty integration test results. This was primarily to make testing easier, but also makes the nightly CI dashboard workflow more robust.

In the interest of testing, I modified the `nightly-ci-dashboard.yml` workflow to upload an artifact called `site` which contains all the generated site materials. This workflow will fail if run from any branch other than develop, but the `site` artifact will still exist provided the `Build CI site and upload` job succeeds. So, to test, run the CI dashboard workflow from this branch, and then from a terminal, run
```bash
gh run download <run_id> --name site --dir test-site
cd test-site
python -m http.server
```
Then open `localhost:8000` in a web browser. 

Once this is merged, we can disable the nightly code check workflow.