### PR TITLE
JCF: on Pawel's request, add mypy-protobuf 5.1.0

### DIFF
--- a/configs/fddaq/fddaq-develop/release.yaml
+++ b/configs/fddaq/fddaq-develop/release.yaml
@@ -291,6 +291,9 @@
         - name: multidict
           version: 6.7.0
           source:  pypi
+        - name: mypy-protobuf
+          version: 5.1.0
+          source:  pypi
         - name: nest-asyncio
           version: 1.6.0
           source:  pypi


### PR DESCRIPTION
Successfully created a test build, `TFD_DEV_260803_A9`, where you can see that the `mypy-protobuf` package has been added (and there have been no other changes - e.g., no new dependencies dragged in).