### PR TITLE
JCF: bump the daq-cmake version we use in the nightly

### DIFF
--- a/configs/coredaq/fddaq-develop/release.yaml
+++ b/configs/coredaq/fddaq-develop/release.yaml
@@ -119,7 +119,7 @@
 
     coredaq:
         - name: daq-cmake
-          version: v3.3.1
+          version: v3.3.2
           commit: null
         - name: ers
           version: "develop"


### PR DESCRIPTION
Notice as a sanity check a successful test build `TFD_DEV_260805_A9` which uses this branch and hence `daq-cmake` `v3.3.2` (https://github.com/DUNE-DAQ/daq-release/actions/runs/31024786909, https://github.com/DUNE-DAQ/daq-release/actions/runs/31030727031) was performed. 